### PR TITLE
Safer idempotency key generation to fix wallet charge requests

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -129,8 +129,26 @@ export function unwrapApiData<T>(payload: ApiResponse<T> | T): T {
 
 /** 멱등성 키 헤더를 포함한 axios config를 반환합니다. */
 export function idempotencyConfig() {
+  const key = (() => {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+
+    if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+      const bytes = new Uint8Array(16);
+      crypto.getRandomValues(bytes);
+      bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+      bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122 variant
+      const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+      return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+    }
+
+    const fallback = `${Date.now().toString(16)}-${Math.random().toString(16).slice(2)}`;
+    return `fallback-${fallback}`;
+  })();
+
   return {
-    headers: { 'Idempotency-Key': crypto.randomUUID() },
+    headers: { 'Idempotency-Key': key },
   };
 }
 


### PR DESCRIPTION
### Motivation
- Clicking the wallet charge button could throw immediately when `crypto.randomUUID()` is unavailable, preventing the `/wallet/charge` request from being sent and showing a generic "충전 요청 실패" toast. This change prevents client-side exceptions during idempotency key creation.

### Description
- Replace unconditional `crypto.randomUUID()` usage with a robust generator in `idempotencyConfig()` in `src/api/client.ts` that: first uses `crypto.randomUUID()` if available, falls back to a UUIDv4-like generator using `crypto.getRandomValues()`, and finally uses a timestamp/random fallback string if neither is present. 
- The idempotency header is now set to the generated `key` instead of calling `crypto.randomUUID()` directly.

### Testing
- Ran `npm ci` which completed successfully. 
- Ran `npm run build` which initially failed with `vite: not found` before dependencies were installed, and afterwards the build completed successfully (`vite build` produced `dist/` assets).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e83e9e1ac4833083fefc9a30f270ea)