### PR TITLE
feat(admin): add tech stack management UI and endpoint compatibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ const AdminUsers        = lazy(() => import('./pages/admin/AdminUsers'))
 const AdminEvents       = lazy(() => import('./pages/admin/AdminEvents'))
 const AdminApplications = lazy(() => import('./pages/admin/AdminApplications'))
 const AdminSettlements  = lazy(() => import('./pages/admin/AdminSettlements'))
+const AdminTechStacks   = lazy(() => import('./pages/admin/AdminTechStacks'))
 
 // ── 가드 ──────────────────────────────────────────────────────────
 function RequireAuth({ children }: { children: React.ReactNode }) {
@@ -110,6 +111,7 @@ export default function App() {
           <Route path="/admin/events"       element={<AdminEvents />} />
           <Route path="/admin/applications" element={<AdminApplications />} />
           <Route path="/admin/settlements"  element={<AdminSettlements />} />
+          <Route path="/admin/techstacks"   element={<AdminTechStacks />} />
         </Route>
 
         <Route path="*" element={<NotFound />} />

--- a/src/api/admin.api.ts
+++ b/src/api/admin.api.ts
@@ -9,6 +9,7 @@ import type {
   UserRoleRequest, UserRoleResponse,
   SellerApplicationListResponse,
   SettlementResponse,
+  AdminTechStackItem,
 } from './types';
 
 // ── 대시보드 ───────────────────────────────────────────────────────────────────
@@ -58,3 +59,16 @@ export const createFeePolicy = (body: unknown) =>
 
 export const updateFeePolicy = (policyId: string, body: unknown) =>
   apiClient.patch(`/admin/fee-policies/${policyId}`, body);
+
+// ── 기술 스택 관리 ──────────────────────────────────────────────────────────────
+export const getAdminTechStacks = () =>
+  apiClient.get<AdminTechStackItem[]>('/admin/techstacks');
+
+export const createAdminTechStack = (name: string) =>
+  apiClient.post<AdminTechStackItem>('/admin/techstacks', { name });
+
+export const updateAdminTechStack = (id: number, name: string) =>
+  apiClient.put<AdminTechStackItem>(`/admin/techstacks/${id}`, { name });
+
+export const deleteAdminTechStack = (id: number) =>
+  apiClient.delete(`/admin/techstacks/${id}`);

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -60,4 +60,5 @@ export const getSellerApplicationStatus = () =>
 
 // ── 공통 ──────────────────────────────────────────────────────────────────────
 export const getTechStacks = () =>
-  apiClient.get<TechStackListResponse>('/tech-stacks');
+  apiClient.get<TechStackListResponse>('/techstacks')
+    .catch(() => apiClient.get<TechStackListResponse>('/tech-stacks'));

--- a/src/api/techStacks.ts
+++ b/src/api/techStacks.ts
@@ -1,11 +1,13 @@
 import type { TechStackItem } from "./types";
 
 type TechStackContainer =
+  | unknown[]
   | { techStacks?: unknown }
   | { data?: { techStacks?: unknown; data?: { techStacks?: unknown } } };
 
 export function extractTechStacks(payload: TechStackContainer): TechStackItem[] {
   const candidates = [
+    payload,
     (payload as any)?.techStacks,
     (payload as any)?.data?.techStacks,
     (payload as any)?.data?.data?.techStacks,
@@ -17,12 +19,16 @@ export function extractTechStacks(payload: TechStackContainer): TechStackItem[] 
   return found
     .map((value) => {
       if (!value || typeof value !== "object") return null;
-      const item = value as { techStackId?: unknown; name?: unknown };
+      const item = value as { techStackId?: unknown; id?: unknown; name?: unknown };
       const id =
         typeof item.techStackId === "number"
           ? item.techStackId
           : typeof item.techStackId === "string"
             ? Number(item.techStackId)
+            : typeof item.id === "number"
+              ? item.id
+              : typeof item.id === "string"
+                ? Number(item.id)
             : NaN;
       if (!Number.isFinite(id) || typeof item.name !== "string") return null;
       return { techStackId: id, name: item.name } satisfies TechStackItem;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -789,3 +789,8 @@ export interface TechStackItem {
 export interface TechStackListResponse {
   techStacks: TechStackItem[];
 }
+
+export interface AdminTechStackItem {
+  id: number;
+  name: string;
+}

--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -6,6 +6,7 @@ const NAV = [
   { to: '/admin',               label: '대시보드',       icon: '▦' },
   { to: '/admin/users',         label: '회원 관리',      icon: '👤' },
   { to: '/admin/events',        label: '이벤트 관리',    icon: '🎫' },
+  { to: '/admin/techstacks',    label: '기술 스택',      icon: '🧩' },
   { to: '/admin/applications',  label: '판매자 심사',    icon: '📋' },
   { to: '/admin/settlements',   label: '정산 관리',      icon: '₩' },
 ]

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -26,6 +26,7 @@ export default function AdminDashboard() {
   const SHORTCUTS = [
     { to: '/admin/users',        label: '회원 관리',     icon: '👥', desc: '회원 조회·제재·권한 변경' },
     { to: '/admin/events',       label: '이벤트 관리',   icon: '🎫', desc: '이벤트 조회·강제 취소' },
+    { to: '/admin/techstacks',   label: '기술 스택',     icon: '🧩', desc: '기술 스택 생성·수정·삭제' },
     { to: '/admin/applications', label: '판매자 심사',   icon: '📋', desc: '신청 승인·반려' },
     { to: '/admin/settlements',  label: '정산 실행',     icon: '⚡', desc: '정산 프로세스 실행·조회' },
   ]

--- a/src/pages/admin/AdminTechStacks.tsx
+++ b/src/pages/admin/AdminTechStacks.tsx
@@ -1,0 +1,204 @@
+import { FormEvent, useCallback, useEffect, useState } from 'react'
+import {
+  createAdminTechStack,
+  deleteAdminTechStack,
+  getAdminTechStacks,
+  updateAdminTechStack,
+} from '../../api/admin.api'
+import type { AdminTechStackItem } from '../../api/types'
+import { useToast } from '../../contexts/ToastContext'
+
+export default function AdminTechStacks() {
+  const { toast } = useToast()
+  const [techStacks, setTechStacks] = useState<AdminTechStackItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [creating, setCreating] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [editingName, setEditingName] = useState('')
+  const [actionId, setActionId] = useState<number | null>(null)
+
+  const fetchTechStacks = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await getAdminTechStacks()
+      setTechStacks((res.data ?? []).slice().sort((a, b) => a.id - b.id))
+    } catch {
+      toast('기술 스택을 불러오지 못했습니다', 'error')
+    } finally {
+      setLoading(false)
+    }
+  }, [toast])
+
+  useEffect(() => {
+    fetchTechStacks()
+  }, [fetchTechStacks])
+
+  const handleCreate = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const trimmed = newName.trim()
+    if (!trimmed) return
+
+    setCreating(true)
+    try {
+      await createAdminTechStack(trimmed)
+      setNewName('')
+      toast('기술 스택이 생성되었습니다', 'success')
+      fetchTechStacks()
+    } catch {
+      toast('생성에 실패했습니다', 'error')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const startEdit = (item: AdminTechStackItem) => {
+    setEditingId(item.id)
+    setEditingName(item.name)
+  }
+
+  const cancelEdit = () => {
+    setEditingId(null)
+    setEditingName('')
+  }
+
+  const handleUpdate = async (id: number) => {
+    const trimmed = editingName.trim()
+    if (!trimmed) {
+      toast('기술 스택 이름을 입력해 주세요', 'error')
+      return
+    }
+
+    setActionId(id)
+    try {
+      await updateAdminTechStack(id, trimmed)
+      toast('기술 스택이 수정되었습니다', 'success')
+      cancelEdit()
+      fetchTechStacks()
+    } catch {
+      toast('수정에 실패했습니다', 'error')
+    } finally {
+      setActionId(null)
+    }
+  }
+
+  const handleDelete = async (id: number, name: string) => {
+    if (!confirm(`'${name}' 기술 스택을 삭제할까요?`)) return
+    setActionId(id)
+    try {
+      await deleteAdminTechStack(id)
+      toast('기술 스택이 삭제되었습니다', 'success')
+      if (editingId === id) cancelEdit()
+      fetchTechStacks()
+    } catch {
+      toast('삭제에 실패했습니다', 'error')
+    } finally {
+      setActionId(null)
+    }
+  }
+
+  return (
+    <div style={{ padding: '32px 36px' }}>
+      <div style={{ marginBottom: 24 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 4 }}>기술 스택 관리</h1>
+        <p style={{ fontSize: 14, color: 'var(--text-3)' }}>총 {techStacks.length}개</p>
+      </div>
+
+      <form onSubmit={handleCreate} className="card" style={{ padding: 16, marginBottom: 16 }}>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <input
+            className="form-input"
+            placeholder="새 기술 스택 이름"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            style={{ maxWidth: 360 }}
+          />
+          <button type="submit" className="btn btn-primary" disabled={creating || !newName.trim()}>
+            {creating ? '생성 중...' : '추가'}
+          </button>
+        </div>
+      </form>
+
+      {loading ? (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: 60 }}>
+          <div className="spinner" />
+        </div>
+      ) : (
+        <div className="card" style={{ overflow: 'hidden' }}>
+          <table>
+            <thead>
+              <tr>
+                <th style={{ width: 120 }}>ID</th>
+                <th>이름</th>
+                <th style={{ width: 220 }}>관리</th>
+              </tr>
+            </thead>
+            <tbody>
+              {techStacks.map((item) => {
+                const isEditing = editingId === item.id
+                const isActionLoading = actionId === item.id
+                return (
+                  <tr key={item.id}>
+                    <td style={{ color: 'var(--text-3)', fontSize: 13 }}>{item.id}</td>
+                    <td>
+                      {isEditing ? (
+                        <input
+                          className="form-input"
+                          value={editingName}
+                          onChange={(e) => setEditingName(e.target.value)}
+                        />
+                      ) : (
+                        <span style={{ fontWeight: 500 }}>{item.name}</span>
+                      )}
+                    </td>
+                    <td>
+                      <div style={{ display: 'flex', gap: 6 }}>
+                        {isEditing ? (
+                          <>
+                            <button
+                              type="button"
+                              className="btn btn-sm btn-primary"
+                              disabled={isActionLoading}
+                              onClick={() => handleUpdate(item.id)}
+                            >
+                              저장
+                            </button>
+                            <button
+                              type="button"
+                              className="btn btn-sm btn-secondary"
+                              disabled={isActionLoading}
+                              onClick={cancelEdit}
+                            >
+                              취소
+                            </button>
+                          </>
+                        ) : (
+                          <button
+                            type="button"
+                            className="btn btn-sm btn-secondary"
+                            disabled={isActionLoading}
+                            onClick={() => startEdit(item)}
+                          >
+                            수정
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-danger"
+                          disabled={isActionLoading}
+                          onClick={() => handleDelete(item.id, item.name)}
+                        >
+                          삭제
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide an admin UI to manage tech stacks (create, update, delete) from the admin panel.  
- Align frontend requests with backend changes where tech stacks moved from `/tech-stacks` to `/techstacks`.  
- Make the shared tech stack parser tolerant to multiple payload shapes returned by different endpoints.

### Description
- Added a new admin page `src/pages/admin/AdminTechStacks.tsx` with list, create, edit, and delete flows and toast feedback.  
- Added admin CRUD API helpers in `src/api/admin.api.ts`: `getAdminTechStacks`, `createAdminTechStack`, `updateAdminTechStack`, and `deleteAdminTechStack`.  
- Introduced `AdminTechStackItem` type in `src/api/types.ts` to model admin responses.  
- Updated app routing and admin navigation to include the new page (`src/App.tsx`, `src/components/AdminLayout.tsx`, `src/pages/admin/AdminDashboard.tsx`).  
- Made `getTechStacks()` in `src/api/auth.api.ts` try `'/techstacks'` first and fall back to `'/tech-stacks'`.  
- Extended `extractTechStacks()` in `src/api/techStacks.ts` to accept raw arrays and support both `techStackId` and `id` fields when normalizing items.

### Testing
- Ran the frontend production build with `npm run build` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e824073f7483308c40f5e121a4c447)