### PR TITLE
fix: 결제 관련 에러 해결, order 상태 체크 api 연결

### DIFF
--- a/src/api/orders.api.ts
+++ b/src/api/orders.api.ts
@@ -4,6 +4,7 @@ import type {
   OrderListRequest, OrderListResponse,
   OrderDetailResponse,
   OrderCancelResponse,
+  OrderStatusResponse,
 } from './types';
 
 export const createOrder = (body: OrderRequest) =>
@@ -17,3 +18,6 @@ export const getOrderDetail = (orderId: string) =>
 
 export const cancelOrder = (orderId: string) =>
   apiClient.patch<ApiResponse<OrderCancelResponse>>(`/orders/${orderId}/cancel`);
+
+export const getOrderStatus = (orderId: string) =>
+  apiClient.get<OrderStatusResponse>(`/orders/${orderId}/status`);

--- a/src/api/payments.api.ts
+++ b/src/api/payments.api.ts
@@ -6,7 +6,7 @@ import type {
 } from './types';
 
 export const readyPayment = (body: PaymentRequest) =>
-  apiClient.post<ApiResponse<PaymentResponse>>('/payments/ready', body);
+  apiClient.post<PaymentResponse>('/payments/ready', body);
 
 export const confirmPayment = (body: PaymentConfirmRequest) =>
   apiClient.post<ApiResponse<PaymentConfirmResponse>>('/payments/confirm', body);

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -415,6 +415,12 @@ export interface OrderCancelResponse {
   status: string;
 }
 
