### PR TITLE
refactor: align recommendation and tech-stack API paths

### DIFF
--- a/src/api/ai.api.ts
+++ b/src/api/ai.api.ts
@@ -1,5 +1,5 @@
 import { apiClient, ApiResponse } from './client'
-import type { RecommendationRequest, RecommendationResponse } from './types'
+import type { RecommendationResponse } from './types'
 
-export const recommendByUserVector = (body: RecommendationRequest) =>
-  apiClient.post<ApiResponse<RecommendationResponse> | RecommendationResponse>('/internal/ai/recommendation', body)
+export const getEventRecommendations = () =>
+  apiClient.get<ApiResponse<RecommendationResponse> | RecommendationResponse>('/events/recommendations')

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -60,5 +60,4 @@ export const getSellerApplicationStatus = () =>
 
 // ── 공통 ──────────────────────────────────────────────────────────────────────
 export const getTechStacks = () =>
-  apiClient.get<TechStackListResponse>('/techstacks')
-    .catch(() => apiClient.get<TechStackListResponse>('/tech-stacks'));
+  apiClient.get<TechStackListResponse>('/tech-stacks');

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { addCartItem, clearCart, getCart } from '../api/cart.api'
 import { getEventDetail } from '../api/events.api'
-import { recommendByUserVector } from '../api/ai.api'
+import { getEventRecommendations } from '../api/ai.api'
 import { unwrapApiData } from '../api/client'
 import type { CartItemDetail } from '../api/types'
 import { useToast } from '../contexts/ToastContext'
@@ -41,14 +41,13 @@ export default function Cart() {
   }
 
   const fetchRecommendations = async () => {
-    const userId = localStorage.getItem('userId')
-    if (!userId) {
+    if (!localStorage.getItem('userId')) {
       setRecommendLoading(false)
       return
     }
 
     try {
-      const recRes = await recommendByUserVector({ userId })
+      const recRes = await getEventRecommendations()
       const recData = unwrapApiData(recRes.data)
       const recommendedIds = (recData.eventIdList ?? []).slice(0, 5)
 


### PR DESCRIPTION
### Motivation
- Align the frontend API clients with backend contract changes so recommendation lookup uses a header-based endpoint and tech-stack listing uses a single canonical path.
- Simplify the recommendation flow in the cart by removing body-based `userId` and relying on the existing `X-User-Id` header injection from `apiClient`.

### Description
- Replace `recommendByUserVector` (POST `/internal/ai/recommendation`) with `getEventRecommendations` (GET `/events/recommendations`) in `src/api/ai.api.ts`.
- Update `src/pages/Cart.tsx` to call `getEventRecommendations` and stop passing `userId` in the request body, keeping the rest of the recommendation-to-detail resolution flow unchanged.
- Normalize tech stack lookup to only call `/tech-stacks` by changing `getTechStacks` in `src/api/auth.api.ts`.

### Testing
- Changes were committed successfully (`refactor: align recommendation and tech-stack API paths`).
- Ran `npm run build` in this environment but the build failed with `vite: not found`, so a full production build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ca47d50483308ba50b14aa483a96)