### PR TITLE
[Front] Feat: 이벤트 상세페이지 카카오 지도 추가, 판매자 이벤트 등록시 주소입력 카카오주소창으로 변경

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,3 @@
 VITE_API_BASE_URL=http://localhost:8080/api
 VITE_GOOGLE_OAUTH_URL=http://localhost:8080/oauth2/authorization/google
+VITE_KAKAO_MAP_KEY=키값

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.6.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-kakao-maps-sdk": "^1.2.1",
         "react-router-dom": "^6.22.3"
       },
       "devDependencies": {
@@ -254,6 +255,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1674,6 +1684,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.40.tgz",
+      "integrity": "sha512-nX69MB1ok04epe3OqS+/tEeWBbU31GSQbvDPJmQRRltzzqn6t4jBsO5v1nzalUjCKzwcH2CptOc767NZ7Hbu3g==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -1827,6 +1844,21 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-kakao-maps-sdk": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.2.1.tgz",
+      "integrity": "sha512-qvdt+82D/MxTxmgF9tXaqa6eNqMUiFOeEdn+PyU0u9EHoxeD9WMJeHkum/GWrbP62MR0qWPtZ/G4iM9f2/1TPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.22.15",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "kakao.maps.d.ts": "^0.1.40",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-refresh": {
@@ -1988,6 +2020,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "axios": "^1.6.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-kakao-maps-sdk": "^1.2.1",
     "react-router-dom": "^6.22.3"
   },
   "devDependencies": {

--- a/src/components/EventMap.tsx
+++ b/src/components/EventMap.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react'
+import { Map, MapMarker, useKakaoLoader } from 'react-kakao-maps-sdk'
+
+interface Props {
+  location: string
+}
+
+interface Coords {
+  lat: number
+  lng: number
+}
+
+export default function EventMap({ location }: Props) {
+  const [sdkLoading, sdkError] = useKakaoLoader({
+    appkey: import.meta.env.VITE_KAKAO_MAP_KEY as string,
+    libraries: ['services'],
+  })
+
+  const [coords, setCoords] = useState<Coords | null>(null)
+  const [geocodeStatus, setGeocodeStatus] = useState<'idle' | 'ok' | 'error'>('idle')
+
+  useEffect(() => {
+    if (sdkLoading || !location) return
+
+    if (sdkError || !window.kakao?.maps?.services) {
+      setGeocodeStatus('error')
+      return
+    }
+
+    const geocoder = new window.kakao.maps.services.Geocoder()
+    geocoder.addressSearch(location, (result: any[], status: any) => {
+      if (status === window.kakao.maps.services.Status.OK && result.length > 0) {
+        setCoords({ lat: parseFloat(result[0].y), lng: parseFloat(result[0].x) })
+        setGeocodeStatus('ok')
+      } else {
+        setGeocodeStatus('error')
+      }
+    })
+  }, [sdkLoading, sdkError, location])
+
+  if (sdkLoading || geocodeStatus === 'idle') {
+    return (
+      <div style={{
+        height: 280, borderRadius: 'var(--r-xl)',
+        background: 'var(--surface-2)', border: '1px solid var(--border)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        color: 'var(--text-3)', fontSize: 14,
+      }}>
+        지도 불러오는 중...
+      </div>
+    )
+  }
+
+  if (geocodeStatus === 'error' || !coords) {
+    return (
+      <div style={{
+        height: 280, borderRadius: 'var(--r-xl)',
+        background: 'var(--surface-2)', border: '1px solid var(--border)',
+        display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+        gap: 8, color: 'var(--text-3)', fontSize: 14,
+      }}>
+        <span style={{ fontSize: 28 }}>📍</span>
+        <span>지도를 불러올 수 없습니다</span>
+        <span style={{ fontSize: 12 }}>{location}</span>
+      </div>
+    )
+  }
+
+  return (
+    <Map
+      center={coords}
+      style={{ width: '100%', height: 280, borderRadius: 'var(--r-xl)', border: '1px solid var(--border)' }}
+      level={3}
+    >
+      <MapMarker position={coords} />
+    </Map>
+  )
+}

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -5,6 +5,7 @@ import { addCartItem } from '../api/cart.api'
 import type { EventDetailResponse } from '../api/types'
 import { useAuth } from '../contexts/AuthContext'
 import { useToast } from '../contexts/ToastContext'
+import EventMap from '../components/EventMap'
 
 const STATUS_MAP: Record<string, { label: string; color: string; bg: string }> = {
   ON_SALE:  { label: '판매 중',  color: 'var(--success-text)', bg: 'var(--success-bg)' },
@@ -162,6 +163,15 @@ export default function EventDetail() {
               {event.description || '상세 설명이 없습니다.'}
             </div>
           </div>
+
+          {/* Map */}
+          {event.location && (
+            <div style={{ marginTop: 32 }}>
+              <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 12, color: 'var(--text)' }}>행사 위치</h2>
+              <EventMap location={event.location} />
+              <div style={{ marginTop: 8, fontSize: 13, color: 'var(--text-3)' }}>📍 {event.location}</div>
+            </div>
+          )}
         </div>
 
         {/* Right – Purchase box */}

--- a/src/pages/seller/SellerEventCreate.tsx
+++ b/src/pages/seller/SellerEventCreate.tsx
@@ -48,6 +48,38 @@ const EMPTY_FORM: EventForm = {
   imageUrls: [],
 };
 
+function useKakaoPostcode(onSelect: (address: string) => void) {
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if ((window as any).daum?.Postcode) {
+      setLoaded(true);
+      return;
+    }
+    const existing = document.getElementById('kakao-postcode-script');
+    if (existing) {
+      existing.addEventListener('load', () => setLoaded(true));
+      return;
+    }
+    const script = document.createElement('script');
+    script.id = 'kakao-postcode-script';
+    script.src = 'https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
+    script.onload = () => setLoaded(true);
+    document.head.appendChild(script);
+  }, []);
+
+  const open = () => {
+    if (!loaded) return;
+    new (window as any).daum.Postcode({
+      oncomplete: (data: any) => {
+        onSelect(data.roadAddress || data.jibunAddress);
+      },
+    }).open();
+  };
+
+  return { open, loaded };
+}
+
 function EventForm({
   initialData,
   onSubmit,
@@ -64,6 +96,10 @@ function EventForm({
   const [loading, setLoading] = useState(false);
   const [uploadingIndex, setUploadingIndex] = useState<number | null>(null);
   const [uploadErrors, setUploadErrors] = useState<string[]>([]);
+
+  const { open: openAddressSearch, loaded: postcodeLoaded } = useKakaoPostcode(
+    (address) => setForm((f) => ({ ...f, location: address }))
+  );
 
   const handleFileSelect = async (file: File, slotIndex: number) => {
     const MAX_SIZE = 5 * 1024 * 1024;
@@ -220,15 +256,28 @@ function EventForm({
           </div>
           <div className="form-group">
             <label className="form-label">장소 *</label>
-            <input
-              className="form-input"
-              placeholder="서울 강남구 / 온라인"
-              value={form.location}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, location: e.target.value }))
-              }
-              style={errors.location ? { borderColor: "var(--danger)" } : {}}
-            />
+            <div style={{ display: "flex", gap: 8 }}>
+              <input
+                className="form-input"
+                placeholder="주소 검색 버튼을 클릭하세요"
+                value={form.location}
+                readOnly
+                style={{
+                  flex: 1,
+                  cursor: "default",
+                  ...(errors.location ? { borderColor: "var(--danger)" } : {}),
+                }}
+              />
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={openAddressSearch}
+                disabled={!postcodeLoaded}
+                style={{ whiteSpace: "nowrap", flexShrink: 0 }}
+              >
+                주소 검색
+              </button>
+            </div>
             {errors.location && (
               <span className="form-error">{errors.location}</span>
             )}


### PR DESCRIPTION
## 작업 내용
- 이벤트 상세페이지 카카오 지도 추가
-  판매자 이벤트 등록시 주소입력 카카오주소창으로 변경

## 변경사항
- react-kakao-maps-sdk 라이브러리 추가

## 참고사항
- VITE_KAKAO_MAP_KEY 키값 등록 필요.
- Kakao developer_JavaScript 키를 사용할 웹사이트 도메인 등록 
  - http://localhost:13000
  - http://43.201.143.128/