### PR TITLE
Add UI version switching capability with v1/v2 routing

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
 VITE_API_BASE_URL=http://localhost:8080/api
 VITE_GOOGLE_OAUTH_URL=http://localhost:8080/oauth2/authorization/google
-VITE_KAKAO_MAP_KEY=키값
+VITE_KAKAO_MAP_KEY=5246c615b9b3ce1f592d2f29136d5ae6
 VITE_UI_DEFAULT_VERSION=1

--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
 VITE_API_BASE_URL=http://localhost:8080/api
 VITE_GOOGLE_OAUTH_URL=http://localhost:8080/oauth2/authorization/google
 VITE_KAKAO_MAP_KEY=키값
+VITE_UI_DEFAULT_VERSION=1

--- a/src/api/.env.example
+++ b/src/api/.env.example
@@ -2,6 +2,7 @@
 
 # .env.development
 VITE_API_BASE_URL=http://localhost:8080
+VITE_UI_DEFAULT_VERSION=1  # 1 또는 2. 미설정 시 1
 
 # .env.production
 # VITE_API_BASE_URL=https://api.devticket.io

--- a/src/router-v2/VersionedRoute.tsx
+++ b/src/router-v2/VersionedRoute.tsx
@@ -1,0 +1,12 @@
+import type { ReactElement } from 'react'
+import { useUiVersion } from './useUiVersion'
+
+type VersionedRouteProps = {
+  v1: ReactElement
+  v2?: ReactElement
+}
+
+export function VersionedRoute({ v1, v2 }: VersionedRouteProps): ReactElement {
+  const version = useUiVersion()
+  return version === '2' && v2 ? v2 : v1
+}

--- a/src/router-v2/index.ts
+++ b/src/router-v2/index.ts
@@ -1,0 +1,3 @@
+export { VersionedRoute } from './VersionedRoute'
+export { useUiVersion } from './useUiVersion'
+export type { UiVersion } from './useUiVersion'

--- a/src/router-v2/useUiVersion.ts
+++ b/src/router-v2/useUiVersion.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react'
+
+export type UiVersion = '1' | '2'
+
+const STORAGE_KEY = 'ui.version'
+
+function normalize(value: string | null | undefined): UiVersion | null {
+  return value === '1' || value === '2' ? value : null
+}
+
+function readUrlVersion(): UiVersion | null {
+  return normalize(new URLSearchParams(window.location.search).get('v'))
+}
+
+function readStorageVersion(): UiVersion | null {
+  return normalize(localStorage.getItem(STORAGE_KEY))
+}
+
+function readEnvVersion(): UiVersion | null {
+  return normalize(import.meta.env.VITE_UI_DEFAULT_VERSION)
+}
+
+export function useUiVersion(): UiVersion {
+  const urlVersion = readUrlVersion()
+
+  useEffect(() => {
+    if (urlVersion === '2') localStorage.setItem(STORAGE_KEY, '2')
+    else if (urlVersion === '1') localStorage.removeItem(STORAGE_KEY)
+  }, [urlVersion])
+
+  return urlVersion ?? readStorageVersion() ?? readEnvVersion() ?? '1'
+}


### PR DESCRIPTION
## Summary
This PR introduces a UI versioning system that allows users to switch between two versions of the application (v1 and v2) via URL parameter, with persistence via localStorage and a configurable default version.

## Key Changes
- **useUiVersion hook**: New custom hook that manages UI version state with a priority-based resolution:
  1. URL parameter (`?v=1` or `?v=2`)
  2. localStorage persistence
  3. Environment variable default (`VITE_UI_DEFAULT_VERSION`)
  4. Fallback to v1
  
- **VersionedRoute component**: New component that conditionally renders v1 or v2 implementations based on the active UI version

- **Version persistence**: When a user specifies a version via URL parameter, it's automatically saved to localStorage for subsequent visits

- **Environment configuration**: Added `VITE_UI_DEFAULT_VERSION` environment variable to `.env.development` and `.env.example` for configurable defaults

- **Public exports**: Created `router-v2/index.ts` barrel export for easy importing of versioning utilities

## Implementation Details
- Version validation is centralized in the `normalize()` function to ensure only valid versions ('1' or '2') are accepted
- URL parameter takes precedence over stored preferences, enabling easy testing and sharing of specific versions
- The hook uses `useEffect` to synchronize URL-based version changes to localStorage
- Defaults gracefully to v1 if no version is specified anywhere

https://claude.ai/code/session_01LofB4pqWzYZNU2dWNMg6YA