### PR TITLE
Normalize tech stack payloads and centralize position constants

### DIFF
--- a/src/api/techStacks.ts
+++ b/src/api/techStacks.ts
@@ -1,0 +1,31 @@
+import type { TechStackItem } from "./types";
+
+type TechStackContainer =
+  | { techStacks?: unknown }
+  | { data?: { techStacks?: unknown; data?: { techStacks?: unknown } } };
+
+export function extractTechStacks(payload: TechStackContainer): TechStackItem[] {
+  const candidates = [
+    (payload as any)?.techStacks,
+    (payload as any)?.data?.techStacks,
+    (payload as any)?.data?.data?.techStacks,
+  ];
+
+  const found = candidates.find(Array.isArray);
+  if (!found) return [];
+
+  return found
+    .map((value) => {
+      if (!value || typeof value !== "object") return null;
+      const item = value as { techStackId?: unknown; name?: unknown };
+      const id =
+        typeof item.techStackId === "number"
+          ? item.techStackId
+          : typeof item.techStackId === "string"
+            ? Number(item.techStackId)
+            : NaN;
+      if (!Number.isFinite(id) || typeof item.name !== "string") return null;
+      return { techStackId: id, name: item.name } satisfies TechStackItem;
+    })
+    .filter((value): value is TechStackItem => value !== null);
+}

--- a/src/constants/profile.ts
+++ b/src/constants/profile.ts
@@ -1,0 +1,14 @@
+export const POSITION_OPTIONS = [
+  { value: "BACKEND", label: "백엔드" },
+  { value: "FRONTEND", label: "프론트엔드" },
+  { value: "FULLSTACK", label: "풀스택" },
+  { value: "DEVOPS", label: "DevOps/인프라" },
+  { value: "AI_ML", label: "AI/ML" },
+  { value: "MOBILE", label: "모바일" },
+  { value: "OTHER", label: "기타" },
+] as const;
+
+export const POSITION_LABELS: Record<string, string> = POSITION_OPTIONS.reduce(
+  (acc, item) => ({ ...acc, [item.value]: item.label }),
+  {} as Record<string, string>,
+);

--- a/src/pages/EventList.tsx
+++ b/src/pages/EventList.tsx
@@ -5,6 +5,7 @@ import {
   filterEvents,
 } from "../api/events.api";
 import { getTechStacks } from "../api/auth.api";
+import { extractTechStacks } from "../api/techStacks";
 import type { EventItem } from "../api/types";
 import EventCard from "../components/EventCard";
 import Pagination from "../components/Pagination";
