### PR TITLE
feat: finalize payment/refund contract and implement refund flows (mypage/seller/admin)

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -35,7 +35,9 @@ export const apiClient: AxiosInstance = axios.create({
 // ── Request: access token 주입 ──────────────────────────────────────────────
 apiClient.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   const token = localStorage.getItem('accessToken');
+  const userId = localStorage.getItem('userId');
   if (token) config.headers.Authorization = `Bearer ${token}`;
+  if (userId) config.headers['X-User-Id'] = userId;
   return config;
 });
 
@@ -94,6 +96,7 @@ apiClient.interceptors.response.use(
       processQueue(refreshError, null);
       localStorage.removeItem('accessToken');
       localStorage.removeItem('refreshToken');
+      localStorage.removeItem('userId');
       window.location.href = '/login';
       return Promise.reject(refreshError);
     } finally {

--- a/src/api/refunds.api.ts
+++ b/src/api/refunds.api.ts
@@ -1,19 +1,26 @@
 import { apiClient, ApiResponse } from './client';
 import type {
-  WalletRefundRequest, WalletRefundResponse,
-  PgRefundRequest, PgRefundResponse,
+  RefundInfoResponse,
+  TicketRefundRequest, TicketRefundResponse,
+  OrderRefundRequest, OrderRefundResponse,
   RefundListResponse,
   RefundDetailResponse,
 } from './types';
 
-export const refundByWallet = (body: WalletRefundRequest) =>
-  apiClient.post<ApiResponse<WalletRefundResponse>>('/refunds/wallet', body);
+export const getRefundInfo = (ticketId: string) =>
+  apiClient.get<ApiResponse<RefundInfoResponse>>('/refunds/info', { params: { ticketId } });
 
-export const refundByPg = (body: PgRefundRequest) =>
-  apiClient.post<ApiResponse<PgRefundResponse>>('/refunds/pg', body);
+export const refundTicketByPg = (ticketId: string, body: TicketRefundRequest) =>
+  apiClient.post<ApiResponse<TicketRefundResponse>>(`/refunds/pg/${ticketId}`, body);
 
-export const getRefunds = () =>
-  apiClient.get<ApiResponse<RefundListResponse>>('/refunds');
+export const refundOrder = (orderId: string, body: OrderRefundRequest) =>
+  apiClient.post<ApiResponse<OrderRefundResponse>>(`/refunds/orders/${orderId}`, body);
+
+export const getRefunds = (params?: { page?: number; size?: number }) =>
+  apiClient.get<RefundListResponse>('/refunds', { params });
 
 export const getRefundDetail = (refundId: string) =>
   apiClient.get<ApiResponse<RefundDetailResponse>>(`/refunds/${refundId}`);
+
+export const getSellerEventRefundsPage = (eventId: string, params?: { page?: number; size?: number }) =>
+  apiClient.get<RefundListResponse>(`/seller/refunds/events/${eventId}`, { params });

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -467,6 +467,7 @@ export interface PaymentConfirmRequest {
 export interface PaymentConfirmResponse {
   paymentId: string;
   orderId: string;
+  paymentMethod: "PG" | "WALLET";
   status: string;
   amount: number;
   approvedAt: string;
@@ -490,11 +491,11 @@ export interface WalletChargeConfirmRequest {
   amount: number;
 }
 export interface WalletChargeConfirmResponse {
-  userId: string;
+  transactionId: string;
   amount: number;
   balance: number;
   status: string;
-  completedAt: string;
+  approvedAt: string;
 }
 
 export interface WalletBalanceResponse {
@@ -517,9 +518,8 @@ export interface WalletTransactionItem {
   createdAt: string;
 }
 export interface WalletTransactionListResponse {
-  content: WalletTransactionItem[];
-  page: number;
-  size: number;
+  items: WalletTransactionItem[];
+  currentPage: number;
   totalElements: number;
   totalPages: number;
 }
@@ -530,54 +530,65 @@ export interface WalletWithdrawRequest {
 export interface WalletWithdrawResponse {
   walletId: string;
   transactionId: string;
-  transactionKey: string;
-  type: string;
-  amount: number;
-  balanceAfter: number;
+  withdrawnAmount: number;
+  balance: number;
+  status: "SUCCESS" | "FAILED";
   requestedAt: string;
 }
 
 // ── Refunds ──────────────────────────────────────────────────────────────────
-export interface WalletRefundRequest {
-  orderId: string;
-}
-export interface WalletRefundResponse {
-  refundId: string;
-  orderId: string;
-  paymentId: string;
-  paymentMethod: string;
-  refundStatus: string;
+export interface RefundInfoResponse {
+  ticketId: string;
+  eventTitle: string;
+  eventDate: string;
+  originalAmount: number;
   refundAmount: number;
   refundRate: number;
-  walletTransactionType: string;
-  walletBalanceAfter: number;
-  requestedAt: string;
-  completedAt: string;
+  dDay: number;
+  refundable: boolean;
+  paymentMethod: "PG" | "WALLET";
 }
 
-export interface PgRefundRequest {
-  orderId: string;
+export interface TicketRefundRequest {
+  reason: string;
 }
-export interface PgRefundResponse {
-  refundId: string;
+export interface TicketRefundResponse {
+  ticketId: string;
   orderId: string;
-  paymentId: string;
-  refundStatus: string;
+  paymentAmount: number;
   refundAmount: number;
-  requestedAt: string;
+  refundRate: number;
+  paymentMethod: "PG" | "WALLET";
+  refundStatus: "REQUESTED" | "APPROVED" | "REJECTED" | "COMPLETED" | "FAILED";
+  refundedAt?: string;
+}
+
+export interface OrderRefundRequest {
+  reason: string;
+}
+export interface OrderRefundResponse {
+  refundId: string;
+  orderRefundId: string;
+  orderId: string;
+  ticketCount: number;
+  refundAmount: number;
+  refundRate: number;
+  paymentMethod: "PG" | "WALLET";
+  status: "REQUESTED" | "APPROVED" | "REJECTED" | "COMPLETED" | "FAILED";
 }
 
 export interface RefundItem {
   refundId: string;
   orderId: string;
-  refundStatus: string;
+  paymentId: string;
   refundAmount: number;
+  refundRate: number;
+  status: "REQUESTED" | "APPROVED" | "REJECTED" | "COMPLETED" | "FAILED";
   requestedAt: string;
+  completedAt?: string;
 }
 export interface RefundListResponse {
   content: RefundItem[];
-  page: number;
-  size: number;
   totalElements: number;
   totalPages: number;
 }
@@ -586,8 +597,8 @@ export interface RefundDetailResponse {
   refundId: string;
   orderId: string;
   paymentId: string;
-  paymentMethod: string;
-  refundStatus: string;
+  paymentMethod: "PG" | "WALLET";
+  status: "REQUESTED" | "APPROVED" | "REJECTED" | "COMPLETED" | "FAILED";
   refundAmount: number;
   refundRate: number;
   requestedAt: string;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -61,6 +61,13 @@ export const WALLET_TX_TYPE = {
   WITHDRAW: { label: '출금', sign: '−', color: 'var(--text-3)' },
 } as const
 
+// ── 결제/환불 Enum 상수 (payment 모듈 확정본) ───────────────────────────────
+export const PAYMENT_METHODS = ['WALLET', 'PG'] as const
+export const PAYMENT_STATUSES = ['READY', 'SUCCESS', 'FAILED', 'CANCELLED', 'REFUNDED'] as const
+export const REFUND_STATUSES = ['REQUESTED', 'APPROVED', 'REJECTED', 'COMPLETED', 'FAILED'] as const
+export const WALLET_CHARGE_STATUSES = ['PENDING', 'PROCESSING', 'COMPLETED', 'FAILED'] as const
+export const WALLET_TRANSACTION_TYPES = ['CHARGE', 'USE', 'REFUND', 'WITHDRAW'] as const
+
 // ── 카테고리 목록 ─────────────────────────────────────────────────
 export const EVENT_CATEGORIES = [
   '컨퍼런스', '밋업', '해커톤', '스터디', '세미나', '워크샵', '기타',

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -35,6 +35,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     try {
       const res = await getProfile()
       const user = res.data
+      localStorage.setItem('userId', user.userId)
       setState({
         user,
         isLoggedIn: true,
@@ -54,6 +55,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
       localStorage.removeItem('accessToken')
       localStorage.removeItem('refreshToken')
+      localStorage.removeItem('userId')
       setState({ user: null, isLoggedIn: false, isLoading: false, role: null })
     }
   }, [])
@@ -69,6 +71,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const logout = useCallback(() => {
     localStorage.removeItem('accessToken')
     localStorage.removeItem('refreshToken')
+    localStorage.removeItem('userId')
     setState({ user: null, isLoggedIn: false, isLoading: false, role: null })
   }, [])
 

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -8,7 +8,7 @@ import { getOrders, cancelOrder } from '../api/orders.api'
 import { getWalletBalance, getWalletTransactions, startWalletCharge, withdrawWallet } from '../api/wallet.api'
 import { getRefunds } from '../api/refunds.api'
 import { getTechStacks, updateProfile, changePassword, withdrawUser } from '../api/auth.api'
-import { refundByWallet } from '../api/refunds.api'
+import { getRefundInfo, refundTicketByPg, refundOrder } from '../api/refunds.api'
 import { extractTechStacks } from '../api/techStacks'
 import { POSITION_OPTIONS } from '../constants/profile'
 
@@ -115,6 +115,7 @@ function TicketsTab({ toast }: { toast: any }) {
   const [tickets, setTickets] = useState<TicketItem[]>([])
   const [loading, setLoading] = useState(true)
   const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [processingTicketId, setProcessingTicketId] = useState<number | null>(null)
 
   useEffect(() => {
     getTickets({ page: 0, size: 20 })
@@ -127,6 +128,26 @@ function TicketsTab({ toast }: { toast: any }) {
   if (tickets.length === 0) return (
     <EmptyState icon="🎫" title="보유한 티켓이 없습니다" desc="이벤트를 구매하면 여기에 표시됩니다" />
   )
+
+  const handleTicketRefund = async (ticketId: number) => {
+    setProcessingTicketId(ticketId)
+    try {
+      const info = await getRefundInfo(String(ticketId))
+      if (!info.data.data.refundable) {
+        toast('현재 환불 가능한 티켓이 아닙니다', 'error')
+        return
+      }
+      const confirmed = confirm(`[${info.data.data.eventTitle}] 티켓을 ${info.data.data.refundRate}% (${info.data.data.refundAmount.toLocaleString()}원) 환불할까요?`)
+      if (!confirmed) return
+      const reason = prompt('환불 사유를 입력해주세요.', '단순 변심') || '단순 변심'
+      await refundTicketByPg(String(ticketId), { reason })
+      toast('티켓 환불이 완료되었습니다', 'success')
+    } catch {
+      toast('티켓 환불 실패', 'error')
+    } finally {
+      setProcessingTicketId(null)
+    }
+  }
 
   return (
     <>
@@ -153,6 +174,19 @@ function TicketsTab({ toast }: { toast: any }) {
               <div style={{ marginTop: 10, fontSize: 11, color: 'var(--text-4)', fontFamily: 'var(--font-mono)' }}>
                 #{ticket.ticketId}
               </div>
+              {ticket.status === 'VALID' && (
+                <button
+                  className="btn btn-danger btn-sm"
+                  style={{ marginTop: 10 }}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleTicketRefund(ticket.ticketId)
+                  }}
+                  disabled={processingTicketId === ticket.ticketId}
+                >
+                  {processingTicketId === ticket.ticketId ? '환불 처리중...' : '티켓 환불'}
+                </button>
+              )}
             </div>
           )
         })}
@@ -184,10 +218,11 @@ function OrdersTab({ toast }: { toast: any }) {
   }
 
   const handleRefund = async (orderId: string) => {
-    if (!confirm('환불을 요청할까요?')) return
+    if (!confirm('주문 전체를 환불 요청할까요?')) return
     try {
-      await refundByWallet({ orderId })
-      toast('환불 요청이 완료되었습니다', 'success')
+      const reason = prompt('환불 사유를 입력해주세요.', '일정 변경') || '일정 변경'
+      await refundOrder(orderId, { reason })
+      toast('주문 전체 환불 요청이 완료되었습니다', 'success')
       fetchOrders()
     } catch { toast('환불 요청 실패', 'error') }
   }
@@ -219,7 +254,7 @@ function OrdersTab({ toast }: { toast: any }) {
                   <button className="btn btn-ghost btn-sm" onClick={() => handleCancel(order.orderId)}>주문 취소</button>
                 )}
                 {canRefund && (
-                  <button className="btn btn-danger btn-sm" onClick={() => handleRefund(order.orderId)}>환불 요청</button>
+                  <button className="btn btn-danger btn-sm" onClick={() => handleRefund(order.orderId)}>주문 전체 환불</button>
                 )}
               </div>
             )}
@@ -433,7 +468,7 @@ function RefundsTab({ toast }: { toast: any }) {
   }
 
   useEffect(() => {
-    getRefunds().then(r => setRefunds(r.data.content)).catch(() => toast('로드 실패', 'error')).finally(() => setLoading(false))
+    getRefunds({ page: 0, size: 20 }).then(r => setRefunds(r.data.content)).catch(() => toast('로드 실패', 'error')).finally(() => setLoading(false))
   }, [])
 
   if (loading) return <LoadingSpinner />

--- a/src/pages/admin/AdminEvents.tsx
+++ b/src/pages/admin/AdminEvents.tsx
@@ -32,11 +32,11 @@ export function AdminEvents() {
   useEffect(() => { fetchEvents() }, [fetchEvents])
 
   const handleForceCancel = async (eventId: string, title: string) => {
-    if (!confirm(`"${title}" 이벤트를 강제 취소할까요?\n참여자 전원에게 자동 환불됩니다.`)) return
+    if (!confirm(`"${title}" 이벤트를 관리자 권한으로 취소할까요?\n참여자 전원 환불이 자동 처리됩니다.`)) return
     setActionLoading(eventId)
     try {
       await forcecancelEvent(eventId)
-      toast('강제 취소 처리되었습니다', 'success')
+      toast('관리자 이벤트 취소 및 환불 처리가 완료되었습니다', 'success')
       fetchEvents()
     } catch { toast('처리 실패', 'error') }
     finally { setActionLoading(null) }
@@ -98,7 +98,7 @@ export function AdminEvents() {
                           disabled={actionLoading === event.eventId}
                           onClick={() => handleForceCancel(event.eventId, event.title)}
                         >
-                          {actionLoading === event.eventId ? '...' : '강제 취소'}
+                          {actionLoading === event.eventId ? '...' : '관리자 취소'}
                         </button>
                       )}
                     </td>

--- a/src/pages/seller/SellerDashboard.tsx
+++ b/src/pages/seller/SellerDashboard.tsx
@@ -33,10 +33,10 @@ export default function SellerDashboard() {
   useEffect(() => { fetchEvents() }, [activeTab])
 
   const handleStop = async (eventId: string, title: string) => {
-    if (!confirm(`"${title}" 판매를 중지할까요?`)) return
+    if (!confirm(`"${title}" 이벤트를 취소할까요?\n구매자 환불 프로세스가 함께 진행됩니다.`)) return
     try {
       await stopSellerEvent(eventId)
-      toast('판매 중지되었습니다', 'success')
+      toast('이벤트 취소 및 환불 처리가 시작되었습니다', 'success')
       fetchEvents()
     } catch { toast('처리 실패', 'error') }
   }
@@ -149,7 +149,7 @@ export default function SellerDashboard() {
                         <Link to={`/seller/events/${event.eventId}`} className="btn btn-ghost btn-sm">상세</Link>
                         <Link to={`/seller/events/${event.eventId}/edit`} className="btn btn-secondary btn-sm">수정</Link>
                         {event.status === 'ON_SALE' && (
-                          <button className="btn btn-danger btn-sm" onClick={() => handleStop(event.eventId, event.title)}>중지</button>
+                          <button className="btn btn-danger btn-sm" onClick={() => handleStop(event.eventId, event.title)}>이벤트 취소</button>
                         )}
                       </div>
                     </td>


### PR DESCRIPTION
### Motivation
- Finalize the frontend contract for the payment/refund module so UI actions match backend endpoints and DTOs.  
- Provide end-user refund flows for personal pages: ticket-level refund and full-order refund, and make seller/admin event cancellation explicitly trigger refund processing.  
- Ensure requests include the required `X-User-Id` header (UUID) by default from authenticated profile state.

### Description
- Align and extend API DTOs in `src/api/types.ts` to match the finalized payment/refund responses (e.g. `PaymentConfirmResponse.paymentMethod`, `WalletChargeConfirmResponse`, `WalletTransactionListResponse.items`, `WalletWithdrawResponse`, `RefundInfoResponse`, `TicketRefundResponse`, `OrderRefundResponse`, `RefundItem.status`).
- Add and adapt refund API bindings in `src/api/refunds.api.ts` including `getRefundInfo`, `refundTicketByPg`, `refundOrder`, paged `getRefunds` and `getSellerEventRefundsPage` to reflect the new endpoints and paging shape.
- Implement MyPage refund UX in `src/pages/MyPage.tsx` including ticket-level refund (ticket card button → `/refunds/info` check → prompt reason → `/refunds/pg/{ticketId}`) and full-order refund (order list → prompt reason → `/refunds/orders/{orderId}`), and adjusted refund list paging usage.
- Inject `X-User-Id` header automatically from `localStorage.userId` in `src/api/client.ts` and persist/clear `userId` in `src/contexts/AuthContext.tsx`; add payment/refund enum constants in `src/constants/index.ts`; update seller/admin event cancellation copy/labels in `src/pages/seller/SellerDashboard.tsx` and `src/pages/admin/AdminEvents.tsx` to indicate refund processing.

### Testing
- Built the production bundle with `npm run build`, which completed successfully (Vite build passed).  
- No additional automated tests exist for these UI flows in this change set; manual interaction paths implemented rely on the adjusted API shapes and were verified via a successful build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58f5d2bb483308e117f747e56f75f)