### PR TITLE
feat: implement v2 Layout chrome (IDE-style UI skeleton)

### DIFF
--- a/src/components-v2/Icon/index.tsx
+++ b/src/components-v2/Icon/index.tsx
@@ -1,0 +1,236 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Source: docs/redesign/prototype/common.jsx — Icon + FileIcon set, ported to
+ * typed React components. Decorative by default (aria-hidden="true"); consumers
+ * are expected to label the surrounding interactive element.
+ *
+ * stroke="currentColor" so icons follow the parent text color
+ * (.act-btn / .tab / .side-item all rely on this).
+ */
+
+export type IconName =
+  | 'folder'
+  | 'file'
+  | 'search'
+  | 'git'
+  | 'ext'
+  | 'user'
+  | 'cart'
+  | 'ticket'
+  | 'sun'
+  | 'moon'
+  | 'x'
+  | 'chev'
+  | 'chevd'
+  | 'bell'
+  | 'check'
+  | 'play'
+  | 'wallet'
+  | 'refund'
+  | 'terminal'
+  | 'trash'
+  | 'plus'
+  | 'minus'
+  | 'settings'
+  | 'zap'
+  | 'calendar'
+  | 'pin';
+
+const PATHS: Record<IconName, ReactNode> = {
+  folder: <path d="M4 4h5l2 3h9v11a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z" />,
+  file: (
+    <>
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14 2 14 8 20 8" />
+    </>
+  ),
+  search: (
+    <>
+      <circle cx="11" cy="11" r="7" />
+      <path d="m20 20-3.5-3.5" />
+    </>
+  ),
+  git: (
+    <>
+      <circle cx="6" cy="18" r="3" />
+      <circle cx="6" cy="6" r="3" />
+      <circle cx="18" cy="12" r="3" />
+      <path d="M6 9v6" />
+      <path d="M6 9a9 9 0 0 0 9 9" />
+    </>
+  ),
+  ext: (
+    <>
+      <rect x="3" y="3" width="7" height="7" />
+      <rect x="14" y="3" width="7" height="7" />
+      <rect x="14" y="14" width="7" height="7" />
+      <rect x="3" y="14" width="7" height="7" />
+    </>
+  ),
+  user: (
+    <>
+      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+      <circle cx="12" cy="7" r="4" />
+    </>
+  ),
+  cart: (
+    <>
+      <circle cx="9" cy="21" r="1" />
+      <circle cx="20" cy="21" r="1" />
+      <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6" />
+    </>
+  ),
+  ticket: (
+    <>
+      <path d="M2 9a3 3 0 0 1 0 6v2a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-2a3 3 0 0 1 0-6V7a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2z" />
+      <path d="M13 5v2" />
+      <path d="M13 17v2" />
+      <path d="M13 11v2" />
+    </>
+  ),
+  sun: (
+    <>
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+    </>
+  ),
+  moon: <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />,
+  x: <path d="M18 6 6 18M6 6l12 12" />,
+  chev: <polyline points="9 18 15 12 9 6" />,
+  chevd: <polyline points="6 9 12 15 18 9" />,
+  bell: (
+    <>
+      <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+      <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+    </>
+  ),
+  check: <polyline points="20 6 9 17 4 12" />,
+  play: <polygon points="5 3 19 12 5 21 5 3" />,
+  wallet: (
+    <>
+      <path d="M21 12V7H5a2 2 0 0 1 0-4h14v4" />
+      <path d="M3 5v14a2 2 0 0 0 2 2h16v-5" />
+      <path d="M18 12a2 2 0 0 0 0 4h4v-4z" />
+    </>
+  ),
+  refund: (
+    <>
+      <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
+      <path d="M3 3v5h5" />
+    </>
+  ),
+  terminal: (
+    <>
+      <polyline points="4 17 10 11 4 5" />
+      <line x1="12" y1="19" x2="20" y2="19" />
+    </>
+  ),
+  trash: (
+    <>
+      <polyline points="3 6 5 6 21 6" />
+      <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+    </>
+  ),
+  plus: (
+    <>
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </>
+  ),
+  minus: <line x1="5" y1="12" x2="19" y2="12" />,
+  settings: (
+    <>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </>
+  ),
+  zap: <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />,
+  calendar: (
+    <>
+      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+    </>
+  ),
+  pin: (
+    <>
+      <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+      <circle cx="12" cy="10" r="3" />
+    </>
+  ),
+};
+
+export interface IconProps {
+  name: IconName;
+  size?: number;
+  className?: string;
+}
+
+export function Icon({ name, size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={className}
+    >
+      {PATHS[name]}
+    </svg>
+  );
+}
+
+/* File-tree / tab icons. Language brand colors are intentionally hard-coded —
+ * these are identity colors (React cyan, TS blue, …), not theme tokens. */
+
+export type FileIconKind = 'jsx' | 'ts' | 'tsx' | 'go' | 'rs' | 'json' | 'md' | 'py' | 'css';
+
+const FILE_COLORS: Record<FileIconKind, string> = {
+  jsx: '#61DAFB',
+  ts: '#3178C6',
+  tsx: '#3178C6',
+  go: '#00ADD8',
+  rs: '#CE422B',
+  json: '#CBD43B',
+  md: '#42A5F5',
+  py: '#FFD43B',
+  css: '#1572B6',
+};
+
+const FILE_FALLBACK = '#94A3B8';
+
+export interface FileIconProps {
+  kind?: FileIconKind;
+  size?: number;
+  className?: string;
+}
+
+export function FileIcon({ kind = 'jsx', size = 14, className }: FileIconProps) {
+  const c = FILE_COLORS[kind] ?? FILE_FALLBACK;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+      className={className}
+    >
+      <path
+        d="M9 1H3a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V6l-5-5z"
+        fill={c}
+        opacity="0.15"
+        stroke={c}
+        strokeWidth="1"
+      />
+      <path d="M9 1v5h5" fill={c} opacity="0.35" />
+    </svg>
+  );
+}

--- a/src/components-v2/Layout/ActivityBar.tsx
+++ b/src/components-v2/Layout/ActivityBar.tsx
@@ -1,0 +1,94 @@
+import { Icon, type IconName } from '../Icon';
+import type { ActivityItem, NavigateFn, RouteKey } from './types';
+
+/**
+ * Source: docs/redesign/layout.plan.md §3-5 + §6-6 a11y markup.
+ *
+ * Items list is a component-internal constant per §3-5. The settings button
+ * is rendered separately after the spacer; it is intentionally not wired —
+ * §3-5 leaves its click target undecided.
+ *
+ * Auth gating per §4-2: cart/mypage clicks while logged-out route to login;
+ * the cart badge only shows for logged-in users with at least one item.
+ *
+ * Active rule per §4-1: 'events' item stays active across the events and
+ * detail routes (a single nav slot for the events flow).
+ */
+export interface ActivityBarProps {
+  currentRoute: RouteKey;
+  cartCount: number;
+  isLoggedIn: boolean;
+  onNavigate: NavigateFn;
+  onOpenPalette: () => void;
+  className?: string;
+}
+
+const ITEMS: ActivityItem[] = [
+  { key: 'home', icon: 'terminal', label: '홈' },
+  { key: 'events', icon: 'folder', label: '이벤트' },
+  { key: 'search', icon: 'search', label: '검색', action: 'palette' },
+  { key: 'cart', icon: 'cart', label: '장바구니' },
+  { key: 'mypage', icon: 'user', label: '마이페이지' },
+];
+
+function isItemActive(item: ActivityItem, currentRoute: RouteKey): boolean {
+  if (item.action === 'palette') return false;
+  if (item.key === 'events') {
+    return currentRoute === 'events' || currentRoute === 'detail';
+  }
+  return item.key === currentRoute;
+}
+
+export function ActivityBar({
+  currentRoute,
+  cartCount,
+  isLoggedIn,
+  onNavigate,
+  onOpenPalette,
+  className,
+}: ActivityBarProps) {
+  const containerCls = className ? `ide-activity ${className}` : 'ide-activity';
+
+  const handleClick = (item: ActivityItem) => {
+    if (item.action === 'palette') {
+      onOpenPalette();
+      return;
+    }
+    if ((item.key === 'cart' || item.key === 'mypage') && !isLoggedIn) {
+      onNavigate('login');
+      return;
+    }
+    onNavigate(item.key as RouteKey);
+  };
+
+  return (
+    <nav className={containerCls} aria-label="주요 메뉴">
+      {ITEMS.map((item) => {
+        const active = isItemActive(item, currentRoute);
+        const showBadge = item.key === 'cart' && isLoggedIn && cartCount > 0;
+        const ariaLabel = showBadge ? `${item.label} ${cartCount}개` : item.label;
+        return (
+          <button
+            key={item.key}
+            type="button"
+            className={active ? 'act-btn active' : 'act-btn'}
+            aria-label={ariaLabel}
+            aria-current={active ? 'page' : undefined}
+            onClick={() => handleClick(item)}
+          >
+            <Icon name={item.icon as IconName} size={20} />
+            {showBadge && (
+              <span className="act-badge" aria-hidden="true">
+                {cartCount}
+              </span>
+            )}
+          </button>
+        );
+      })}
+      <div className="act-spacer" />
+      <button type="button" className="act-btn" aria-label="설정">
+        <Icon name="settings" size={18} />
+      </button>
+    </nav>
+  );
+}