@@ -30,7 +31,7 @@ export default function EventList() {
   >([]);
 
   useEffect(() => {
-    getTechStacks().then((res) => setTechStacks(res.data.techStacks));
+    getTechStacks().then((res) => setTechStacks(extractTechStacks(res.data)));
   }, []);
 
   const debouncedKeyword = useDebounce(keyword, 350);

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -9,6 +9,7 @@ import { getWalletBalance, getWalletTransactions, startWalletCharge, withdrawWal
 import { getRefunds } from '../api/refunds.api'
 import { updateProfile, changePassword, withdrawUser } from '../api/auth.api'
 import { refundByWallet } from '../api/refunds.api'
+import { POSITION_OPTIONS } from '../constants/profile'
 import type {
   TicketItem, OrderItem, WalletTransactionItem, RefundItem,
   UpdateProfileRequest,
@@ -523,15 +524,7 @@ function SettingsTab({ user, toast, refresh, navigate }: { user: any; toast: any
           <div className="form-group">
             <label className="form-label">포지션</label>
             <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-              {[
-                { value: 'BACKEND', label: '백엔드' },
-                { value: 'FRONTEND', label: '프론트엔드' },
-                { value: 'FULLSTACK', label: '풀스택' },
-                { value: 'DEVOPS', label: '데브옵스' },
-                { value: 'AI_ML', label: 'AI/ML' },
-                { value: 'MOBILE', label: '모바일' },
-                { value: 'OTHER', label: '기타' },
-              ].map(pos => (
+              {POSITION_OPTIONS.map(pos => (
                   <button
                       key={pos.value}
                       type="button"

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { signup, createProfile, getTechStacks, reissueToken } from '../api/auth.api'
+import { extractTechStacks } from '../api/techStacks'
+import { POSITION_LABELS, POSITION_OPTIONS } from '../constants/profile'
 import { useAuth } from '../contexts/AuthContext'
 import { useToast } from '../contexts/ToastContext'
 
@@ -9,12 +11,6 @@ const GOOGLE_OAUTH_URL = import.meta.env.VITE_GOOGLE_OAUTH_URL ?? 'http://localh
 interface TechStackItem {
   techStackId: number
   name: string
-}
-
-const POSITIONS = ['BACKEND', 'FRONTEND', 'FULLSTACK', 'DEVOPS', 'AI_ML', 'MOBILE', 'OTHER']
-const POSITION_LABELS: Record<string, string> = {
-  BACKEND: '백엔드', FRONTEND: '프론트엔드', FULLSTACK: '풀스택',
-  DEVOPS: 'DevOps/인프라', AI_ML: 'AI/ML', MOBILE: '모바일', OTHER: '기타',
 }
 
 export default function Signup() {
@@ -37,13 +33,16 @@ export default function Signup() {
   const [signupResult, setSignupResult] = useState<{ accessToken: string; refreshToken: string } | null>(null)
 
   useEffect(() => {
-    getTechStacks().then(res => {
-      setTechStacks(res.data.data.techStacks)
-    }).catch(() => {
-      const fallbacks = ['Java','Spring Boot','Kotlin','JavaScript','TypeScript','React','Vue.js','Node.js','Python','FastAPI','Go','Rust','Docker','Kubernetes','AWS','MySQL','PostgreSQL','Redis','Kafka','ElasticSearch']
-      setTechStacks(fallbacks.map((name, i) => ({ techStackId: i + 1, name })))
-    })
-  }, [])
+    getTechStacks()
+      .then(res => {
+        const stacks = extractTechStacks(res.data)
+        if (stacks.length === 0) throw new Error('NO_TECH_STACKS')
+        setTechStacks(stacks)
+      })
+      .catch(() => {
+        toast('기술 스택 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.', 'error')
+      })
+  }, [toast])
 
   // ─── Step 1 검증 ───
   const validateStep1 = () => {
@@ -257,17 +256,17 @@ export default function Signup() {
               <div className="form-group">
                 <label className="form-label">포지션 <span style={{ color: 'var(--danger)' }}>*</span></label>
                 <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 8 }}>
-                  {POSITIONS.map(pos => (
-                    <button key={pos} type="button"
-                      onClick={() => { setStep2(p => ({ ...p, position: pos })); setErrors({}) }}
+                  {POSITION_OPTIONS.map(({ value }) => (
+                    <button key={value} type="button"
+                      onClick={() => { setStep2(p => ({ ...p, position: value })); setErrors({}) }}
                       style={{
                         padding: '8px 10px', borderRadius: 'var(--r-md)', fontSize: 13,
-                        border: `1px solid ${step2.position === pos ? 'var(--brand)' : 'var(--border)'}`,
-                        background: step2.position === pos ? 'var(--brand-light)' : 'var(--surface)',
-                        color: step2.position === pos ? 'var(--brand)' : 'var(--text-2)',
+                        border: `1px solid ${step2.position === value ? 'var(--brand)' : 'var(--border)'}`,
+                        background: step2.position === value ? 'var(--brand-light)' : 'var(--surface)',
+                        color: step2.position === value ? 'var(--brand)' : 'var(--text-2)',
                         cursor: 'pointer', transition: 'all 0.12s', textAlign: 'left',
                       }}
-                    >{POSITION_LABELS[pos] ?? pos}</button>
+                    >{POSITION_LABELS[value] ?? value}</button>
                   ))}
                 </div>
                 {errors.position && <span className="form-error">{errors.position}</span>}

--- a/src/pages/SocialProfileSetup.tsx
+++ b/src/pages/SocialProfileSetup.tsx
@@ -1,18 +1,14 @@
 import { useState, useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { createProfile, getTechStacks } from '../api/auth.api'
+import { extractTechStacks } from '../api/techStacks'
+import { POSITION_LABELS, POSITION_OPTIONS } from '../constants/profile'
 import { useAuth } from '../contexts/AuthContext'
 import { useToast } from '../contexts/ToastContext'
 
 interface TechStackItem {
   techStackId: number
   name: string
-}
-
-const POSITIONS = ['BACKEND', 'FRONTEND', 'FULLSTACK', 'DEVOPS', 'AI_ML', 'MOBILE', 'OTHER']
-const POSITION_LABELS: Record<string, string> = {
-  BACKEND: '백엔드', FRONTEND: '프론트엔드', FULLSTACK: '풀스택',
-  DEVOPS: 'DevOps/인프라', AI_ML: 'AI/ML', MOBILE: '모바일', OTHER: '기타',
 }
 
 export default function SocialProfileSetup() {
@@ -32,14 +28,15 @@ export default function SocialProfileSetup() {
       return
     }
     getTechStacks()
-      .then(res => setTechStacks(res.data.data.techStacks))
-      .catch(() => {
-        const fallbacks = ['Java','Spring Boot','Kotlin','JavaScript','TypeScript','React','Vue.js',
-          'Node.js','Python','FastAPI','Go','Rust','Docker','Kubernetes','AWS','MySQL','PostgreSQL',
-          'Redis','Kafka','ElasticSearch']
-        setTechStacks(fallbacks.map((name, i) => ({ techStackId: i + 1, name })))
+      .then(res => {
+        const stacks = extractTechStacks(res.data)
+        if (stacks.length === 0) throw new Error('NO_TECH_STACKS')
+        setTechStacks(stacks)
       })
-  }, [navigate])
+      .catch(() => {
+        toast('기술 스택 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.', 'error')
+      })
+  }, [navigate, toast])
 
   // 이미 로그인 완료된 사용자(프로필 있음)는 홈으로
   useEffect(() => {
@@ -158,20 +155,20 @@ export default function SocialProfileSetup() {
                 포지션 <span style={{ color: 'var(--danger)' }}>*</span>
               </label>
               <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 8 }}>
-                {POSITIONS.map(pos => (
+                {POSITION_OPTIONS.map(({ value }) => (
                   <button
-                    key={pos}
+                    key={value}
                     type="button"
-                    onClick={() => { setForm(p => ({ ...p, position: pos })); setErrors(prev => ({ ...prev, position: '' })) }}
+                    onClick={() => { setForm(p => ({ ...p, position: value })); setErrors(prev => ({ ...prev, position: '' })) }}
                     style={{
                       padding: '8px 10px', borderRadius: 'var(--r-md)', fontSize: 13,
-                      border: `1px solid ${form.position === pos ? 'var(--brand)' : 'var(--border)'}`,
-                      background: form.position === pos ? 'var(--brand-light)' : 'var(--surface)',
-                      color: form.position === pos ? 'var(--brand)' : 'var(--text-2)',
+                      border: `1px solid ${form.position === value ? 'var(--brand)' : 'var(--border)'}`,
+                      background: form.position === value ? 'var(--brand-light)' : 'var(--surface)',
+                      color: form.position === value ? 'var(--brand)' : 'var(--text-2)',
                       cursor: 'pointer', transition: 'all 0.12s', textAlign: 'left',
                     }}
                   >
-                    {POSITION_LABELS[pos] ?? pos}
+                    {POSITION_LABELS[value] ?? value}
                   </button>
                 ))}
               </div>

--- a/src/pages/seller/SellerEventCreate.tsx
+++ b/src/pages/seller/SellerEventCreate.tsx
@@ -6,6 +6,7 @@ import {
   updateSellerEvent,
 } from "../../api/events.api";
 import { getTechStacks } from "../../api/auth.api";
+import { extractTechStacks } from "../../api/techStacks";
 import { useToast } from "../../contexts/ToastContext";
 
 const CATEGORIES = [
@@ -394,7 +395,7 @@ export default function SellerEventCreate() {
   >([]);
 
   useEffect(() => {
-    getTechStacks().then((res) => setTechStackOptions(res.data.techStacks));
+    getTechStacks().then((res) => setTechStackOptions(extractTechStacks(res.data)));
   }, []);
 
   const handleSubmit = async (form: EventForm) => {
@@ -453,7 +454,7 @@ export function SellerEventEdit() {
   >([]);
 
   useEffect(() => {
-    getTechStacks().then((res) => setTechStackOptions(res.data.techStacks));
+    getTechStacks().then((res) => setTechStackOptions(extractTechStacks(res.data)));
   }, []);
 
   useEffect(() => {
@@ -485,7 +486,9 @@ export function SellerEventEdit() {
       title: form.title,
       description: form.description,
       category: form.category,
-      techStackIds: form.techStacks.map(s => TECH_STACK_MAP[s]).filter(Boolean),
+      techStackIds: form.techStacks
+        .map((s) => techStackOptions.find((t) => t.name === s)?.techStackId)
+        .filter((id): id is number => id !== undefined),
       price: parseInt(form.price) || 0,
       totalQuantity: parseInt(form.totalQuantity),
       maxQuantity: parseInt(form.maxQuantityPerUser) || 1,


### PR DESCRIPTION
## 작업 배경
- 다양한 형태의 API 응답에서 기술 스택 payload를 안정적으로 파싱할 수 있도록 하여, 호출부가 깨지기 쉬운 구조에 의존하거나 동일한 추출 로직을 반복 작성하지 않도록 했습니다.
- 포지션 옵션 값과 라벨을 중앙에서 관리해, 회원가입 / 프로필 설정 / 설정 화면 전반에서 중복된 인라인 배열을 제거하고 UI 일관성을 높였습니다.
- 기술 스택 로딩에 실패했을 때 하드코딩된 목록으로 조용히 대체하지 않고, 에러를 사용자에게 명확히 보여주도록 UX를 개선했습니다.

## 작업 내용
- src/api/techStacks.ts를 추가하고, 다양한 payload 구조에서 techStacks 배열을 찾아 정제한 뒤 TechStackItem 형태로 정규화하는 extractTechStacks(payload)를 구현했습니다.

- src/constants/profile.ts를 추가하여, 사용 가능한 포지션 목록과 표시용 라벨을 일관되게 관리할 수 있도록 POSITION_OPTIONS와 POSITION_LABELS를 export 하도록 했습니다.

- 여러 페이지 및 컴포넌트(EventList, Signup, SocialProfileSetup, SellerEventCreate, MyPage, 판매자 이벤트 수정 플로우)에서 중복된 인라인 배열이나 직접적인 payload 인덱싱 대신 extractTechStacks, POSITION_OPTIONS, POSITION_LABELS를 사용하도록 변경했고, 선택된 기술 스택 이름을 조회된 옵션 기준으로 id에 매핑하도록 수정했습니다.

- 기존처럼 기술 스택이 없을 때 임의의 fallback 목록을 조용히 사용하는 대신, toast 에러 메시지를 표시하고 빈 스택 목록이 그대로 사용되지 않도록 방어 로직을 추가했습니다.

## 테스트
- 리팩터링과 타입 변경 사항이 문제없는지 확인하기 위해 tsc --noEmit으로 TypeScript 타입 체크를 수행했고, 오류 없이 통과했습니다.
-  이번 변경에 대해 별도의 자동화 단위 테스트는 추가하지 않았습니다.