### PR TITLE
[frontend] feat: 장바구니 추천 기능 연동 및 API 호출 수정

### DIFF
--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -60,5 +60,4 @@ export const getSellerApplicationStatus = () =>
 
 // ── 공통 ──────────────────────────────────────────────────────────────────────
 export const getTechStacks = () =>
-  apiClient.get<TechStackListResponse>('/techstacks')
-    .catch(() => apiClient.get<TechStackListResponse>('/tech-stacks'));
+    apiClient.get<TechStackListResponse>('/tech-stacks');

--- a/src/api/events.api.ts
+++ b/src/api/events.api.ts
@@ -84,3 +84,5 @@ export const getSellerEventRefunds = (
     { params },
   );
 
+export const recommendEvents = () =>
+    apiClient.get('/events/user/recommendations');

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { addCartItem, clearCart, getCart } from '../api/cart.api'
 import { getEventDetail } from '../api/events.api'
-import { recommendByUserVector } from '../api/ai.api'
+import { recommendEvents } from '../api/events.api'
 import { unwrapApiData } from '../api/client'
 import type { CartItemDetail } from '../api/types'
 import { useToast } from '../contexts/ToastContext'
@@ -41,44 +41,16 @@ export default function Cart() {
   }
 
   const fetchRecommendations = async () => {
-    const userId = localStorage.getItem('userId')
-    if (!userId) {
-      setRecommendLoading(false)
-      return
-    }
-
     try {
-      const recRes = await recommendByUserVector({ userId })
+      const recRes = await recommendEvents()
       const recData = unwrapApiData(recRes.data)
-      const recommendedIds = (recData.eventIdList ?? []).slice(0, 5)
-
-      const detailResults = await Promise.allSettled(
-        recommendedIds.map((eventId) => getEventDetail(eventId)),
-      )
-
-      const cards = detailResults.map((result, index) => {
-        const fallbackId = recommendedIds[index]
-
-        if (result.status !== 'fulfilled') {
-          return {
-            eventId: fallbackId,
-            title: `추천 이벤트 ${index + 1}`,
-            price: 0,
-            eventDateTime: '',
-            category: '추천',
-          }
-        }
-
-        const detail = unwrapApiData(result.value.data)
-        return {
-          eventId: detail.eventId,
-          title: detail.title,
-          price: detail.price,
-          eventDateTime: detail.eventDateTime,
-          category: detail.category,
-        }
-      })
-
+      const cards = (recData.events ?? []).slice(0, 5).map((event: any) => ({
+        eventId: event.eventId,
+        title: event.title,
+        price: event.price,
+        eventDateTime: event.eventDateTime,
+        category: event.category ?? '추천',
+      }))
       setRecommendations(cards)
     } catch {
       setRecommendations([])


### PR DESCRIPTION


## 작업 내용
- Cart.tsx: AI 직접 호출 방식 → Event Service 경유 추천 API로 변경
  - recommendByUserVector (ai.api) → recommendEvents (events.api)
  - getEventDetail 별도 호출 제거, Event Service 응답 구조로 직접 파싱
- events.api.ts: recommendEvents 함수 추가 (/events/user/recommendations)
- auth.api.ts: getTechStacks URL 수정 (/techstacks 폴백 제거 → /tech-stacks 단일 호출)

## 변경 파일
- src/pages/Cart.tsx
- src/api/events.api.ts
- src/api/auth.api.ts