--- a/src/components-v2/Layout/CommandPalette/PaletteList.tsx
+++ b/src/components-v2/Layout/CommandPalette/PaletteList.tsx
@@ -1,0 +1,66 @@
+import { Icon, type IconName } from '../../Icon';
+import type { PaletteItem } from '../types';
+
+/**
+ * Source: docs/redesign/layout.plan.md §3-14 + §6-7 a11y.
+ *
+ * Empty-state rendering ("검색 결과가 없습니다") is this component's
+ * responsibility per §3-14. When empty, the listbox is omitted entirely —
+ * an aria-controls relationship from the input is broken in that state, but
+ * the alternative (a non-option child inside the listbox) muddies semantics.
+ *
+ * Items render as <li role="option"> per §6-7 with stable id="palette-item-${i}";
+ * the parent CommandPalette wires aria-activedescendant on the input so
+ * arrow-key navigation is announced without moving DOM focus off the input.
+ *
+ * Hover updates selectedIndex (mouse-driven) via onHover; click runs the
+ * action via onRun. Keyboard arrow handling lives at the input/parent level.
+ */
+export interface PaletteListProps {
+  items: PaletteItem[];
+  selectedIndex: number;
+  onHover: (index: number) => void;
+  onRun: (index: number) => void;
+  className?: string;
+}
+
+export function PaletteList({
+  items,
+  selectedIndex,
+  onHover,
+  onRun,
+  className,
+}: PaletteListProps) {
+  if (items.length === 0) {
+    const emptyCls = className ? `palette-empty ${className}` : 'palette-empty';
+    return <div className={emptyCls}>검색 결과가 없습니다</div>;
+  }
+
+  const listCls = className ? `palette-list ${className}` : 'palette-list';
+
+  return (
+    <ul className={listCls} role="listbox" aria-label="검색 결과">
+      {items.map((item, i) => {
+        const isSelected = i === selectedIndex;
+        return (
+          <li
+            key={item.key}
+            id={`palette-item-${i}`}
+            role="option"
+            aria-selected={isSelected}
+            className={isSelected ? 'palette-item sel' : 'palette-item'}
+            onMouseEnter={() => onHover(i)}
+            onClick={() => onRun(i)}
+          >
+            <Icon name={item.icon as IconName} size={14} className="fi" />
+            <div className="palette-item-body">
+              <div className="palette-item-label truncate">{item.label}</div>
+              <div className="palette-item-hint">{item.hint}</div>
+            </div>
+            {item.shortcut && <span className="shortcut">{item.shortcut}</span>}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components-v2/Layout/CommandPalette/index.tsx
+++ b/src/components-v2/Layout/CommandPalette/index.tsx
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { KeyboardEvent } from 'react';
+import { PaletteList } from './PaletteList';
+import { usePaletteCommands } from './usePaletteCommands';
+
+/**
+ * Source: docs/redesign/layout.plan.md §3-13 + §6-7 focus trap.
+ *
+ * Lifecycle (§6-7):
+ *   open=true  → capture document.activeElement, reset query/index, focus input
+ *   open=false → return null + restore the captured element's focus
+ *
+ * Focus trap: two sibling tabindex=0 sentinels around the dialog body. The
+ * only natively focusable element inside is the search input — sentinels
+ * always redirect Tab/Shift+Tab back to the input, keeping focus inside the
+ * modal (the listbox uses aria-activedescendant, so options never take focus).
+ *
+ * Combobox a11y (§6-7):
+ *   role="combobox" + aria-autocomplete="list" + aria-activedescendant
+ *   pointing at "palette-item-${selectedIndex}" — PaletteList emits matching
+ *   ids on each <li role="option">.
+ *
+ * Item run = side-effect + onClose, mirroring the prototype's split — the
+ * hook author writes only the action, the dialog handles the close.
+ */
+export interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const FOCUS_DELAY_MS = 10;
+
+export function CommandPalette({ open, onClose }: CommandPaletteProps) {
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const lastFocusedRef = useRef<HTMLElement | null>(null);
+
+  const { items } = usePaletteCommands(query);
+
+  useEffect(() => {
+    if (!open) {
+      lastFocusedRef.current?.focus();
+      lastFocusedRef.current = null;
+      return;
+    }
+    lastFocusedRef.current = document.activeElement as HTMLElement | null;
+    setQuery('');
+    setSelectedIndex(0);
+    const t = window.setTimeout(() => inputRef.current?.focus(), FOCUS_DELAY_MS);
+    return () => window.clearTimeout(t);
+  }, [open]);
+
+  useEffect(() => {
+    if (selectedIndex >= items.length) {
+      setSelectedIndex(Math.max(0, items.length - 1));
+    }
+  }, [items.length, selectedIndex]);
+
+  const run = useCallback(
+    (i: number) => {
+      const item = items[i];
+      if (!item) return;
+      item.action();
+      onClose();
+    },
+    [items, onClose],
+  );
+
+  const handleInputKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex((s) => Math.min(s + 1, Math.max(0, items.length - 1)));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex((s) => Math.max(s - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      run(selectedIndex);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  const trapFocus = () => inputRef.current?.focus();
+
+  if (!open) return null;
+
+  const activeId =
+    items.length > 0 && selectedIndex < items.length
+      ? `palette-item-${selectedIndex}`
+      : undefined;
+
+  return (
+    <div className="palette-backdrop" onClick={onClose}>
+      <div
+        className="palette"
+        role="dialog"
+        aria-modal="true"
+        aria-label="명령 팔레트"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div tabIndex={0} onFocus={trapFocus} aria-hidden="true" />
+        <input
+          ref={inputRef}
+          className="palette-input"
+          type="text"
+          placeholder="명령이나 이벤트 검색..."
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setSelectedIndex(0);
+          }}
+          onKeyDown={handleInputKey}
+          role="combobox"
+          aria-expanded={items.length > 0}
+          aria-autocomplete="list"
+          aria-activedescendant={activeId}
+          aria-label="명령 또는 이벤트 검색"
+        />
+        <PaletteList
+          items={items}
+          selectedIndex={selectedIndex}
+          onHover={setSelectedIndex}
+          onRun={run}
+        />
+        <div className="palette-hint">
+          <span>
+            <kbd>↑↓</kbd>이동
+          </span>
+          <span>
+            <kbd>↵</kbd>실행
+          </span>
+          <span>
+            <kbd>esc</kbd>닫기
+          </span>
+          <span className="palette-hint-count">{items.length}개 결과</span>
+        </div>
+        <div tabIndex={0} onFocus={trapFocus} aria-hidden="true" />
+      </div>
+    </div>
+  );
+}

--- a/src/components-v2/Layout/CommandPalette/usePaletteCommands.ts
+++ b/src/components-v2/Layout/CommandPalette/usePaletteCommands.ts
@@ -1,0 +1,153 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { searchEvents } from '@/api/events.api';
+import { useAuth } from '@/contexts/AuthContext';
+import { useChrome } from '../LayoutChromeContext';
+import type { PaletteItem } from '../types';
+import { pathFromRoute } from '../utils';
+
+/**
+ * Source: docs/redesign/layout.plan.md §3-15.
+ *
+ * Static commands (6 routes / theme / login-logout) are filtered locally on
+ * label+hint substring; event search results are merged in via a debounced
+ * `searchEvents` call when the query is non-empty.
+ *
+ * Item actions perform only their side effect — closing the palette is the
+ * parent CommandPalette's responsibility (mirrors the prototype's
+ * run() = action() + onClose() split). This keeps each command unit-testable
+ * and prevents close-coupling action authors with the palette lifecycle.
+ */
+export interface UsePaletteCommandsResult {
+  items: PaletteItem[];
+  loading: boolean;
+}
+
+const DEBOUNCE_MS = 200;
+const SEARCH_PAGE_SIZE = 10;
+
+export function usePaletteCommands(query: string): UsePaletteCommandsResult {
+  const navigate = useNavigate();
+  const { isLoggedIn } = useAuth();
+  const { toggleTheme, logout } = useChrome();
+
+  const [eventItems, setEventItems] = useState<PaletteItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const staticItems = useMemo<PaletteItem[]>(() => {
+    const goCart = () =>
+      navigate(isLoggedIn ? pathFromRoute('cart') : pathFromRoute('login'));
+    const goMypage = () =>
+      navigate(isLoggedIn ? pathFromRoute('mypage') : pathFromRoute('login'));
+
+    return [
+      {
+        key: 'home',
+        label: '홈',
+        hint: '시작 화면',
+        icon: 'terminal',
+        shortcut: 'g h',
+        action: () => navigate(pathFromRoute('home')),
+      },
+      {
+        key: 'events',
+        label: '이벤트 목록',
+        hint: '모든 이벤트 둘러보기',
+        icon: 'folder',
+        shortcut: 'g e',
+        action: () => navigate(pathFromRoute('events')),
+      },
+      {
+        key: 'cart',
+        label: '장바구니',
+        hint: '담은 티켓 확인',
+        icon: 'cart',
+        shortcut: 'g c',
+        action: goCart,
+      },
+      {
+        key: 'mypage',
+        label: '마이페이지',
+        hint: '내 티켓 · 주문 내역',
+        icon: 'user',
+        shortcut: 'g m',
+        action: goMypage,
+      },
+      {
+        key: 'auth',
+        label: isLoggedIn ? '로그아웃' : '로그인',
+        hint: isLoggedIn ? '세션 종료' : '계정에 로그인',
+        icon: 'terminal',
+        action: () => {
+          if (isLoggedIn) {
+            logout();
+          } else {
+            navigate(pathFromRoute('login'));
+          }
+        },
+      },
+      {
+        key: 'theme',
+        label: '테마 전환',
+        hint: '라이트 ↔ 다크',
+        icon: 'moon',
+        action: toggleTheme,
+      },
+    ];
+  }, [navigate, isLoggedIn, toggleTheme, logout]);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      setEventItems([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      try {
+        const res = await searchEvents({
+          keyword: trimmed,
+          page: 0,
+          size: SEARCH_PAGE_SIZE,
+        });
+        if (cancelled) return;
+        const events = res.data?.data?.content ?? [];
+        const items: PaletteItem[] = events.map((event) => ({
+          key: `ev_${event.eventId}`,
+          label: event.title,
+          hint: `${event.category} · ${
+            event.price === 0 ? '무료' : `${event.price.toLocaleString()}원`
+          }`,
+          icon: 'ticket',
+          action: () =>
+            navigate(pathFromRoute('detail', { id: event.eventId })),
+        }));
+        setEventItems(items);
+      } catch {
+        if (!cancelled) setEventItems([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [query, navigate]);
+
+  const items = useMemo(() => {
+    const trimmed = query.trim();
+    if (!trimmed) return staticItems;
+    const q = trimmed.toLowerCase();
+    const filtered = staticItems.filter((it) =>
+      `${it.label} ${it.hint}`.toLowerCase().includes(q),
+    );
+    return [...filtered, ...eventItems];
+  }, [query, staticItems, eventItems]);
+
+  return { items, loading };
+}

--- a/src/components-v2/Layout/LayoutChromeContext.tsx
+++ b/src/components-v2/Layout/LayoutChromeContext.tsx
@@ -1,0 +1,91 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+/**
+ * Source: docs/redesign/layout.plan.md §3-2.
+ *
+ * `paletteOpen` is exposed on top of the §3-2 listed members so the consumer
+ * (Layout) can wire it into <CommandPalette open={…} onClose={…} /> per §3-13
+ * without lifting the state outside the provider.
+ */
+export interface ChromeContextValue {
+  paletteOpen: boolean;
+  openPalette: () => void;
+  closePalette: () => void;
+  toggleTheme: () => void;
+  logout: () => void;
+  focusSearch: () => void;
+  registerSearchInput: (el: HTMLInputElement | null) => void;
+}
+
+export interface LayoutChromeProviderProps {
+  children: React.ReactNode;
+  onToggleTheme: () => void;
+  onLogout: () => void;
+}
+
+const LayoutChromeContext = createContext<ChromeContextValue | null>(null);
+
+export function LayoutChromeProvider({
+  children,
+  onToggleTheme,
+  onLogout,
+}: LayoutChromeProviderProps) {
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+
+  const openPalette = useCallback(() => setPaletteOpen(true), []);
+  const closePalette = useCallback(() => setPaletteOpen(false), []);
+
+  const focusSearch = useCallback(() => {
+    searchInputRef.current?.focus();
+  }, []);
+
+  const registerSearchInput = useCallback(
+    (el: HTMLInputElement | null) => {
+      searchInputRef.current = el;
+    },
+    [],
+  );
+
+  const value = useMemo<ChromeContextValue>(
+    () => ({
+      paletteOpen,
+      openPalette,
+      closePalette,
+      toggleTheme: onToggleTheme,
+      logout: onLogout,
+      focusSearch,
+      registerSearchInput,
+    }),
+    [
+      paletteOpen,
+      openPalette,
+      closePalette,
+      onToggleTheme,
+      onLogout,
+      focusSearch,
+      registerSearchInput,
+    ],
+  );
+
+  return (
+    <LayoutChromeContext.Provider value={value}>
+      {children}
+    </LayoutChromeContext.Provider>
+  );
+}
+
+export function useChrome(): ChromeContextValue {
+  const ctx = useContext(LayoutChromeContext);
+  if (!ctx) {
+    throw new Error('useChrome must be used within a LayoutChromeProvider');
+  }
+  return ctx;
+}

--- a/src/components-v2/Layout/Minimap.tsx
+++ b/src/components-v2/Layout/Minimap.tsx
@@ -1,0 +1,45 @@
+import type { RouteKey } from './types';
+
+/**
+ * Source: docs/redesign/layout.plan.md §3-11.
+ *
+ * Decorative right-rail "minimap" that mimics IDE syntax patterns. No
+ * interaction; `aria-hidden` per §6-6.
+ *
+ * Patterns are fixed strings of class tokens (kw/fn/str/cmt or '' for plain)
+ * cycled to fill 80 lines. Per-line width varies via inline style — class
+ * variants would require dozens of width buckets, so a single style attribute
+ * for dynamic geometry is the pragmatic choice (matches prototype semantics).
+ */
+export interface MinimapProps {
+  route: RouteKey;
+  className?: string;
+}
+
+const PATTERNS: Record<RouteKey, string[]> = {
+  home:   ['kw', '', 'fn', '', 'str', '', 'cmt', '', 'kw', 'fn', '', 'str', '', '', 'kw', '', 'fn', 'str', '', '', 'cmt'],
+  events: ['kw', '', 'kw', 'fn', '', 'str', 'cmt', '', 'kw', '', '', 'fn', '', '', 'str', '', 'cmt', '', '', 'kw', 'fn', '', '', '', 'str'],
+  detail: ['kw', '', 'fn', '', '', 'str', '', '', 'kw', '', '', 'fn', 'str', '', '', 'str', '', '', 'kw', '', 'fn', '', '', '', '', 'cmt'],
+  cart:   ['kw', '', '', 'fn', '', 'str', '', 'kw', '', '', 'fn', '', '', 'str', '', 'cmt', '', 'kw', '', 'fn', '', '', '', '', '', ''],
+  mypage: ['kw', 'fn', '', '', 'str', '', '', 'kw', '', '', 'fn', '', 'str', '', '', 'cmt', '', 'kw', 'fn', '', 'str', ''],
+  login:  ['kw', '', '', 'fn', '', 'str', '', '', 'cmt', '', 'kw', 'fn', '', '', 'str', '', '', ''],
+};
+
+const LINE_COUNT = 80;
+
+export function Minimap({ route, className }: MinimapProps) {
+  const base = PATTERNS[route];
+  const containerClass = className ? `ide-minimap ${className}` : 'ide-minimap';
+
+  return (
+    <div className={containerClass} aria-hidden="true">
+      {Array.from({ length: LINE_COUNT }, (_, i) => {
+        const tone = base[i % base.length];
+        const width = 70 + ((i * 37) % 30);
+        const cls = tone ? `mini-line ${tone}` : 'mini-line';
+        return <div key={i} className={cls} style={{ width: `${width}%` }} />;
+      })}
+      <div className="mini-window" />
+    </div>
+  );
+}

--- a/src/components-v2/Layout/Sidebar/SidebarMenu.tsx
+++ b/src/components-v2/Layout/Sidebar/SidebarMenu.tsx
@@ -1,0 +1,150 @@
+import { Icon } from '../../Icon';
+import type { CategoryCount, NavigateFn, RouteKey } from '../types';
+
+/**
+ * Source: docs/redesign/layout.plan.md §3-7.
+ *
+ * Item active rule per §4-1: simple 1:1 with currentRoute (events item is
+ * active only on 'events', not 'detail' — distinct from ActivityBar).
+ *
+ * Auth gating per §4-2: cart/mypage clicks while logged-out route to login;
+ * the explicit "로그인" row is only shown for logged-out sessions.
+ *
+ * Categories use the shared aria-label "${name}, ${count}개" form (§6-6).
+ */
+export interface SidebarMenuProps {
+  currentRoute: RouteKey;
+  isLoggedIn: boolean;
+  open: boolean;
+  onToggle: () => void;
+  totalEventCount: number;
+  categories: CategoryCount[];
+  onNavigate: NavigateFn;
+  className?: string;
+}
+
+const LIST_ID = 'side-menu-group';
+
+const itemCls = (active: boolean) => (active ? 'side-item active' : 'side-item');
+
+export function SidebarMenu({
+  currentRoute,
+  isLoggedIn,
+  open,
+  onToggle,
+  totalEventCount,
+  categories,
+  onNavigate,
+  className,
+}: SidebarMenuProps) {
+  const groupCls = className ? `side-group ${className}` : 'side-group';
+
+  const handleAuthRoute = (route: RouteKey) => {
+    if ((route === 'cart' || route === 'mypage') && !isLoggedIn) {
+      onNavigate('login');
+      return;
+    }
+    onNavigate(route);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className="side-header"
+        aria-expanded={open}
+        aria-controls={LIST_ID}
+        onClick={onToggle}
+      >
+        <span>메뉴</span>
+        <Icon name={open ? 'chevd' : 'chev'} size={10} />
+      </button>
+      {open && (
+        <ul id={LIST_ID} className={groupCls} role="list">
+          <li>
+            <button
+              type="button"
+              className={itemCls(currentRoute === 'home')}
+              aria-current={currentRoute === 'home' ? 'page' : undefined}
+              onClick={() => onNavigate('home')}
+            >
+              <span className="tri" aria-hidden="true">▸</span>
+              <Icon name="terminal" size={13} />
+              <span>홈</span>
+            </button>
+          </li>
+
+          <li>
+            <button
+              type="button"
+              className={itemCls(currentRoute === 'events')}
+              aria-current={currentRoute === 'events' ? 'page' : undefined}
+              onClick={() => onNavigate('events')}
+            >
+              <span className="tri" aria-hidden="true">▾</span>
+              <Icon name="folder" size={13} />
+              <span>이벤트 둘러보기</span>
+              <span className="side-count">{totalEventCount}</span>
+            </button>
+          </li>
+
+          {categories.map((cat) => (
+            <li key={cat.name}>
+              <button
+                type="button"
+                className="side-item side-nested"
+                aria-label={`${cat.name}, ${cat.count}개`}
+                onClick={() => onNavigate('events', { category: cat.name })}
+              >
+                <span className="side-prefix" aria-hidden="true">#</span>
+                <span>{cat.name}</span>
+                <span className="side-count" aria-hidden="true">{cat.count}</span>
+              </button>
+            </li>
+          ))}
+
+          <li>
+            <button
+              type="button"
+              className={itemCls(currentRoute === 'cart')}
+              aria-current={currentRoute === 'cart' ? 'page' : undefined}
+              onClick={() => handleAuthRoute('cart')}
+            >
+              <span className="tri" aria-hidden="true">▸</span>
+              <Icon name="cart" size={13} />
+              <span>장바구니</span>
+            </button>
+          </li>
+
+          <li>
+            <button
+              type="button"
+              className={itemCls(currentRoute === 'mypage')}
+              aria-current={currentRoute === 'mypage' ? 'page' : undefined}
+              onClick={() => handleAuthRoute('mypage')}
+            >
+              <span className="tri" aria-hidden="true">▸</span>
+              <Icon name="user" size={13} />
+              <span>마이페이지</span>
+            </button>
+          </li>
+
+          {!isLoggedIn && (
+            <li>
+              <button
+                type="button"
+                className={itemCls(currentRoute === 'login')}
+                aria-current={currentRoute === 'login' ? 'page' : undefined}
+                onClick={() => onNavigate('login')}
+              >
+                <span className="tri" aria-hidden="true">▸</span>
+                <Icon name="terminal" size={13} />
+                <span>로그인</span>
+              </button>
+            </li>
+          )}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/src/components-v2/Layout/Sidebar/SidebarSession.tsx
+++ b/src/components-v2/Layout/Sidebar/SidebarSession.tsx
@@ -1,0 +1,32 @@
+import type { SessionUser } from '../types';
+
+/**
+ * Source: docs/redesign/layout.plan.md §3-9.
+ *
+ * Session row is always expanded (no toggle) — gating logged-out rendering is
+ * the parent's responsibility, so user is always non-null here.
+ *
+ * Markup follows §6-6: section as <h2>, single-item <ul role="list"> with the
+ * online dot decorative (aria-hidden) and the trailing "온라인" tag styled via
+ * .side-meta.
+ */
+export interface SidebarSessionProps {
+  user: SessionUser;
+  className?: string;
+}
+
+export function SidebarSession({ user, className }: SidebarSessionProps) {
+  const groupCls = className ? `side-group ${className}` : 'side-group';
+  return (
+    <>
+      <h2 className="side-header">세션</h2>
+      <ul className={groupCls} role="list">
+        <li className="side-item side-item--mini">
+          <span className="side-dot" aria-hidden="true" />
+          <span>{user.nickname}</span>
+          <span className="side-meta">온라인</span>
+        </li>
+      </ul>
+    </>
+  );
+}

--- a/src/components-v2/Layout/Sidebar/SidebarUpcoming.tsx
+++ b/src/components-v2/Layout/Sidebar/SidebarUpcoming.tsx
@@ -1,0 +1,74 @@
+import type { KeyboardEvent } from 'react';
+import { Icon } from '../../Icon';
+import type { UpcomingEventVM } from '../types';
+
+/**
+ * Source: docs/redesign/layout.plan.md §3-8.
+ *
+ * Header is a <button> per §6-6 (aria-expanded + aria-controls); list is a
+ * <ul role="list"> matching the controls id. Each row is two stacked lines
+ * (title + date · price) — block content inside a <button> is invalid HTML,
+ * so the row is a <div role="button" tabIndex={0}> with Enter/Space handling
+ * (mirrors the TabBar tab-row pattern).
+ */
+export interface SidebarUpcomingProps {
+  open: boolean;
+  onToggle: () => void;
+  events: UpcomingEventVM[];
+  onSelectEvent: (eventId: string) => void;
+  className?: string;
+}
+
+const LIST_ID = 'side-upcoming-group';
+
+export function SidebarUpcoming({
+  open,
+  onToggle,
+  events,
+  onSelectEvent,
+  className,
+}: SidebarUpcomingProps) {
+  const groupCls = className ? `side-group ${className}` : 'side-group';
+
+  const handleItemKey = (e: KeyboardEvent<HTMLDivElement>, eventId: string) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onSelectEvent(eventId);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className="side-header"
+        aria-expanded={open}
+        aria-controls={LIST_ID}
+        onClick={onToggle}
+      >
+        <span>다가오는 이벤트</span>
+        <Icon name={open ? 'chevd' : 'chev'} size={10} />
+      </button>
+      {open && (
+        <ul id={LIST_ID} className={groupCls} role="list">
+          {events.map((event) => (
+            <li key={event.eventId}>
+              <div
+                className="side-item side-item--card"
+                role="button"
+                tabIndex={0}
+                onClick={() => onSelectEvent(event.eventId)}
+                onKeyDown={(ke) => handleItemKey(ke, event.eventId)}
+              >
+                <div className="side-card-title">{event.title}</div>
+                <div className="side-card-meta">
+                  {event.dateText} · {event.priceText}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/src/components-v2/Layout/Sidebar/index.tsx
+++ b/src/components-v2/Layout/Sidebar/index.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import type {
+  CategoryCount,
+  NavigateFn,
+  RouteKey,
+  SessionUser,
+  UpcomingEventVM,
+} from '../types';
+import { SidebarMenu } from './SidebarMenu';
+import { SidebarUpcoming } from './SidebarUpcoming';
+import { SidebarSession } from './SidebarSession';
+
+/**
+ * Source: docs/redesign/layout.plan.md §3-6.
+ *
+ * Container only — owns the two collapse states (menu, upcoming) per §3-6 and
+ * gates SidebarSession on auth (§4-2). Session is always expanded (§3-9).
+ *
+ * Selecting an upcoming event delegates to onNavigate('detail', { id: … }) so
+ * route-shaping stays in the parent (§4-1 routing rules).
+ */
+export interface SidebarProps {
+  currentRoute: RouteKey;
+  isLoggedIn: boolean;
+  user: SessionUser | null;
+  totalEventCount: number;
+  categories: CategoryCount[];
+  upcoming: UpcomingEventVM[];
+  onNavigate: NavigateFn;
+  className?: string;
+}
+
+export function Sidebar({
+  currentRoute,
+  isLoggedIn,
+  user,
+  totalEventCount,
+  categories,
+  upcoming,
+  onNavigate,
+  className,
+}: SidebarProps) {
+  const [menuOpen, setMenuOpen] = useState(true);
+  const [upcomingOpen, setUpcomingOpen] = useState(true);
+
+  const containerCls = className ? `ide-sidebar ${className}` : 'ide-sidebar';
+
+  const handleSelectEvent = (eventId: string) => {
+    onNavigate('detail', { id: eventId });
+  };
+
+  return (
+    <aside className={containerCls} aria-label="사이드 네비게이션">
+      <SidebarMenu
+        currentRoute={currentRoute}
+        isLoggedIn={isLoggedIn}
+        open={menuOpen}
+        onToggle={() => setMenuOpen((v) => !v)}
+        totalEventCount={totalEventCount}
+        categories={categories}
+        onNavigate={onNavigate}
+      />
+      <SidebarUpcoming
+        open={upcomingOpen}
+        onToggle={() => setUpcomingOpen((v) => !v)}
+        events={upcoming}
+        onSelectEvent={handleSelectEvent}
+      />
+      {isLoggedIn && user && <SidebarSession user={user} />}
+    </aside>
+  );
+}

--- a/src/components-v2/Layout/StatusBar.tsx
+++ b/src/components-v2/Layout/StatusBar.tsx
@@ -1,0 +1,72 @@
+import { Icon } from '../Icon';
+import type { RouteKey, SessionUser } from './types';
+
+/**
+ * Source: docs/redesign/layout.plan.md §3-12 + §6-6 a11y markup.
+ *
+ * Layout (left → right):
+ *   git icon · DevTicket | ● 정상 | route label | (spacer) | 한국어 | ● user | ⌘K
+ *
+ * Only the ⌘K trigger is interactive — the prototype's git slot is decorative
+ * with `clickable` styling but no wired handler, so v2 drops the class to keep
+ * the §6-5 rule "clickable elements are buttons" honest.
+ */
+export interface StatusBarProps {
+  currentRoute: RouteKey;
+  isLoggedIn: boolean;
+  user: SessionUser | null;
+  onOpenPalette: () => void;
+  className?: string;
+}
+
+const ROUTE_LABEL: Record<RouteKey, string> = {
+  home: '홈',
+  events: '이벤트 목록',
+  detail: '이벤트 상세',
+  cart: '장바구니',
+  mypage: '마이페이지',
+  login: '로그인',
+};
+
+const LANGUAGE_LABEL = '한국어';
+
+export function StatusBar({
+  currentRoute,
+  isLoggedIn,
+  user,
+  onOpenPalette,
+  className,
+}: StatusBarProps) {
+  const containerCls = className ? `ide-status ${className}` : 'ide-status';
+  const sessionText = isLoggedIn ? `${user?.nickname ?? ''} 님` : '비회원';
+
+  return (
+    <footer className={containerCls} role="contentinfo">
+      <div className="status-item">
+        <Icon name="git" size={12} />
+        <span>DevTicket</span>
+      </div>
+      <div className="status-item term-ok" aria-label="시스템 상태: 정상">
+        <span aria-hidden="true">●</span>
+        <span aria-hidden="true">정상</span>
+      </div>
+      <div className="status-item">
+        <span>{ROUTE_LABEL[currentRoute]}</span>
+      </div>
+      <div className="status-spacer" />
+      <div className="status-item">{LANGUAGE_LABEL}</div>
+      <div className="status-item">
+        <span className="term-ok" aria-hidden="true">●</span>
+        <span>{sessionText}</span>
+      </div>
+      <button
+        type="button"
+        className="status-item clickable"
+        aria-label="명령 팔레트 열기"
+        onClick={onOpenPalette}
+      >
+        <kbd>⌘K</kbd>
+      </button>
+    </footer>
+  );
+}

--- a/src/components-v2/Layout/TabBar.tsx
+++ b/src/components-v2/Layout/TabBar.tsx
@@ -1,0 +1,72 @@
+import type { KeyboardEvent } from 'react';
+import { Icon, type IconName } from '../Icon';
+import type { RouteKey, TabDef } from './types';
+
+/**
+ * Source: docs/redesign/layout.plan.md §3-10.
+ *
+ * Each tab is a <div role="tab"> rather than a <button> so the inner close
+ * <button> remains valid HTML (button-in-button is invalid). Selection is
+ * still keyboard-accessible via Enter / Space + tabIndex roving (active tab
+ * is the only one in the tab order; others are reachable via Tab → arrow nav
+ * within the tablist would be the next refinement, currently out of scope).
+ *
+ * §6-6 a11y: role="tablist" + aria-label, each tab aria-selected and
+ * aria-controls="ide-editor"; close button has explicit aria-label.
+ */
+export interface TabBarProps {
+  tabs: TabDef[];
+  activeKey: RouteKey;
+  onSelect: (key: RouteKey) => void;
+  /** Omit (or pass single tab) to hide the close affordance. */
+  onClose?: (key: RouteKey) => void;
+  className?: string;
+}
+
+export function TabBar({ tabs, activeKey, onSelect, onClose, className }: TabBarProps) {
+  const showClose = Boolean(onClose) && tabs.length > 1;
+  const containerCls = className ? `ide-tabs ${className}` : 'ide-tabs';
+
+  const handleTabKey = (e: KeyboardEvent<HTMLDivElement>, key: RouteKey) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onSelect(key);
+    }
+  };
+
+  return (
+    <div className={containerCls} role="tablist" aria-label="열린 페이지">
+      {tabs.map((t) => {
+        const isActive = activeKey === t.key;
+        return (
+          <div
+            key={t.key}
+            className={isActive ? 'tab active' : 'tab'}
+            role="tab"
+            aria-selected={isActive}
+            aria-controls="ide-editor"
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => onSelect(t.key)}
+            onKeyDown={(e) => handleTabKey(e, t.key)}
+          >
+            <Icon name={t.icon as IconName} size={13} />
+            <span>{t.label}</span>
+            {showClose && (
+              <button
+                type="button"
+                className="close"
+                aria-label={`${t.label} 탭 닫기`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClose?.(t.key);
+                }}
+              >
+                <Icon name="x" size={12} />
+              </button>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components-v2/Layout/TitleBar.tsx
+++ b/src/components-v2/Layout/TitleBar.tsx
@@ -1,0 +1,55 @@
+import { Icon } from '../Icon';
+import type { ThemeMode } from './types';
+
+/**
+ * Source: docs/redesign/layout.plan.md §3-4 + §6-6 a11y markup.
+ *
+ * theme arrives as a 'light' | 'dark' resolved value (§4-3): 'system' has been
+ * collapsed at the Layout level. Sun icon means "switch to light" (so it shows
+ * when currently dark), and vice versa.
+ *
+ * The title-cmd "search box" is actually a <button> that opens the command
+ * palette — there is no real <input> in the title bar. The §3-2
+ * registerSearchInput / focusSearch hooks remain forward-looking; this PR
+ * simply does not call registerSearchInput from here.
+ */
+export interface TitleBarProps {
+  theme: ThemeMode;
+  onToggleTheme: () => void;
+  onOpenPalette: () => void;
+  className?: string;
+}
+
+export function TitleBar({ theme, onToggleTheme, onOpenPalette, className }: TitleBarProps) {
+  const containerCls = className ? `ide-title ${className}` : 'ide-title';
+  const themeIcon = theme === 'dark' ? 'sun' : 'moon';
+
+  return (
+    <header className={containerCls} role="banner">
+      <div className="traffic" aria-hidden="true">
+        <span className="tc-red" />
+        <span className="tc-yellow" />
+        <span className="tc-green" />
+      </div>
+      <h1 className="title-text">DevTicket · 개발자를 위한 이벤트 티켓</h1>
+      <button
+        type="button"
+        className="title-cmd"
+        aria-label="명령 팔레트 열기 (⌘K)"
+        onClick={onOpenPalette}
+      >
+        <Icon name="search" size={11} />
+        <span>이벤트, 기술 스택으로 검색하기</span>
+        <kbd>⌘K</kbd>
+      </button>
+      <button
+        type="button"
+        className="act-btn"
+        aria-label="테마 전환"
+        onClick={onToggleTheme}
+      >
+        <Icon name={themeIcon} size={14} />
+      </button>
+    </header>
+  );
+}

--- a/src/components-v2/Layout/__preview.tsx
+++ b/src/components-v2/Layout/__preview.tsx
@@ -1,0 +1,127 @@
+import { useNavigate, useLocation } from 'react-router-dom';
+import Layout from '.';
+import type { RouteKey } from './types';
+import { pathFromRoute, routeFromPath } from './utils';
+
+/**
+ * Source: docs/redesign/layout.plan.md §7-0, §7-2 Step 8.
+ *
+ * Dev-only verification harness for the v2 Layout chrome. Mounted via
+ * main.tsx when `import.meta.env.DEV && location.pathname === '/__layout-preview'`.
+ *
+ * The preview drives Layout via real routing (uses navigate so the
+ * underlying useLocation flow is exercised), and renders a small mock pane
+ * for each of the six RouteKeys so visual states can be cycled. Removed
+ * in the first v2 page PR (§7-3).
+ *
+ * Inline styles are intentional here — this file is throwaway scaffolding
+ * and is excluded from production via the DEV guard at the entry.
+ */
+
+const ROUTES: RouteKey[] = [
+  'home',
+  'events',
+  'detail',
+  'cart',
+  'mypage',
+  'login',
+];
+
+const MOCK_LABEL: Record<RouteKey, string> = {
+  home: '홈 (Landing 자리)',
+  events: '이벤트 목록',
+  detail: '이벤트 상세',
+  cart: '장바구니',
+  mypage: '마이페이지',
+  login: '로그인',
+};
+
+function MockPane({ route }: { route: RouteKey }) {
+  return (
+    <div
+      style={{
+        padding: 32,
+        fontFamily: 'var(--font-mono)',
+        color: 'var(--text-2)',
+        fontSize: 13,
+        lineHeight: 1.7,
+      }}
+    >
+      <div style={{ color: 'var(--syn-comment)' }}>
+        // Mock content — {MOCK_LABEL[route]}
+      </div>
+      <div>
+        <span style={{ color: 'var(--syn-keyword)' }}>route</span>
+        <span style={{ color: 'var(--syn-punct)' }}>: </span>
+        <span style={{ color: 'var(--syn-string)' }}>"{route}"</span>
+      </div>
+      <div style={{ marginTop: 16, color: 'var(--text-3)' }}>
+        Layout chrome (titlebar, activity rail, sidebar, tabs, status bar,
+        minimap) should reflect this route. Try ⌘K, theme toggle, sidebar
+        toggles, and the preview controls below.
+      </div>
+    </div>
+  );
+}
+
+export default function LayoutPreview() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const currentRoute = routeFromPath(location.pathname);
+
+  const goRoute = (key: RouteKey) => {
+    const params = key === 'detail' ? { id: 'mock-event-1' } : undefined;
+    navigate(pathFromRoute(key, params));
+  };
+
+  return (
+    <Layout>
+      <MockPane route={currentRoute} />
+      <div
+        style={{
+          position: 'fixed',
+          bottom: 36,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          zIndex: 500,
+          padding: '8px 12px',
+          background: 'var(--surface)',
+          border: '1px solid var(--border)',
+          borderRadius: 8,
+          boxShadow: '0 8px 24px rgba(0, 0, 0, 0.18)',
+          display: 'flex',
+          gap: 6,
+          fontFamily: 'var(--font-mono)',
+          fontSize: 11.5,
+        }}
+      >
+        <strong style={{ color: 'var(--text-3)', alignSelf: 'center' }}>
+          Preview:
+        </strong>
+        {ROUTES.map((r) => {
+          const isActive = currentRoute === r;
+          return (
+            <button
+              key={r}
+              type="button"
+              onClick={() => goRoute(r)}
+              style={{
+                padding: '4px 10px',
+                borderRadius: 4,
+                border: '1px solid',
+                borderColor: isActive ? 'var(--brand)' : 'var(--border)',
+                background: isActive ? 'var(--brand-light)' : 'var(--editor-bg)',
+                color: isActive ? 'var(--brand)' : 'var(--text-2)',
+                fontFamily: 'inherit',
+                fontSize: 'inherit',
+                cursor: 'pointer',
+              }}
+            >
+              {r}
+            </button>
+          );
+        })}
+      </div>
+    </Layout>
+  );
+}

--- a/src/components-v2/Layout/hooks/useCartCount.ts
+++ b/src/components-v2/Layout/hooks/useCartCount.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getCart } from '@/api/cart.api';
+import { useAuth } from '@/contexts/AuthContext';
+
+/**
+ * Source: docs/redesign/layout.plan.md §4-4 (1차 안).
+ *
+ * Layout-internal cart badge feed. Reads `isLoggedIn` from AuthContext, fetches
+ * `/cart` on login transition, returns 0 while logged out (no API call).
+ *
+ * Limitation acknowledged in §4-4: in-page mutations (addCartItem / clearCart)
+ * are not observed — count refreshes only when the caller explicitly invokes
+ * `refresh()` or when `isLoggedIn` flips. The follow-up PR promotes this to a
+ * shared `CartContext` so Cart.tsx can dispatch refreshes after mutations.
+ */
+export interface UseCartCountResult {
+  count: number;
+  refresh: () => Promise<void>;
+  isLoading: boolean;
+}
+
+export function useCartCount(): UseCartCountResult {
+  const { isLoggedIn } = useAuth();
+  const [count, setCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!isLoggedIn) {
+      setCount(0);
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const res = await getCart();
+      const items = res.data?.items ?? [];
+      setCount(items.length);
+    } catch {
+      // Cart fetch is non-critical chrome data — swallow errors so the
+      // Layout never blocks on a transient cart endpoint failure.
+      setCount(0);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isLoggedIn]);
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      void refresh();
+    } else {
+      setCount(0);
+    }
+  }, [isLoggedIn, refresh]);
+
+  return { count, refresh, isLoading };
+}

--- a/src/components-v2/Layout/hooks/useGlobalShortcuts.ts
+++ b/src/components-v2/Layout/hooks/useGlobalShortcuts.ts
@@ -1,0 +1,139 @@
+import { useEffect, useRef } from 'react';
+import type { NavigateFn } from '../types';
+
+/**
+ * Source: docs/redesign/layout.plan.md §3-16 + §6-5 keyboard table.
+ *
+ * Always-on keys (work even inside inputs):
+ *   Cmd/Ctrl+K → onOpenPalette
+ *   Escape     → onClosePalette
+ *
+ * Outside-input keys:
+ *   /          → onFocusSearch
+ *   g h/e/c/m  → onNavigate (cart/mypage gate to login when !isLoggedIn)
+ *   j / k      → onCardNav(±1) — only if the page wires it
+ *   Enter      → onCardOpen — only if wired AND focus is not on an
+ *                interactive element (avoids double-firing native handlers)
+ *
+ * `g` is a two-key sequence with a 1s timeout; an unrelated key in the pending
+ * window resets it but falls through so 'g' can restart and 'j'/'k' still work.
+ *
+ * The handler is bound once via useEffect and reads opts via a ref to avoid
+ * re-binding the listener every render.
+ */
+export interface UseGlobalShortcutsOptions {
+  isLoggedIn: boolean;
+  onOpenPalette: () => void;
+  onClosePalette: () => void;
+  onFocusSearch: () => void;
+  onNavigate: NavigateFn;
+  onCardNav?: (delta: 1 | -1) => void;
+  onCardOpen?: () => void;
+}
+
+const G_SEQUENCE_TIMEOUT_MS = 1000;
+
+function isInInput(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA') return true;
+  if (target.isContentEditable) return true;
+  return false;
+}
+
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === 'BUTTON' || tag === 'A') return true;
+  const role = target.getAttribute('role');
+  return role === 'button' || role === 'tab' || role === 'option' || role === 'link';
+}
+
+export function useGlobalShortcuts(opts: UseGlobalShortcutsOptions): void {
+  const optsRef = useRef(opts);
+  optsRef.current = opts;
+
+  useEffect(() => {
+    let gPending = false;
+    let gTimer: number | null = null;
+
+    const clearG = () => {
+      gPending = false;
+      if (gTimer != null) {
+        window.clearTimeout(gTimer);
+        gTimer = null;
+      }
+    };
+
+    const handler = (e: KeyboardEvent) => {
+      const o = optsRef.current;
+      const target = e.target;
+
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        o.onOpenPalette();
+        clearG();
+        return;
+      }
+
+      if (e.key === 'Escape') {
+        o.onClosePalette();
+        clearG();
+        return;
+      }
+
+      if (isInInput(target)) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      if (gPending) {
+        const k = e.key.toLowerCase();
+        let consumed = true;
+        if (k === 'h') o.onNavigate('home');
+        else if (k === 'e') o.onNavigate('events');
+        else if (k === 'c') o.onNavigate(o.isLoggedIn ? 'cart' : 'login');
+        else if (k === 'm') o.onNavigate(o.isLoggedIn ? 'mypage' : 'login');
+        else consumed = false;
+        clearG();
+        if (consumed) {
+          e.preventDefault();
+          return;
+        }
+      }
+
+      if (e.key === 'g') {
+        gPending = true;
+        gTimer = window.setTimeout(clearG, G_SEQUENCE_TIMEOUT_MS);
+        return;
+      }
+
+      if (e.key === '/') {
+        e.preventDefault();
+        o.onFocusSearch();
+        return;
+      }
+
+      if (e.key === 'j' && o.onCardNav) {
+        e.preventDefault();
+        o.onCardNav(1);
+        return;
+      }
+
+      if (e.key === 'k' && o.onCardNav) {
+        e.preventDefault();
+        o.onCardNav(-1);
+        return;
+      }
+
+      if (e.key === 'Enter' && o.onCardOpen) {
+        if (isInteractiveTarget(target)) return;
+        o.onCardOpen();
+      }
+    };
+
+    document.addEventListener('keydown', handler);
+    return () => {
+      document.removeEventListener('keydown', handler);
+      clearG();
+    };
+  }, []);
+}

--- a/src/components-v2/Layout/index.tsx
+++ b/src/components-v2/Layout/index.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { getEvents } from '@/api/events.api';
+import type { EventItem } from '@/api/types';
+import { useAuth } from '@/contexts/AuthContext';
+import { useTheme } from '@/contexts/ThemeContext';
+import '@/styles-v2/components/ide-chrome.css';
+
+import { ActivityBar } from './ActivityBar';
+import { CommandPalette } from './CommandPalette';
+import { LayoutChromeProvider, useChrome } from './LayoutChromeContext';
+import { Minimap } from './Minimap';
+import { Sidebar } from './Sidebar';
+import { StatusBar } from './StatusBar';
+import { TabBar } from './TabBar';
+import { TitleBar } from './TitleBar';
+import { useCartCount } from './hooks/useCartCount';
+import { useGlobalShortcuts } from './hooks/useGlobalShortcuts';
+import type {
+  CategoryCount,
+  NavigateFn,
+  SessionUser,
+  TabDef,
+  UpcomingEventVM,
+} from './types';
+import { pathFromRoute, routeFromPath } from './utils';
+
+/**
+ * Source: docs/redesign/layout.plan.md §3-3.
+ *
+ * Single-prop API (children?). When omitted, renders <Outlet/> from the
+ * router so this works as both a route element and a manual wrapper (the
+ * dev preview passes children directly to bypass routing).
+ *
+ * The chrome state (palette open, search ref) lives in LayoutChromeProvider;
+ * LayoutInner reads it via useChrome and Layout itself only wires the two
+ * external callbacks (toggleTheme, logout) into the provider.
+ *
+ * Sidebar adapter is inlined here per §4-5 ("Layout/adapters.ts 또는 페이지
+ * 어댑터") — small enough to keep in-file and avoid an extra abstraction.
+ *
+ * §6-7 aria-hidden on .ide while open is intentionally omitted: aria-modal
+ * on the palette dialog already tells AT to ignore the background, and
+ * adding aria-hidden on an ancestor of the focused dialog breaks SR focus
+ * announcements (current ARIA APG guidance).
+ */
+export interface LayoutProps {
+  children?: ReactNode;
+}
+
+const CATEGORY_LIST = ['컨퍼런스', '밋업', '해커톤', '스터디', '세미나', '워크샵'];
+
+const TABS: TabDef[] = [
+  { key: 'home', label: '홈', icon: 'terminal' },
+  { key: 'events', label: '이벤트 목록', icon: 'folder' },
+  { key: 'detail', label: '이벤트 상세', icon: 'file' },
+  { key: 'cart', label: '장바구니', icon: 'cart' },
+  { key: 'mypage', label: '마이페이지', icon: 'user' },
+  { key: 'login', label: '로그인', icon: 'terminal' },
+];
+
+const SIDEBAR_FETCH_SIZE = 50;
+const UPCOMING_LIMIT = 4;
+
+function formatEventDate(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+function formatEventPrice(price: number): string {
+  return price === 0 ? '무료' : `${price.toLocaleString()}원`;
+}
+
+function LayoutInner({ children }: LayoutProps) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { isLoggedIn, user } = useAuth();
+  const { resolvedTheme } = useTheme();
+  const { count: cartCount } = useCartCount();
+  const chrome = useChrome();
+
+  const [events, setEvents] = useState<EventItem[]>([]);
+  const [totalEvents, setTotalEvents] = useState(0);
+
+  const currentRoute = routeFromPath(location.pathname);
+  const sessionUser: SessionUser | null = user
+    ? { nickname: user.nickname }
+    : null;
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await getEvents({ page: 0, size: SIDEBAR_FETCH_SIZE });
+        if (cancelled) return;
+        const data = res.data?.data;
+        setEvents(data?.content ?? []);
+        setTotalEvents(data?.totalElements ?? 0);
+      } catch {
+        // chrome must not block on a sidebar feed failure
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const categories = useMemo<CategoryCount[]>(
+    () =>
+      CATEGORY_LIST.map((name) => ({
+        name,
+        count: events.filter((e) => e.category === name).length,
+      })),
+    [events],
+  );
+
+  const upcoming = useMemo<UpcomingEventVM[]>(
+    () =>
+      events
+        .filter((e) => e.status === 'ON_SALE')
+        .slice(0, UPCOMING_LIMIT)
+        .map((e) => ({
+          eventId: e.eventId,
+          title: e.title,
+          dateText: formatEventDate(e.eventDateTime),
+          priceText: formatEventPrice(e.price),
+        })),
+    [events],
+  );
+
+  const onNavigate: NavigateFn = (key, params) => {
+    navigate(pathFromRoute(key, params));
+  };
+
+  useGlobalShortcuts({
+    isLoggedIn,
+    onOpenPalette: chrome.openPalette,
+    onClosePalette: chrome.closePalette,
+    onFocusSearch: chrome.focusSearch,
+    onNavigate,
+  });
+
+  return (
+    <>
+      <div className="ide" role="application" aria-label="DevTicket">
+        <a className="skip-link" href="#ide-editor">
+          본문으로 건너뛰기
+        </a>
+        <TitleBar
+          theme={resolvedTheme}
+          onToggleTheme={chrome.toggleTheme}
+          onOpenPalette={chrome.openPalette}
+        />
+        <ActivityBar
+          currentRoute={currentRoute}
+          cartCount={cartCount}
+          isLoggedIn={isLoggedIn}
+          onNavigate={onNavigate}
+          onOpenPalette={chrome.openPalette}
+        />
+        <Sidebar
+          currentRoute={currentRoute}
+          isLoggedIn={isLoggedIn}
+          user={sessionUser}
+          totalEventCount={totalEvents}
+          categories={categories}
+          upcoming={upcoming}
+          onNavigate={onNavigate}
+        />
+        <TabBar tabs={TABS} activeKey={currentRoute} onSelect={onNavigate} />
+        <main className="ide-editor" id="ide-editor" tabIndex={-1}>
+          {children ?? <Outlet />}
+        </main>
+        <Minimap route={currentRoute} />
+        <StatusBar
+          currentRoute={currentRoute}
+          isLoggedIn={isLoggedIn}
+          user={sessionUser}
+          onOpenPalette={chrome.openPalette}
+        />
+      </div>
+      <CommandPalette open={chrome.paletteOpen} onClose={chrome.closePalette} />
+    </>
+  );
+}
+
+export default function Layout({ children }: LayoutProps) {
+  const { toggleTheme } = useTheme();
+  const { logout } = useAuth();
+  return (
+    <LayoutChromeProvider onToggleTheme={toggleTheme} onLogout={logout}>
+      <LayoutInner>{children}</LayoutInner>
+    </LayoutChromeProvider>
+  );
+}

--- a/src/components-v2/Layout/types.ts
+++ b/src/components-v2/Layout/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared types for the v2 Layout chrome.
+ * Source: docs/redesign/layout.plan.md §3-1.
+ */
+
+export type RouteKey =
+  | 'home'
+  | 'events'
+  | 'detail'
+  | 'cart'
+  | 'mypage'
+  | 'login';
+
+export type ActivityKey = RouteKey | 'search' | 'settings';
+
+export interface ActivityItem {
+  key: ActivityKey;
+  /** Icon component name (e.g. 'terminal', 'folder', 'cart'). */
+  icon: string;
+  /** Tooltip + accessibility label. */
+  label: string;
+  /** Shown only when greater than 0. */
+  badge?: number;
+  /** When 'palette', clicking opens the command palette instead of navigating. */
+  action?: 'palette';
+}
+
+export interface TabDef {
+  key: RouteKey;
+  label: string;
+  icon: string;
+}
+
+export interface PaletteItem {
+  key: string;
+  label: string;
+  hint: string;
+  icon: string;
+  /** Display-only ('g h' etc); the actual binding lives in useGlobalShortcuts. */
+  shortcut?: string;
+  action: () => void;
+}
+
+export interface UpcomingEventVM {
+  eventId: string;
+  title: string;
+  /** Pre-formatted, e.g. "2026-05-12". */
+  dateText: string;
+  /** Pre-formatted, e.g. "무료" or "49,000원". */
+  priceText: string;
+}
+
+export interface CategoryCount {
+  name: string;
+  count: number;
+}
+
+export interface SessionUser {
+  nickname: string;
+}
+
+export type ThemeMode = 'light' | 'dark';
+
+export type NavParams = { id?: string; category?: string };
+export type NavigateFn = (key: RouteKey, params?: NavParams) => void;

--- a/src/components-v2/Layout/utils.ts
+++ b/src/components-v2/Layout/utils.ts
@@ -1,0 +1,49 @@
+/**
+ * URL ↔ RouteKey conversion for the v2 Layout chrome.
+ * Source: docs/redesign/layout.plan.md §4-1.
+ *
+ * `/` maps to 'home' per the Landing-introduced policy. Until the cutover PR
+ * wires Landing to `/`, this PR's dev preview drives currentRoute directly via
+ * mock state, so the mismatch with the production `/` (currently EventList) is
+ * not exercised at runtime.
+ */
+
+import type { NavParams, RouteKey } from './types';
+
+export function routeFromPath(pathname: string): RouteKey {
+  if (pathname === '/') return 'home';
+  if (pathname === '/events' || pathname.startsWith('/events/')) {
+    return pathname === '/events' ? 'events' : 'detail';
+  }
+  if (pathname === '/cart' || pathname.startsWith('/cart/')) return 'cart';
+  if (pathname === '/mypage' || pathname.startsWith('/mypage/')) return 'mypage';
+  if (pathname === '/login') return 'login';
+  return 'home';
+}
+
+export function pathFromRoute(key: RouteKey, params?: NavParams): string {
+  switch (key) {
+    case 'home':
+      return '/';
+    case 'events': {
+      const category = params?.category;
+      if (category) {
+        return `/events?category=${encodeURIComponent(category)}`;
+      }
+      return '/events';
+    }
+    case 'detail': {
+      const id = params?.id;
+      if (!id) {
+        throw new Error("pathFromRoute('detail') requires params.id");
+      }
+      return `/events/${encodeURIComponent(id)}`;
+    }
+    case 'cart':
+      return '/cart';
+    case 'mypage':
+      return '/mypage';
+    case 'login':
+      return '/login';
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Suspense, lazy } from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
@@ -10,13 +10,29 @@ import './styles-v2/tokens.css'
 import './styles-v2/global.css'
 import './styles/globals.css'
 
+// Dev-only v2 Layout preview entry. The DEV guard lets Vite/Rollup
+// tree-shake the lazy chunk out of production builds; the path guard keeps
+// the rest of the app untouched per layout.plan §7-3 (no App.tsx edits).
+// Removed in the first v2 page PR.
+const LayoutPreview = lazy(() => import('./components-v2/Layout/__preview'))
+const useLayoutPreview =
+  import.meta.env.DEV &&
+  typeof window !== 'undefined' &&
+  window.location.pathname === '/__layout-preview'
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <ErrorBoundary>
       <ThemeProvider>
         <BrowserRouter>
           <AuthProvider>
             <ToastProvider>
-              <App />
+              {useLayoutPreview ? (
+                <Suspense fallback={null}>
+                  <LayoutPreview />
+                </Suspense>
+              ) : (
+                <App />
+              )}
             </ToastProvider>
           </AuthProvider>
         </BrowserRouter>

--- a/src/styles-v2/components/ide-chrome.css
+++ b/src/styles-v2/components/ide-chrome.css
@@ -1,0 +1,472 @@
+/* ide-chrome.css
+ * Layout chrome (IDE skeleton) only. Token consumer — depends on tokens.css.
+ * Page-body classes (terminal, json-card, btn, chip, form, syntax) live elsewhere.
+ * Source: docs/redesign/prototype/ide-theme.css L98-805 (chrome subset).
+ */
+
+/* ─── Grid container ──────────────────────────────────── */
+.ide {
+  --ide-titlebar-h: 36px;
+  --ide-tabs-h: 34px;
+  --ide-status-h: 24px;
+  --ide-activity-w: 48px;
+  --ide-sidebar-w: 220px;
+  --ide-minimap-w: 60px;
+
+  display: grid;
+  grid-template-rows:
+    var(--ide-titlebar-h)
+    var(--ide-tabs-h)
+    1fr
+    var(--ide-status-h);
+  grid-template-columns:
+    var(--ide-activity-w)
+    var(--ide-sidebar-w)
+    1fr
+    var(--ide-minimap-w);
+  grid-template-areas:
+    "title  title   title   title"
+    "act    tabs    tabs    tabs"
+    "act    side    editor  mini"
+    "status status  status  status";
+  height: 100vh;
+  background: var(--editor-bg);
+  color: var(--text);
+}
+
+.ide-title    { grid-area: title; }
+.ide-activity { grid-area: act; }
+.ide-sidebar  { grid-area: side; }
+.ide-tabs     { grid-area: tabs; }
+.ide-editor   { grid-area: editor; position: relative; overflow: auto; }
+.ide-minimap  { grid-area: mini; }
+.ide-status   { grid-area: status; }
+
+/* ─── Title bar ───────────────────────────────────────── */
+.ide-title {
+  background: var(--chrome);
+  border-bottom: 1px solid var(--chrome-2);
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--text-3);
+  -webkit-app-region: drag;
+  user-select: none;
+}
+.traffic { display: flex; gap: 8px; }
+.traffic span {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: block;
+}
+.traffic .tc-red    { background: #FF5F57; }
+.traffic .tc-yellow { background: #FEBC2E; }
+.traffic .tc-green  { background: #28C840; }
+
+.title-text {
+  flex: 1;
+  text-align: center;
+  font-family: var(--font);
+  font-size: 12px;
+  font-weight: inherit;
+  margin: 0;
+  color: var(--text-3);
+  letter-spacing: 0.01em;
+}
+
+.title-cmd {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 4px;
+  background: var(--editor-bg);
+  border: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--text-3);
+  cursor: pointer;
+  min-width: 260px;
+  justify-content: space-between;
+  -webkit-app-region: no-drag;
+}
+.title-cmd:hover { background: var(--surface); color: var(--text-2); }
+.title-cmd kbd {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 1px 5px;
+  background: var(--chrome-2);
+  border-radius: 3px;
+  color: var(--text-3);
+}
+
+/* ─── Activity bar (left icon rail) ───────────────────── */
+.ide-activity {
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 6px 0;
+  gap: 2px;
+}
+.act-btn {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  border-left: 2px solid transparent;
+  color: var(--text-4);
+  cursor: pointer;
+  transition: color 0.12s;
+  position: relative;
+}
+.act-btn:hover { color: var(--text-2); }
+.act-btn.active {
+  color: var(--text);
+  border-left-color: var(--brand);
+}
+.act-btn svg { width: 20px; height: 20px; }
+.act-badge {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--brand);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+}
+.act-spacer { flex: 1; }
+
+/* ─── Sidebar (explorer) ──────────────────────────────── */
+.ide-sidebar {
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+  font-size: 13px;
+}
+.side-header {
+  padding: 8px 14px 6px;
+  font-family: var(--font);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-3);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0;
+}
+.side-group { padding: 0 0 8px; margin: 0; list-style: none; }
+.side-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 12px 3px 18px;
+  background: transparent;
+  border: 0;
+  border-left: 2px solid transparent;
+  color: var(--text-2);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  text-align: left;
+  width: 100%;
+  transition: background 0.08s;
+}
+.side-item:hover { background: var(--surface-2); }
+.side-item.active {
+  background: var(--editor-line);
+  color: var(--text);
+  border-left-color: var(--brand);
+}
+.side-item .tri {
+  width: 10px;
+  color: var(--text-4);
+  font-size: 10px;
+}
+.side-item .fi {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+.side-count {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--text-4);
+  background: var(--surface-2);
+  padding: 0 5px;
+  border-radius: 8px;
+  font-weight: 600;
+}
+.side-nested { padding-left: 28px; }
+
+/* ─── Tab bar ─────────────────────────────────────────── */
+.ide-tabs {
+  background: var(--chrome);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+}
+.ide-tabs::-webkit-scrollbar { display: none; }
+
+.tab {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  height: 100%;
+  background: transparent;
+  border: 0;
+  border-right: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--text-3);
+  cursor: pointer;
+  position: relative;
+  white-space: nowrap;
+  transition: background 0.1s, color 0.1s;
+  flex-shrink: 0;
+}
+.tab:hover { background: var(--chrome-2); color: var(--text-2); }
+.tab.active {
+  background: var(--editor-bg);
+  color: var(--text);
+}
+.tab.active::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--brand);
+}
+.tab .fi { width: 14px; height: 14px; flex-shrink: 0; }
+.tab .close {
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  color: var(--text-4);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+}
+.tab:hover .close { color: var(--text-2); }
+.tab .close:hover { background: var(--surface-2); }
+.tab .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-3);
+}
+.tab .dot.modified { background: var(--text); }
+
+/* ─── Minimap ─────────────────────────────────────────── */
+.ide-minimap {
+  background: var(--minimap-bg);
+  border-left: 1px solid var(--border);
+  overflow: hidden;
+  padding: 6px 6px 0;
+  position: relative;
+}
+.mini-line {
+  height: 3px;
+  margin-bottom: 2px;
+  border-radius: 1px;
+  background: var(--surface-3);
+  opacity: 0.7;
+}
+.mini-line.kw  { background: var(--syn-keyword); opacity: 0.5; }
+.mini-line.fn  { background: var(--syn-fn);      opacity: 0.5; }
+.mini-line.str { background: var(--syn-string);  opacity: 0.5; }
+.mini-line.cmt { background: var(--syn-comment); opacity: 0.35; }
+.mini-window {
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  height: 120px;
+  background: rgba(79, 70, 229, 0.12);
+  border-radius: 2px;
+  pointer-events: none;
+  top: 40px;
+  transition: top 0.2s;
+}
+
+/* ─── Status bar ──────────────────────────────────────── */
+.ide-status {
+  background: var(--status-bg);
+  color: var(--status-text);
+  display: flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  padding: 0 10px;
+  gap: 0;
+}
+.status-item {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 10px;
+  height: 100%;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  transition: background 0.1s;
+  cursor: default;
+}
+.status-item.clickable { cursor: pointer; }
+.status-item.clickable:hover { background: rgba(255, 255, 255, 0.1); }
+.status-item svg { width: 12px; height: 12px; }
+.status-spacer { flex: 1; }
+.status-item.term-ok { color: var(--term-green); }
+
+/* ─── Command palette (⌘K) ────────────────────────────── */
+.palette-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(4px);
+  z-index: 1000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 120px;
+}
+.palette {
+  width: 560px;
+  max-width: 92vw;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+  font-family: var(--font-mono);
+}
+.palette-input {
+  width: 100%;
+  padding: 14px 16px;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 14px;
+  font-family: inherit;
+  color: var(--text);
+  outline: none;
+}
+.palette-input::placeholder { color: var(--text-4); }
+.palette-list {
+  max-height: 340px;
+  overflow-y: auto;
+  padding: 6px;
+  margin: 0;
+  list-style: none;
+}
+.palette-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12.5px;
+  color: var(--text-2);
+}
+.palette-item:hover,
+.palette-item.sel {
+  background: var(--brand-light);
+  color: var(--brand);
+}
+.palette-item .fi { width: 14px; height: 14px; flex-shrink: 0; }
+.palette-item .shortcut {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--text-4);
+}
+.palette-hint {
+  padding: 8px 14px;
+  font-size: 10.5px;
+  color: var(--text-4);
+  background: var(--surface-2);
+  display: flex;
+  gap: 16px;
+}
+.palette-hint kbd {
+  padding: 1px 5px;
+  background: var(--editor-bg);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  margin-right: 4px;
+}
+
+/* ─── Scrollbars (sidebar + editor) ───────────────────── */
+.ide-editor::-webkit-scrollbar,
+.ide-sidebar::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+.ide-editor::-webkit-scrollbar-track,
+.ide-sidebar::-webkit-scrollbar-track {
+  background: transparent;
+}
+.ide-editor::-webkit-scrollbar-thumb,
+.ide-sidebar::-webkit-scrollbar-thumb {
+  background: var(--surface-3);
+  border-radius: 5px;
+}
+.ide-editor::-webkit-scrollbar-thumb:hover,
+.ide-sidebar::-webkit-scrollbar-thumb:hover {
+  background: var(--text-4);
+}
+
+/* ─── Dark overrides ──────────────────────────────────── */
+/* brand-light 위 텍스트 가독성 보정. tokens.css 가 처리하지 못하는 1건. */
+[data-theme="dark"] .palette-item:hover,
+[data-theme="dark"] .palette-item.sel {
+  color: #C7D2FE;
+}
+
+/* ─── Responsive ──────────────────────────────────────── */
+/* Tablet: hide minimap (4 cols → 3 cols + 0). */
+@media (max-width: 1279px) {
+  .ide {
+    grid-template-columns:
+      var(--ide-activity-w)
+      var(--ide-sidebar-w)
+      1fr
+      0;
+  }
+  .ide-minimap { display: none; }
+}
+
+/* Mobile: hide sidebar + title search box. */
+@media (max-width: 959px) {
+  .ide {
+    grid-template-columns: var(--ide-activity-w) 0 1fr 0;
+  }
+  .ide-sidebar { display: none; }
+  .title-cmd   { display: none; }
+}

--- a/src/styles-v2/components/ide-chrome.css
+++ b/src/styles-v2/components/ide-chrome.css
@@ -464,7 +464,8 @@ button.side-header {
   border: 0;
   border-bottom: 1px solid var(--border);
   font-size: 14px;
-  font-family: inherit;
+  /* Sans for the search query — the rest of the palette is mono. */
+  font-family: var(--font);
   color: var(--text);
   outline: none;
 }
@@ -496,6 +497,27 @@ button.side-header {
   margin-left: auto;
   font-size: 10px;
   color: var(--text-4);
+}
+/* Two-line column inside a palette item: label on top, hint below.  */
+.palette-item-body {
+  flex: 1;
+  min-width: 0;
+}
+.palette-item-label {
+  font-family: var(--font);
+  color: var(--text);
+}
+.palette-item-hint {
+  font-family: var(--font);
+  font-size: 11px;
+  color: var(--text-4);
+}
+/* Empty-results placeholder inside the list. */
+.palette-empty {
+  padding: 18px 14px;
+  color: var(--text-4);
+  font-size: 13px;
+  font-family: var(--font);
 }
 .palette-hint {
   padding: 8px 14px;

--- a/src/styles-v2/components/ide-chrome.css
+++ b/src/styles-v2/components/ide-chrome.css
@@ -226,6 +226,21 @@
  * border. The first header (메뉴) stays clean. */
 .side-group + .side-header { border-top: 1px solid var(--border); }
 
+/* Button-element variant of .side-header — reset native button chrome and let
+ * the existing .side-header flex/typography rules drive the layout. Used by
+ * SidebarMenu and SidebarUpcoming for the aria-expanded toggle. */
+button.side-header {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+}
+
 /* Smaller, dimmer side-item variant (session row). */
 .side-item.side-item--mini {
   font-size: 11.5px;

--- a/src/styles-v2/components/ide-chrome.css
+++ b/src/styles-v2/components/ide-chrome.css
@@ -102,6 +102,13 @@
   color: var(--text-3);
 }
 
+/* Theme toggle reuses .act-btn but must fit inside the 36px title bar. */
+.ide-title .act-btn {
+  width: 30px;
+  height: 26px;
+  border-left: 0;
+}
+
 /* ─── Activity bar (left icon rail) ───────────────────── */
 .ide-activity {
   background: var(--sidebar-bg);

--- a/src/styles-v2/components/ide-chrome.css
+++ b/src/styles-v2/components/ide-chrome.css
@@ -527,6 +527,8 @@ button.side-header {
   display: flex;
   gap: 16px;
 }
+/* Trailing "N개 결과" pushed to the right edge of the hint footer. */
+.palette-hint-count { margin-left: auto; }
 .palette-hint kbd {
   padding: 1px 5px;
   background: var(--editor-bg);

--- a/src/styles-v2/components/ide-chrome.css
+++ b/src/styles-v2/components/ide-chrome.css
@@ -350,6 +350,18 @@
 .status-item svg { width: 12px; height: 12px; }
 .status-spacer { flex: 1; }
 .status-item.term-ok { color: var(--term-green); }
+/* Lets the login indicator scope a green dot child without re-coloring siblings. */
+.ide-status .term-ok { color: var(--term-green); }
+/* ⌘K kbd inside the indigo status bar — its own contrast envelope, not the
+ * lighter palette/title-cmd kbd treatment. */
+.ide-status kbd {
+  background: rgba(255, 255, 255, 0.15);
+  padding: 0 4px;
+  border-radius: 2px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: inherit;
+}
 
 /* ─── Command palette (⌘K) ────────────────────────────── */
 .palette-backdrop {

--- a/src/styles-v2/components/ide-chrome.css
+++ b/src/styles-v2/components/ide-chrome.css
@@ -222,6 +222,63 @@
 }
 .side-nested { padding-left: 28px; }
 
+/* Section divider — any side-header that follows another section gets a top
+ * border. The first header (메뉴) stays clean. */
+.side-group + .side-header { border-top: 1px solid var(--border); }
+
+/* Smaller, dimmer side-item variant (session row). */
+.side-item.side-item--mini {
+  font-size: 11.5px;
+  color: var(--text-3);
+}
+
+/* Two-row "card" variant for upcoming-events rows. */
+.side-item.side-item--card {
+  display: block;
+  padding: 7px 12px;
+}
+.side-card-title {
+  font-family: var(--font);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-2);
+  line-height: 1.4;
+  margin-bottom: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.side-card-meta {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-4);
+}
+
+/* Online indicator dot inside a side-item (session row). */
+.side-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--term-green);
+  flex-shrink: 0;
+}
+
+/* Trailing meta tag inside a side-item (e.g. "온라인"). */
+.side-meta {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-4);
+}
+
+/* '#' prefix glyph for category rows. */
+.side-prefix {
+  color: var(--text-4);
+  font-size: 11px;
+  width: 10px;
+  text-align: center;
+}
+
 /* ─── Tab bar ─────────────────────────────────────────── */
 .ide-tabs {
   background: var(--chrome);

--- a/src/styles-v2/global.css
+++ b/src/styles-v2/global.css
@@ -74,6 +74,29 @@ body {
   white-space: nowrap;
 }
 
+/* "Skip to main content" affordance: visually hidden until focused. Used by
+ * Layout's first child to let keyboard users bypass the chrome. */
+.skip-link {
+  position: absolute;
+  left: 8px;
+  top: 8px;
+  z-index: 2000;
+  padding: 6px 10px;
+  background: var(--brand);
+  color: #fff;
+  font-family: var(--font);
+  font-size: 12px;
+  border-radius: 4px;
+  clip-path: inset(50%);
+  clip: rect(0, 0, 0, 0);
+}
+.skip-link:focus {
+  clip-path: none;
+  clip: auto;
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
 /* ── Keyframes (shared across pages) ─────────────────── */
 @keyframes spin {
   to { transform: rotate(360deg); }


### PR DESCRIPTION
## Summary

Introduces the v2 Layout chrome—a complete IDE-inspired UI skeleton featuring a title bar, activity rail, sidebar, tab bar, status bar, and minimap. This is the foundational layout component for the redesigned interface, replacing the current navigation structure with a VS Code-like visual paradigm.

## Key Changes

- **IDE Chrome Stylesheet** (`ide-chrome.css`): 587 lines of layout-only CSS implementing a 4×4 CSS Grid layout with semantic chrome sections (title, activity, sidebar, tabs, editor, minimap, status). Includes component-specific styling for buttons, tabs, sidebar items, and the command palette modal.

- **Icon Component** (`Icon/index.tsx`): Typed React icon library with 24 SVG icons (folder, file, search, git, user, cart, etc.) that inherit parent text color via `stroke="currentColor"` for seamless integration with chrome elements.

- **Layout Container** (`Layout/index.tsx`): Main layout component wrapping the entire app with:
  - `LayoutChromeProvider` managing palette state, theme toggle, and logout
  - Real-time event fetching for sidebar population
  - Route-aware chrome state (active tab, sidebar menu items)
  - Global keyboard shortcut binding

- **Chrome Subcomponents**:
  - `TitleBar`: macOS-style title bar with traffic lights, app name, command palette trigger, and theme toggle
  - `ActivityBar`: Left icon rail with 5 main navigation items + settings button; cart badge support
  - `Sidebar`: Collapsible menu (categories + event count), upcoming events section, and session info
  - `TabBar`: Open tabs with close buttons and active state indicator
  - `StatusBar`: Footer showing git status, route label, language, user session, and ⌘K hint
  - `Minimap`: Decorative right-rail with syntax-colored line patterns per route

- **Command Palette** (`CommandPalette/`): Modal search interface with:
  - Static commands (6 routes, theme toggle, login/logout)
  - Debounced event search integration
  - Focus trap and keyboard navigation (arrow keys, Enter, Escape)
  - Combobox a11y pattern with `aria-activedescendant`

- **Global Shortcuts** (`useGlobalShortcuts.ts`): Keyboard handler for:
  - Always-on: ⌘K (open palette), Escape (close palette)
  - Outside-input: `/` (focus search), `g h/e/c/m` (navigate), `j/k` (card nav), Enter (card open)
  - Two-key `g` sequence with 1s timeout

- **Utilities**:
  - `utils.ts`: URL ↔ RouteKey conversion (maps `/` → 'home', `/events/*` → 'events'/'detail', etc.)
  - `useCartCount.ts`: Cart badge feed (fetches on login, returns 0 while logged out)
  - `types.ts`: Shared TypeScript interfaces for routes, activity items, palette items, etc.

- **Dev Preview** (`__preview.tsx`): Throwaway harness for visual verification of all 6 routes with mock content panes and route-switching controls.

- **Global CSS Updates** (`global.css`): Added `.skip-link` affordance for keyboard users to bypass chrome and jump to main content.

- **Entry Point** (`main.tsx`): Lazy-loaded dev-only layout preview route at `/__layout-preview` for development verification.

## Notable Implementation Details

- **Auth Gating** (§4-2): Cart/mypage clicks while logged-out route to login; cart badge only shows for logged-in users with items
- **Active State Rules** (§4-1): 'events' item stays active across events and detail routes (single nav slot for the flow)
- **Focus Management**: Command palette captures and restores focus on open/close; focus trap prevents Tab escape from modal
- **Accessibility**: Semantic HTML (role="tablist", role="option", aria-expanded, aria-current), skip link, decorative icons marked aria-hidden
- **Styling Strategy**: CSS custom properties for theming

https://claude.ai/code/session_01YEbJLQwn6PxdnezRH3NwkN