+export interface OrderStatusResponse {
+  orderId: string;
+  status: string;
+  updatedAt: string;
+}
+
 // ── Tickets ──────────────────────────────────────────────────────────────────
 export interface TicketListRequest {
   page?: number;

--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react'
-import { readyPayment, confirmPayment } from '../api/payments.api'
+import { useEffect, useRef, useState } from 'react'
+import { readyPayment } from '../api/payments.api'
+import { getOrderStatus } from '../api/orders.api'
 import { getWalletBalance } from '../api/wallet.api'
 import { useToast } from '../contexts/ToastContext'
 
@@ -25,6 +26,40 @@ export default function PaymentModal({ open, orderId, totalAmount, onClose, onSu
   const [walletBalance, setWalletBalance] = useState<number | null>(null)
   const [walletAmountInput, setWalletAmountInput] = useState('')
   const [loading, setLoading] = useState(false)
+  const [orderReady, setOrderReady] = useState(false)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  useEffect(() => {
+    if (!open) {
+      setOrderReady(false)
+      if (pollRef.current) clearInterval(pollRef.current)
+      return
+    }
+
+    setOrderReady(false)
+    let attempts = 0
+    const MAX_ATTEMPTS = 20
+
+    pollRef.current = setInterval(async () => {
+      try {
+        const res = await getOrderStatus(orderId)
+        if (res.data.status === 'PAYMENT_PENDING') {
+          setOrderReady(true)
+          clearInterval(pollRef.current!)
+        } else if (++attempts >= MAX_ATTEMPTS) {
+          clearInterval(pollRef.current!)
+          toast('주문 준비 시간이 초과되었습니다. 다시 시도해주세요.', 'error')
+          onClose()
+        }
+      } catch {
+        clearInterval(pollRef.current!)
+        toast('주문 상태 확인에 실패했습니다.', 'error')
+        onClose()
+      }
+    }, 500)
+
+    return () => { if (pollRef.current) clearInterval(pollRef.current) }
+  }, [open, orderId])
 
   useEffect(() => {
     if (!open) return
@@ -45,11 +80,13 @@ export default function PaymentModal({ open, orderId, totalAmount, onClose, onSu
   const isWalletPgInsufficient = method === 'WALLET_PG' && walletBalance !== null && parsedWalletAmount > walletBalance
   const walletInsufficient = method === 'WALLET' && walletBalance !== null && walletBalance < totalAmount
   const walletPgDisabled = method === 'WALLET_PG' && (isWalletPgInvalidRange || isWalletPgInsufficient)
-  const payDisabled = loading || walletInsufficient || walletPgDisabled
+  const payDisabled = !orderReady || loading || walletInsufficient || walletPgDisabled
 
-  const payLabel = method !== 'WALLET_PG'
-    ? `${totalAmount.toLocaleString()}원 결제`
-    : `예치금 ${parsedWalletAmount.toLocaleString()}원 + PG ${Math.max(totalAmount - parsedWalletAmount, 0).toLocaleString()}원`
+  const payLabel = !orderReady
+    ? '주문 준비 중...'
+    : method !== 'WALLET_PG'
+      ? `${totalAmount.toLocaleString()}원 결제`
+      : `예치금 ${parsedWalletAmount.toLocaleString()}원 + PG ${Math.max(totalAmount - parsedWalletAmount, 0).toLocaleString()}원`
 
   if (!open) return null
 
@@ -61,21 +98,15 @@ export default function PaymentModal({ open, orderId, totalAmount, onClose, onSu
         : { orderId, paymentMethod: method }
 
       const readyRes = await readyPayment(readyBody)
-      const payment = readyRes.data.data
+      const payment = readyRes.data
 
       if (method === 'WALLET') {
-        await confirmPayment({
-          paymentId: payment.paymentId,
-          paymentKey: 'WALLET',
-          orderId,
-          amount: totalAmount,
-        })
         toast('결제가 완료되었습니다!', 'success')
         onSuccess()
         return
       }
 
-      const pgAmount = payment.pgAmount ?? totalAmount
+      const pgAmount = payment.pgAmount || totalAmount
       sessionStorage.setItem('payment_context', JSON.stringify({
         paymentId: payment.paymentId,
         orderId,
@@ -181,7 +212,7 @@ export default function PaymentModal({ open, orderId, totalAmount, onClose, onSu
 
         <div style={{ padding: '16px 24px', borderTop: '1px solid var(--border)', display: 'flex', gap: 10, background: 'var(--surface-2)' }}>
           <button className="btn btn-secondary" style={{ flex: 1, justifyContent: 'center' }} onClick={onClose} disabled={loading}>취소</button>
-          <button className="btn btn-primary" style={{ flex: 2, justifyContent: 'center', fontSize: 15, fontWeight: 700 }} onClick={handlePay} disabled={payDisabled}>
+          <button className="btn btn-primary" style={{ flex: 2, justifyContent: 'center', fontSize: 15, fontWeight: 700 }} onClick={() => { console.log('[PaymentModal] 결제 버튼 클릭 — disabled:', payDisabled, { loading, walletInsufficient, walletPgDisabled }); handlePay() }} disabled={payDisabled}>
             {loading ? '처리 중...' : payLabel}
           </button>
         </div>

--- a/src/pages/Payment.tsx
+++ b/src/pages/Payment.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { readyPayment, confirmPayment } from '../api/payments.api'
+import { readyPayment } from '../api/payments.api'
 import { getWalletBalance } from '../api/wallet.api'
 import { useToast } from '../contexts/ToastContext'
 
@@ -49,18 +49,12 @@ export default function Payment() {
         : { orderId: state.orderId, paymentMethod: method }
 
       const res = await readyPayment(body)
-      const payment = res.data.data
+      const payment = res.data
 
       if (method === 'WALLET') {
-        await confirmPayment({
-          paymentId: payment.paymentId,
-          paymentKey: 'WALLET',
-          orderId: state.orderId,
-          amount: state.totalAmount,
-        })
         navigate('/payment/complete', { state: { paymentId: payment.paymentId, orderId: state.orderId, amount: state.totalAmount, method: 'WALLET' } })
       } else {
-        const pgAmount = payment.pgAmount ?? state.totalAmount
+        const pgAmount = payment.pgAmount || state.totalAmount
         sessionStorage.setItem('payment_context', JSON.stringify({
           paymentId: payment.paymentId,
           orderId: state.orderId,
@@ -79,7 +73,7 @@ export default function Payment() {
           failUrl: `${window.location.origin}/payment/fail`,
         })
       }
-    } catch {
+    } catch (e: unknown) {
       toast('결제 처리 중 오류가 발생했습니다', 'error')
     } finally {
       setLoading(false)


### PR DESCRIPTION
# 결제 플로우 버그 수정 내역

## 1. WALLET 결제 — 불필요한 `confirmPayment` 호출 제거

**파일**: `src/pages/Payment.tsx`, `src/components/PaymentModal.tsx`

백엔드 `readyPayment`가 WALLET 메서드일 때 내부적으로 `processWalletPayment`를 호출해 결제를 완료시킨다. 프론트에서 추가로 `confirmPayment`를 호출하면 이미 처리된 결제에 재요청이 가서 에러가 발생했다.

- `confirmPayment` import 제거
- WALLET 분기에서 `confirmPayment` 호출 제거, `readyPayment` 성공 후 바로 완료 페이지로 이동



---

## 2. `readyPayment` 응답 파싱 오류

**파일**: `src/api/payments.api.ts`, `src/pages/Payment.tsx`, `src/components/PaymentModal.tsx`

백엔드 `/payments/ready`가 `{ code, message, data: {...} }` 래퍼 없이 결제 객체를 직접 반환한다. 프론트는 `res.data.data`로 접근하고 있어 `undefined`가 되어 이후 로직이 전부 에러났다.

- `payments.api.ts` 반환 타입을 `ApiResponse<PaymentResponse>` → `PaymentResponse`로 수정
- `res.data.data` → `res.data`로 수정

---

## 3. PG 결제 — `pgAmount` 0 처리 오류

**파일**: `src/pages/Payment.tsx`, `src/components/PaymentModal.tsx`

순수 PG 결제 시 백엔드가 `pgAmount: 0`을 반환한다. `??` 연산자는 `0`을 유효한 값으로 보기 때문에 `totalAmount` 폴백이 동작하지 않아 Toss에 amount=0이 넘어가 `BELOW_ZERO_AMOUNT` 에러가 발생했다.

- `payment.pgAmount ?? totalAmount` → `payment.pgAmount || totalAmount`로 수정

---

## 4. PaymentModal — 주문 상태 폴링 추가

**파일**: `src/components/PaymentModal.tsx`, `src/api/orders.api.ts`, `src/api/types.ts`

결제 모달이 열릴 때 주문 상태가 아직 `CREATED`인 경우 결제 요청을 보내면 백엔드에서 `PAYMENT_001` 에러가 발생한다. 재고 차감 처리가 완료되어 `PAYMENT_PENDING`이 된 이후에만 결제를 진행해야 한다.

- `GET /api/orders/{orderId}/status` API 함수 추가 (`getOrderStatus`)
- `OrderStatusResponse` 타입 추가
- 모달 open 시 0.5초 간격으로 주문 상태 폴링, `PAYMENT_PENDING` 확인 후 결제 버튼 활성화
- 10초(20회) 초과 시 에러 토스트 표시 후 모달 닫기
