### PR TITLE
Add v2 Login page with form validation and OAuth support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Layout from './components/Layout'
 import SellerLayout from './components/SellerLayout'
 import AdminLayout from './components/AdminLayout'
 import Loading from './components/Loading'
+import { VersionedRoute } from './router-v2'
 
 // 즉시 로드 (비로그인 첫 화면)
 import EventList         from './pages/EventList'
@@ -16,6 +17,9 @@ import NotFound          from './pages/NotFound'
 // lazy – 소셜 로그인
 const OAuthCallback       = lazy(() => import('./pages/OAuthCallback'))
 const SocialProfileSetup  = lazy(() => import('./pages/SocialProfileSetup'))
+
+// lazy – v2 재구축 (router-toggle.plan, Login.plan §6)
+const LoginV2             = lazy(() => import('./pages-v2/Login'))
 
 // lazy – 로그인 후 접근
 const SignupComplete      = lazy(() => import('./pages/SignupComplete'))
@@ -72,7 +76,7 @@ export default function App() {
     <Suspense fallback={<Loading fullscreen />}>
       <Routes>
         {/* 공개 */}
-        <Route path="/login"               element={<Login />} />
+        <Route path="/login"               element={<VersionedRoute v1={<Login />} v2={<LoginV2 />} />} />
         <Route path="/signup"              element={<Signup />} />
         <Route path="/signup/complete"     element={<SignupComplete />} />
 

--- a/src/pages-v2/Login/Login.tsx
+++ b/src/pages-v2/Login/Login.tsx
@@ -1,0 +1,189 @@
+import { Link } from 'react-router-dom';
+import type { FormEvent } from 'react';
+import { Card, Button, Input } from '@/components-v2';
+import type { LoginFieldErrors, LoginFormState } from './hooks';
+
+export type LoginViewProps = {
+  form: LoginFormState;
+  errors: LoginFieldErrors;
+  loading: boolean;
+  onChangeEmail: (v: string) => void;
+  onChangePassword: (v: string) => void;
+  onSubmit: (e: FormEvent) => void;
+  signupHref: string;
+  googleOAuthUrl: string;
+};
+
+export default function LoginView({
+  form,
+  errors,
+  loading,
+  onChangeEmail,
+  onChangePassword,
+  onSubmit,
+  signupHref,
+  googleOAuthUrl,
+}: LoginViewProps) {
+  return (
+    <div className="login-page">
+      <div className="login-shell">
+        <BrandHeader />
+        <PageHeading />
+        <Card padding={28}>
+          <LoginForm
+            email={form.email}
+            password={form.password}
+            errors={errors}
+            loading={loading}
+            onChangeEmail={onChangeEmail}
+            onChangePassword={onChangePassword}
+            onSubmit={onSubmit}
+          />
+          <SocialLoginBlock googleOAuthUrl={googleOAuthUrl} disabled={loading} />
+          <SignupCallout href={signupHref} disabled={loading} />
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function BrandHeader() {
+  return (
+    <div className="login-brand">
+      <span className="login-brand-mark" aria-hidden="true">DT</span>
+      <span className="login-brand-word">DevTicket</span>
+    </div>
+  );
+}
+
+function PageHeading() {
+  return (
+    <div className="login-heading">
+      <h1 className="login-title">로그인</h1>
+      <p className="login-subcopy">계정에 로그인하여 티켓을 관리하세요</p>
+    </div>
+  );
+}
+
+type LoginFormBlockProps = {
+  email: string;
+  password: string;
+  errors: LoginFieldErrors;
+  loading: boolean;
+  onChangeEmail: (v: string) => void;
+  onChangePassword: (v: string) => void;
+  onSubmit: (e: FormEvent) => void;
+};
+
+function LoginForm({
+  email,
+  password,
+  errors,
+  loading,
+  onChangeEmail,
+  onChangePassword,
+  onSubmit,
+}: LoginFormBlockProps) {
+  return (
+    <form className="login-form" onSubmit={onSubmit} noValidate>
+      {errors.form && (
+        <div className="login-form-error" role="alert">
+          <span aria-hidden="true">×</span> {errors.form}
+        </div>
+      )}
+      <Input
+        label="이메일"
+        type="email"
+        autoComplete="email"
+        placeholder="you@example.com"
+        value={email}
+        onChange={e => onChangeEmail(e.target.value)}
+        error={errors.email}
+        disabled={loading}
+      />
+      <Input
+        label="비밀번호"
+        type="password"
+        autoComplete="current-password"
+        placeholder="비밀번호 입력"
+        value={password}
+        onChange={e => onChangePassword(e.target.value)}
+        error={errors.password}
+        disabled={loading}
+      />
+      <Button
+        type="submit"
+        variant="primary"
+        size="lg"
+        full
+        loading={loading}
+        aria-busy={loading}
+      >
+        {loading ? '로그인 중...' : '로그인'}
+      </Button>
+    </form>
+  );
+}
+
+function SocialLoginBlock({
+  googleOAuthUrl,
+  disabled,
+}: {
+  googleOAuthUrl: string;
+  disabled: boolean;
+}) {
+  return (
+    <div className="login-social">
+      <div className="login-divider" role="separator">
+        <span className="login-divider-label">또는</span>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="lg"
+        full
+        disabled={disabled}
+        iconStart={<GoogleIcon />}
+        onClick={() => {
+          window.location.href = googleOAuthUrl;
+        }}
+      >
+        Google로 로그인
+      </Button>
+    </div>
+  );
+}
+
+function SignupCallout({ href, disabled }: { href: string; disabled: boolean }) {
+  return (
+    <div className="login-signup-callout">
+      아직 계정이 없으신가요?{' '}
+      <Link
+        to={href}
+        className="login-signup-link"
+        aria-disabled={disabled || undefined}
+        tabIndex={disabled ? -1 : undefined}
+      >
+        회원가입
+      </Link>
+    </div>
+  );
+}
+
+function GoogleIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path d="M43.611 20.083H42V20H24v8h11.303C33.654 32.657 29.332 36 24 36c-6.627 0-12-5.373-12-12s5.373-12 12-12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C34.046 6.053 29.268 4 24 4 12.955 4 4 12.955 4 24s8.955 20 20 20 20-8.955 20-20c0-1.341-.138-2.65-.389-3.917z" fill="#FFC107" />
+      <path d="M6.306 14.691l6.571 4.819C14.655 15.108 19 12 24 12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C34.046 6.053 29.268 4 24 4 16.318 4 9.656 8.337 6.306 14.691z" fill="#FF3D00" />
+      <path d="M24 44c5.166 0 9.86-1.977 13.409-5.192l-6.19-5.238C29.211 35.091 26.715 36 24 36c-5.316 0-9.828-3.417-11.402-8.162l-6.515 5.021C9.505 39.556 16.227 44 24 44z" fill="#4CAF50" />
+      <path d="M43.611 20.083H42V20H24v8h11.303c-.792 2.237-2.231 4.166-4.087 5.571.001-.001.002-.001.003-.002l6.19 5.238C36.971 39.205 44 34 44 24c0-1.341-.138-2.65-.389-3.917z" fill="#1976D2" />
+    </svg>
+  );
+}

--- a/src/pages-v2/Login/hooks.ts
+++ b/src/pages-v2/Login/hooks.ts
@@ -1,5 +1,14 @@
 import { useState, type FormEvent } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import axios from 'axios';
+import { login as loginApi } from '@/api/auth.api';
+import { unwrapApiData } from '@/api/client';
+import { useAuth } from '@/contexts/AuthContext';
+
+const GOOGLE_OAUTH_URL =
+  import.meta.env.VITE_GOOGLE_OAUTH_URL ?? 'http://localhost:8080/oauth2/authorization/google';
+
+const SIGNUP_HREF = '/signup';
 
 export type LoginFormState = {
   email: string;
@@ -86,6 +95,10 @@ function mapValidationErrors(data: unknown): LoginFieldErrors {
 }
 
 export function useLoginForm() {
+  const auth = useAuth();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
   const [form, setForm] = useState<LoginFormState>({ email: '', password: '' });
   const [errors, setErrors] = useState<LoginFieldErrors>({});
   const [loading, setLoading] = useState(false);
@@ -100,8 +113,7 @@ export function useLoginForm() {
     setErrors(e => ({ ...e, password: undefined, form: undefined }));
   };
 
-  // Step 1 스텁: 클라 검증까지만. axios 호출 + 토큰 저장 + 리다이렉트는 Step 2에서 연결.
-  const onSubmit = (e: FormEvent) => {
+  const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
     const fieldErrors = validate(form);
     if (Object.keys(fieldErrors).length > 0) {
@@ -109,10 +121,18 @@ export function useLoginForm() {
       return;
     }
     setErrors({});
+    setLoading(true);
+    try {
+      const res = await loginApi(form);
+      const { accessToken, refreshToken } = unwrapApiData(res.data);
+      await auth.login(accessToken, refreshToken);
+      navigate(safeReturnTo(searchParams.get('returnTo')), { replace: true });
+    } catch (err) {
+      setErrors(mapLoginError(err));
+    } finally {
+      setLoading(false);
+    }
   };
-
-  // setLoading은 Step 2(API 통합)에서 사용. tsconfig noUnusedLocals=false라 미참조 허용.
-  void setLoading;
 
   return {
     form,
@@ -121,5 +141,7 @@ export function useLoginForm() {
     onChangeEmail,
     onChangePassword,
     onSubmit,
+    signupHref: SIGNUP_HREF,
+    googleOAuthUrl: GOOGLE_OAUTH_URL,
   };
 }

--- a/src/pages-v2/Login/hooks.ts
+++ b/src/pages-v2/Login/hooks.ts
@@ -1,0 +1,125 @@
+import { useState, type FormEvent } from 'react';
+import axios from 'axios';
+
+export type LoginFormState = {
+  email: string;
+  password: string;
+};
+
+export type LoginFieldErrors = {
+  email?: string;
+  password?: string;
+  form?: string;
+};
+
+const EMAIL_REGEX = /\S+@\S+\.\S+/;
+
+export function validate(form: LoginFormState): LoginFieldErrors {
+  const errors: LoginFieldErrors = {};
+  if (!form.email) {
+    errors.email = '이메일을 입력하세요';
+  } else if (!EMAIL_REGEX.test(form.email)) {
+    errors.email = '올바른 이메일 형식이 아닙니다';
+  }
+  if (!form.password) {
+    errors.password = '비밀번호를 입력하세요';
+  }
+  return errors;
+}
+
+// §5.4 화이트리스트: 외부 도메인/프로토콜 우회 차단. `/` 시작 + `//` 비시작만 통과.
+export function safeReturnTo(raw: string | null | undefined): string {
+  if (!raw) return '/';
+  if (!raw.startsWith('/')) return '/';
+  if (raw.startsWith('//')) return '/';
+  return raw;
+}
+
+// §3 에러 매핑 표 + D-2: 422 응답이 `errors: { email?, password? }` 또는
+// `errors: [{ field, message }]` 두 형태 모두 들어올 수 있어 양쪽 수용.
+export function mapLoginError(err: unknown): LoginFieldErrors {
+  if (axios.isAxiosError(err)) {
+    if (!err.response) {
+      return { form: '네트워크 연결을 확인해주세요. 연결 후 다시 시도해주세요.' };
+    }
+    const status = err.response.status;
+    if (status === 400) {
+      return { form: '요청 형식이 올바르지 않습니다.' };
+    }
+    if (status === 401) {
+      return { form: '이메일 또는 비밀번호가 일치하지 않습니다.' };
+    }
+    if (status === 403) {
+      return { form: '계정이 잠겼거나 비활성화되었습니다. 관리자에게 문의하세요.' };
+    }
+    if (status === 422) {
+      return mapValidationErrors(err.response.data);
+    }
+    if (status === 429) {
+      return { form: '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.' };
+    }
+    if (status >= 500 && status < 600) {
+      return { form: '일시적인 오류입니다. 잠시 후 다시 시도해주세요.' };
+    }
+  }
+  return { form: '로그인에 실패했습니다. 잠시 후 다시 시도해주세요.' };
+}
+
+function mapValidationErrors(data: unknown): LoginFieldErrors {
+  const errors = (data as { errors?: unknown } | null)?.errors;
+  const result: LoginFieldErrors = {};
+
+  if (Array.isArray(errors)) {
+    for (const item of errors as Array<{ field?: string; message?: string }>) {
+      if (!item || typeof item.message !== 'string') continue;
+      if (item.field === 'email') result.email = item.message;
+      else if (item.field === 'password') result.password = item.message;
+    }
+  } else if (errors && typeof errors === 'object') {
+    const obj = errors as { email?: unknown; password?: unknown };
+    if (typeof obj.email === 'string') result.email = obj.email;
+    if (typeof obj.password === 'string') result.password = obj.password;
+  }
+
+  if (result.email || result.password) return result;
+  return { form: '입력값을 확인해주세요.' };
+}
+
+export function useLoginForm() {
+  const [form, setForm] = useState<LoginFormState>({ email: '', password: '' });
+  const [errors, setErrors] = useState<LoginFieldErrors>({});
+  const [loading, setLoading] = useState(false);
+
+  const onChangeEmail = (v: string) => {
+    setForm(f => ({ ...f, email: v }));
+    setErrors(e => ({ ...e, email: undefined, form: undefined }));
+  };
+
+  const onChangePassword = (v: string) => {
+    setForm(f => ({ ...f, password: v }));
+    setErrors(e => ({ ...e, password: undefined, form: undefined }));
+  };
+
+  // Step 1 스텁: 클라 검증까지만. axios 호출 + 토큰 저장 + 리다이렉트는 Step 2에서 연결.
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const fieldErrors = validate(form);
+    if (Object.keys(fieldErrors).length > 0) {
+      setErrors(fieldErrors);
+      return;
+    }
+    setErrors({});
+  };
+
+  // setLoading은 Step 2(API 통합)에서 사용. tsconfig noUnusedLocals=false라 미참조 허용.
+  void setLoading;
+
+  return {
+    form,
+    errors,
+    loading,
+    onChangeEmail,
+    onChangePassword,
+    onSubmit,
+  };
+}

--- a/src/pages-v2/Login/index.tsx
+++ b/src/pages-v2/Login/index.tsx
@@ -1,0 +1,21 @@
+import { Navigate, useSearchParams } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+import LoginView from './Login';
+import { safeReturnTo, useLoginForm } from './hooks';
+
+export default function LoginPage() {
+  const auth = useAuth();
+  const [searchParams] = useSearchParams();
+  const formProps = useLoginForm();
+
+  // §5.4 인증 게이트 — 부트스트랩 중에는 카드를 그리지 않아 깜빡임 방지.
+  // (D-1: 별도 fullscreen Loading 컴포넌트 도입 안 함 — null 유지.)
+  if (auth.isLoading) return null;
+
+  // 이미 로그인된 사용자가 /login 으로 직접 진입한 경우 즉시 리다이렉트.
+  if (auth.isLoggedIn) {
+    return <Navigate to={safeReturnTo(searchParams.get('returnTo'))} replace />;
+  }
+
+  return <LoginView {...formProps} />;
+}

--- a/src/styles-v2/index.css
+++ b/src/styles-v2/index.css
@@ -21,3 +21,6 @@
 @import './components/quantity-stepper.css';
 @import './components/meta-line.css';
 @import './components/empty-state.css';
+
+/* Page-level styles. One file per page route. */
+@import './pages/login.css';

--- a/src/styles-v2/pages/login.css
+++ b/src/styles-v2/pages/login.css
@@ -1,0 +1,145 @@
+/* ==========================================================================
+   Login page — v2
+   Tokens: src/styles-v2/tokens.css
+   Spec:   docs/redesign/Spec.md § 1
+   Layout: full-viewport center, 460px shell, Card padding=28 (handled by Card).
+   No layout chrome (Layout.plan / Login.plan §5.4 D-5).
+   ========================================================================== */
+
+.login-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--bg);
+}
+
+.login-shell {
+  width: 100%;
+  max-width: 460px;
+}
+
+/* ── Brand header (DT mark + wordmark) ─────────────────────────── */
+.login-brand {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.login-brand-mark {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--r-md);
+  background: var(--brand);
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: var(--fs-base);
+  font-weight: var(--fw-bold);
+  letter-spacing: var(--ls-wide);
+}
+
+.login-brand-word {
+  font-size: 20px;
+  font-weight: var(--fw-bold);
+  color: var(--text);
+}
+
+/* ── Page heading ──────────────────────────────────────────────── */
+.login-heading {
+  text-align: center;
+  margin-bottom: 26px;
+}
+
+.login-title {
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-semibold);
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.login-subcopy {
+  font-size: var(--fs-base);
+  color: var(--text-3);
+}
+
+/* ── Form ──────────────────────────────────────────────────────── */
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.login-form-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--danger-bg);
+  color: var(--danger-text);
+  border-radius: var(--r-md);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-tight);
+}
+
+.login-form-error span[aria-hidden] {
+  font-weight: var(--fw-bold);
+}
+
+/* ── Social login block ────────────────────────────────────────── */
+.login-social {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.login-divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.login-divider::before,
+.login-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+.login-divider-label {
+  font-size: var(--fs-xs);
+  color: var(--text-4);
+  white-space: nowrap;
+}
+
+/* ── Signup callout (in-card, divider above) ──────────────────── */
+.login-signup-callout {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+  text-align: center;
+  font-size: 13.5px;
+  color: var(--text-3);
+}
+
+.login-signup-link {
+  color: var(--brand);
+  font-weight: var(--fw-semibold);
+  cursor: pointer;
+}
+
+.login-signup-link:hover {
+  color: var(--brand-hover);
+}
+
+.login-signup-link[aria-disabled='true'] {
+  pointer-events: none;
+  opacity: 0.6;
+}


### PR DESCRIPTION
## Summary
Implements a new v2 Login page with complete authentication flow, form validation, error handling, and Google OAuth integration.

## Key Changes
- **New Login page component** (`src/pages-v2/Login/`)
  - `index.tsx`: Page wrapper with auth gate and redirect logic
  - `Login.tsx`: Presentational component with form, social login, and signup callout
  - `hooks.ts`: Form state management, validation, and API integration

- **Form validation & error handling**
  - Email format validation with regex
  - Field-level and form-level error states
  - Comprehensive error mapping for API responses (400, 401, 403, 422, 429, 5xx)
  - Support for both array and object error response formats

- **Authentication flow**
  - Login form submission with email/password
  - Google OAuth button with configurable URL
  - Token storage via `AuthContext.login()`
  - Safe redirect with `returnTo` query parameter (whitelist validation)

- **Styling** (`src/styles-v2/pages/login.css`)
  - Full-viewport centered layout (460px max-width)
  - Brand header with DT mark and wordmark
  - Form inputs with error states
  - Social login divider
  - Signup callout with border separator
  - Uses design tokens from `tokens.css`

- **Integration**
  - Added `VersionedRoute` import to `App.tsx` (router setup)
  - Imported login page styles in `src/styles-v2/index.css`

## Notable Implementation Details
- **Auth gate**: Prevents flash of login form for authenticated users; returns `null` during bootstrap
- **Safe redirect**: `safeReturnTo()` validates `returnTo` parameter to prevent open redirect attacks
- **Loading state**: Disables form inputs and shows loading text during submission
- **Accessibility**: Proper ARIA attributes (`aria-busy`, `aria-disabled`, `role="alert"`)
- **Google OAuth**: Redirects via `window.location.href` for full OAuth flow
- **Error recovery**: Clears field errors on input change, preserves form state on validation failure

https://claude.ai/code/session_01WvmsidurWPuYkDv8ZxCqCi