### PR TITLE
feat(admin): add tech stack empty-embedding reindex button

### DIFF
--- a/src/api/admin.api.ts
+++ b/src/api/admin.api.ts
@@ -72,3 +72,6 @@ export const updateAdminTechStack = (id: number, name: string) =>
 
 export const deleteAdminTechStack = (id: number) =>
   apiClient.delete(`/admin/techstacks/${id}`);
+
+export const reindexAdminTechStacks = () =>
+  apiClient.post('/admin/techstacks/reindex');

--- a/src/pages/admin/AdminTechStacks.tsx
+++ b/src/pages/admin/AdminTechStacks.tsx
@@ -3,6 +3,7 @@ import {
   createAdminTechStack,
   deleteAdminTechStack,
   getAdminTechStacks,
+  reindexAdminTechStacks,
   updateAdminTechStack,
 } from '../../api/admin.api'
 import type { AdminTechStackItem } from '../../api/types'
@@ -17,6 +18,7 @@ export default function AdminTechStacks() {
   const [editingId, setEditingId] = useState<number | null>(null)
   const [editingName, setEditingName] = useState('')
   const [actionId, setActionId] = useState<number | null>(null)
+  const [reindexing, setReindexing] = useState(false)
 
   const fetchTechStacks = useCallback(async () => {
     setLoading(true)
@@ -97,11 +99,36 @@ export default function AdminTechStacks() {
     }
   }
 
+  const handleReindex = async () => {
+    if (!confirm('임베딩이 비어 있는 기술 스택을 재색인할까요?')) return
+
+    setReindexing(true)
+    try {
+      await reindexAdminTechStacks()
+      toast('기술 스택 재색인을 요청했습니다', 'success')
+      fetchTechStacks()
+    } catch {
+      toast('재색인 요청에 실패했습니다', 'error')
+    } finally {
+      setReindexing(false)
+    }
+  }
+
   return (
     <div style={{ padding: '32px 36px' }}>
       <div style={{ marginBottom: 24 }}>
         <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 4 }}>기술 스택 관리</h1>
         <p style={{ fontSize: 14, color: 'var(--text-3)' }}>총 {techStacks.length}개</p>
+        <div style={{ marginTop: 12 }}>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={handleReindex}
+            disabled={reindexing}
+          >
+            {reindexing ? '재색인 요청 중...' : '빈 임베딩 재색인'}
+          </button>
+        </div>
       </div>
 
       <form onSubmit={handleCreate} className="card" style={{ padding: 16, marginBottom: 16 }}>


### PR DESCRIPTION
### Motivation
- Provide a way in the admin UI to trigger reindexing of tech stacks that have empty embeddings.
- Make the action explicit and safe by adding confirmation, loading state and user feedback.

### Description
- Added `reindexAdminTechStacks` API helper which calls `POST /admin/techstacks/reindex` in `src/api/admin.api.ts`.
- Integrated the API into `src/pages/admin/AdminTechStacks.tsx` with a `reindexing` state and `handleReindex` that shows a confirmation dialog, sends the request, shows success/error toasts, and refreshes the list via `fetchTechStacks`.
- Added a new secondary button labeled `빈 임베딩 재색인` that is disabled while the request is in progress and shows `재색인 요청 중...` when loading.

### Testing
- Ran `npm run build` (Vite production build) and it completed successfully.
- No other automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ac7c41308330b0ecc37c43551a98)