### PR TITLE
feat: implement EventDetail page (v2) with purchase panel

### DIFF
--- a/src/pages-v2/EventDetail/EventDetail.tsx
+++ b/src/pages-v2/EventDetail/EventDetail.tsx
@@ -1,0 +1,49 @@
+import { accent } from '@/styles-v2/accent';
+
+import { Breadcrumb } from './components/Breadcrumb';
+import { EventDescription } from './components/EventDescription';
+import { EventHeader } from './components/EventHeader';
+import { HeroBanner } from './components/HeroBanner';
+import { InfoCard } from './components/InfoCard';
+import { PurchasePanel } from './components/PurchasePanel';
+import { useEventDetail } from './hooks';
+
+export interface EventDetailProps {
+  eventId: string;
+}
+
+export function EventDetail({ eventId }: EventDetailProps) {
+  const query = useEventDetail(eventId);
+
+  // PR 1 한정 — stub hook 이 항상 success. loading/error/not-found/forbidden
+  // 분기는 PR 2 의 §5 상태 처리에서 추가.
+  if (query.status !== 'success') return null;
+  const vm = query.data;
+  const accentColor = accent(eventId);
+
+  return (
+    <div className="editor-scroll">
+      <div className="gutter" aria-hidden="true">
+        {Array.from({ length: 60 }, (_, i) => (
+          <span key={i} className={`ln${i === 0 ? ' active' : ''}`}>
+            {i + 1}
+          </span>
+        ))}
+      </div>
+      <div className="editor-body">
+        <Breadcrumb title={vm.title} />
+        <div className="ed-grid">
+          <div className="ed-main">
+            <HeroBanner accent={accentColor} />
+            <EventHeader vm={vm} accent={accentColor} />
+            <InfoCard vm={vm} />
+            <EventDescription description={vm.description} />
+          </div>
+          <PurchasePanel vm={vm} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+EventDetail.displayName = 'EventDetail';

--- a/src/pages-v2/EventDetail/__mocks__/sampleEventDetail.ts
+++ b/src/pages-v2/EventDetail/__mocks__/sampleEventDetail.ts
@@ -1,0 +1,38 @@
+// PR 1 한정 mock. PR 2 에서 실제 getEventDetail 호출로 교체되며 본 파일은
+// 같은 PR 에서 삭제 예정 (EventDetail.plan.md §9.1 N8).
+
+import type { EventDetailResponse } from '@/api/types';
+import { toEventDetailVM } from '../adapters';
+
+const sampleResponse: EventDetailResponse = {
+  eventId: 'sample-on-sale',
+  title: 'Spring Camp 2026 — Reactive & Cloud Native',
+  description:
+    '리액티브 프로그래밍과 클라우드 네이티브 아키텍처를 한 번에 다루는 1일 컨퍼런스.\n\n실무자 12명의 발표 + 라이브 코딩 세션 + 네트워킹 라운지로 구성됩니다. 발표 자료와 녹화본은 행사 후 2주 이내 참가자 메일로 전달됩니다.',
+  category: '컨퍼런스',
+  techStacks: [
+    { techStackId: 1, name: 'Java' },
+    { techStackId: 2, name: 'Spring Boot' },
+    { techStackId: 3, name: 'Kafka' },
+  ],
+  price: 49000,
+  totalQuantity: 200,
+  remainingQuantity: 14,
+  eventDateTime: '2026-05-18T14:00:00',
+  location: '서울 강남구 코엑스 3층',
+  status: 'ON_SALE',
+  sellerNickname: 'Spring User Group Korea',
+  createdAt: '2026-03-01T09:00:00',
+};
+
+export const sampleEventDetail = toEventDetailVM(sampleResponse);
+
+// 매진 분기 시각 검증용. 스텁 hook 에서 sampleEventDetail 대신 import 해서 사용.
+export const sampleEventDetailSoldOut = toEventDetailVM({
+  ...sampleResponse,
+  eventId: 'sample-sold-out',
+  title: 'TypeScript 5.7 마이그레이션 세미나',
+  status: 'SOLD_OUT',
+  remainingQuantity: 0,
+  price: 15000,
+});

--- a/src/pages-v2/EventDetail/adapters.ts
+++ b/src/pages-v2/EventDetail/adapters.ts
@@ -1,0 +1,36 @@
+import type { EventDetailResponse, TechStackItem } from '@/api/types';
+import { toStatus, toDateTimeLabels, isFree, isLowStock } from '@/pages-v2/_shared/eventFormat';
+import type { EventStatus } from '@/types-v2/event';
+import type { EventDetailVM } from './types';
+
+const toTechStackNames = (items: TechStackItem[]): string[] =>
+  items.map((t) => t.name);
+
+const deriveCanBuy = (status: EventStatus, remaining: number): boolean =>
+  status === 'ON_SALE' && remaining > 0;
+
+export const toEventDetailVM = (api: EventDetailResponse): EventDetailVM => {
+  const status = toStatus(api.status);
+  const { dateLabel, timeLabel } = toDateTimeLabels(api.eventDateTime);
+  return {
+    eventId: api.eventId,
+    title: api.title,
+    category: api.category,
+    techStacks: toTechStackNames(api.techStacks),
+    description: api.description,
+    location: api.location,
+    price: api.price,
+    remainingQuantity: api.remainingQuantity,
+    totalQuantity: api.totalQuantity,
+    status,
+    sellerNickname: api.sellerNickname,
+    eventDateTime: api.eventDateTime,
+    dateLabel,
+    timeLabel,
+    isFree: isFree(api.price),
+    isLowStock: isLowStock(api.remainingQuantity),
+    isSoldOut: api.remainingQuantity === 0,
+    canBuy: deriveCanBuy(status, api.remainingQuantity),
+    thumbnailUrl: api.thumbnailUrl,
+  };
+};

--- a/src/pages-v2/EventDetail/components/Breadcrumb.tsx
+++ b/src/pages-v2/EventDetail/components/Breadcrumb.tsx
@@ -1,0 +1,21 @@
+import { Link } from 'react-router-dom';
+
+export interface BreadcrumbProps {
+  title: string;
+}
+
+export function Breadcrumb({ title }: BreadcrumbProps) {
+  return (
+    <nav className="ed-breadcrumb" aria-label="breadcrumb">
+      <Link to="/" className="ed-breadcrumb__link">
+        이벤트
+      </Link>
+      <span className="ed-breadcrumb__sep" aria-hidden="true">
+        ›
+      </span>
+      <span className="ed-breadcrumb__current truncate">{title}</span>
+    </nav>
+  );
+}
+
+Breadcrumb.displayName = 'Breadcrumb';

--- a/src/pages-v2/EventDetail/components/EventDescription.tsx
+++ b/src/pages-v2/EventDetail/components/EventDescription.tsx
@@ -1,0 +1,14 @@
+export interface EventDescriptionProps {
+  description: string;
+}
+
+export function EventDescription({ description }: EventDescriptionProps) {
+  return (
+    <section className="ed-description">
+      <h2 className="ed-description__title">이벤트 소개</h2>
+      <p className="ed-description__body">{description}</p>
+    </section>
+  );
+}
+
+EventDescription.displayName = 'EventDescription';

--- a/src/pages-v2/EventDetail/components/EventHeader.tsx
+++ b/src/pages-v2/EventDetail/components/EventHeader.tsx
@@ -1,0 +1,41 @@
+import { StatusChip, type StatusVariant } from '@/components-v2/StatusChip';
+import type { EventStatus } from '@/types-v2/event';
+
+import type { EventDetailVM } from '../types';
+
+const STATUS_DISPLAY: Record<EventStatus, { variant: StatusVariant; label: string }> = {
+  ON_SALE: { variant: 'ok', label: '판매중' },
+  SOLD_OUT: { variant: 'sold', label: '매진' },
+  SALE_ENDED: { variant: 'end', label: '판매 종료' },
+  CANCELLED: { variant: 'end', label: '취소됨' },
+  ENDED: { variant: 'end', label: '종료됨' },
+};
+
+export interface EventHeaderProps {
+  vm: EventDetailVM;
+  accent: string;
+}
+
+export function EventHeader({ vm, accent }: EventHeaderProps) {
+  const { variant, label } = STATUS_DISPLAY[vm.status];
+  return (
+    <header>
+      <div className="ed-header__row">
+        <span className="ed-header__category" style={{ color: accent }}>
+          {vm.category}
+        </span>
+        <StatusChip variant={variant}>{label}</StatusChip>
+      </div>
+      <h1 className="ed-header__title">{vm.title}</h1>
+      <div className="ed-header__chips">
+        {vm.techStacks.map((name) => (
+          <span key={name} className="chip ed-tech-chip">
+            {name}
+          </span>
+        ))}
+      </div>
+    </header>
+  );
+}
+
+EventHeader.displayName = 'EventHeader';

--- a/src/pages-v2/EventDetail/components/HeroBanner.tsx
+++ b/src/pages-v2/EventDetail/components/HeroBanner.tsx
@@ -1,0 +1,19 @@
+import { AccentMediaBox } from '@/components-v2/AccentMediaBox';
+
+export interface HeroBannerProps {
+  accent: string;
+}
+
+export function HeroBanner({ accent }: HeroBannerProps) {
+  return (
+    <AccentMediaBox
+      accent={accent}
+      variant="box"
+      size="hero"
+      glyph="❯_"
+      className="ed-hero"
+    />
+  );
+}
+
+HeroBanner.displayName = 'HeroBanner';

--- a/src/pages-v2/EventDetail/components/InfoCard.tsx
+++ b/src/pages-v2/EventDetail/components/InfoCard.tsx
@@ -1,0 +1,31 @@
+import { Card } from '@/components-v2/Card';
+
+import type { EventDetailVM } from '../types';
+import { InfoRow } from './InfoRow';
+
+export interface InfoCardProps {
+  vm: EventDetailVM;
+}
+
+export function InfoCard({ vm }: InfoCardProps) {
+  const seatValue = vm.isSoldOut ? (
+    <span className="ed-seat-sold">매진되었습니다</span>
+  ) : (
+    `${vm.remainingQuantity.toLocaleString()}석`
+  );
+
+  return (
+    <Card padding="none" className="ed-info-card">
+      <InfoRow
+        icon="📅"
+        label="일시"
+        value={`${vm.dateLabel} ${vm.timeLabel}`}
+      />
+      <InfoRow icon="📍" label="장소" value={vm.location} />
+      <InfoRow icon="👤" label="주최" value={vm.sellerNickname} />
+      <InfoRow icon="🎫" label="잔여 좌석" value={seatValue} />
+    </Card>
+  );
+}
+
+InfoCard.displayName = 'InfoCard';

--- a/src/pages-v2/EventDetail/components/InfoRow.tsx
+++ b/src/pages-v2/EventDetail/components/InfoRow.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+export interface InfoRowProps {
+  icon: ReactNode;
+  label: string;
+  value: ReactNode;
+}
+
+export function InfoRow({ icon, label, value }: InfoRowProps) {
+  return (
+    <div className="ed-info-row">
+      <span className="ed-info-row__icon" aria-hidden="true">
+        {icon}
+      </span>
+      <div className="ed-info-row__label">{label}</div>
+      <div className="ed-info-row__value">{value}</div>
+    </div>
+  );
+}
+
+InfoRow.displayName = 'InfoRow';

--- a/src/pages-v2/EventDetail/components/PriceSummary.tsx
+++ b/src/pages-v2/EventDetail/components/PriceSummary.tsx
@@ -1,0 +1,18 @@
+export interface PriceSummaryProps {
+  total: number;
+  hidden?: boolean;
+}
+
+export function PriceSummary({ total, hidden = false }: PriceSummaryProps) {
+  if (hidden || total <= 0) return null;
+  return (
+    <div className="ed-price-summary">
+      <span className="ed-price-summary__label">합계</span>
+      <span className="ed-price-summary__value">
+        {total.toLocaleString()}원
+      </span>
+    </div>
+  );
+}
+
+PriceSummary.displayName = 'PriceSummary';

--- a/src/pages-v2/EventDetail/components/PurchasePanel.tsx
+++ b/src/pages-v2/EventDetail/components/PurchasePanel.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+
+import { Button } from '@/components-v2/Button';
+import { Card } from '@/components-v2/Card';
+import { Icon } from '@/components-v2/Icon';
+import { QuantityStepper } from '@/components-v2/QuantityStepper';
+
+import type { EventDetailVM } from '../types';
+import { PriceSummary } from './PriceSummary';
+
+export interface PurchasePanelProps {
+  vm: EventDetailVM;
+}
+
+export function PurchasePanel({ vm }: PurchasePanelProps) {
+  const [qty, setQty] = useState(1);
+
+  const showQuantity = !vm.isFree && vm.canBuy;
+
+  // PR 1 한정 — 실제 구매 액션은 PR 3 의 usePurchaseActions 로 교체.
+  const handleBuyNow = () => {
+    console.log('[PurchasePanel] buyNow stub', { eventId: vm.eventId, qty });
+  };
+  const handleAddToCart = () => {
+    console.log('[PurchasePanel] addToCart stub', { eventId: vm.eventId, qty });
+  };
+
+  return (
+    <div className="ed-purchase-sticky">
+      <Card padding="none" className="ed-purchase">
+        <div className="ed-purchase__inner">
+          <div className="ed-price__label">티켓 가격</div>
+          <div className={`ed-price__amount${vm.isFree ? ' is-free' : ''}`}>
+            {vm.isFree ? '무료' : `${vm.price.toLocaleString()}원`}
+          </div>
+
+          {showQuantity && (
+            <div className="ed-quantity">
+              <div className="ed-quantity__label">수량</div>
+              <QuantityStepper
+                value={qty}
+                onChange={setQty}
+                min={1}
+                max={vm.remainingQuantity}
+                size="md"
+              />
+            </div>
+          )}
+
+          <PriceSummary total={vm.price * qty} hidden={!vm.canBuy} />
+
+          <div className="ed-purchase__actions">
+            {vm.canBuy ? (
+              <>
+                <Button
+                  variant="primary"
+                  size="lg"
+                  full
+                  onClick={handleBuyNow}
+                >
+                  바로 구매하기
+                </Button>
+                <Button
+                  variant="ghost"
+                  full
+                  iconStart={<Icon name="cart" size={13} />}
+                  onClick={handleAddToCart}
+                >
+                  장바구니에 담기
+                </Button>
+              </>
+            ) : (
+              <Button variant="ghost" size="lg" full disabled>
+                매진된 이벤트입니다
+              </Button>
+            )}
+          </div>
+
+          <div className="ed-notice">
+            결제 완료 후 티켓이 즉시 발급됩니다.
+            <br />
+            행사 7일 전까지 100% 환불이 가능합니다.
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+PurchasePanel.displayName = 'PurchasePanel';

--- a/src/pages-v2/EventDetail/hooks.ts
+++ b/src/pages-v2/EventDetail/hooks.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+
+import { sampleEventDetail } from './__mocks__/sampleEventDetail';
+import type { EventDetailQuery } from './types';
+
+// PR 1 한정 스텁. eventId 와 무관하게 항상 같은 mock VM 으로 success 반환.
+// PR 2 에서 getEventDetail 호출 + 캐시 + AbortController 기반 실 구현으로 교체.
+
+export function useEventDetail(
+  _eventId: string,
+): EventDetailQuery & { refetch: () => void } {
+  return useMemo(
+    () => ({
+      status: 'success' as const,
+      data: sampleEventDetail,
+      fetchedAt: Date.now(),
+      refetch: () => {},
+    }),
+    [],
+  );
+}

--- a/src/pages-v2/EventDetail/index.tsx
+++ b/src/pages-v2/EventDetail/index.tsx
@@ -1,0 +1,9 @@
+import { Navigate, useParams } from 'react-router-dom';
+
+import { EventDetail } from './EventDetail';
+
+export default function EventDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  if (!id) return <Navigate to="/" replace />;
+  return <EventDetail eventId={id} />;
+}

--- a/src/pages-v2/EventDetail/types.ts
+++ b/src/pages-v2/EventDetail/types.ts
@@ -1,0 +1,30 @@
+import type { EventStatus } from '@/types-v2/event';
+
+export interface EventDetailVM {
+  eventId: string;
+  title: string;
+  category: string;
+  techStacks: string[];
+  description: string;
+  location: string;
+  price: number;
+  remainingQuantity: number;
+  totalQuantity: number;
+  status: EventStatus;
+  sellerNickname: string;
+  eventDateTime: string;
+  dateLabel: string;
+  timeLabel: string;
+  isFree: boolean;
+  isLowStock: boolean;
+  isSoldOut: boolean;
+  canBuy: boolean;
+  thumbnailUrl?: string;
+}
+
+export type EventDetailQuery =
+  | { status: 'loading'; previous?: EventDetailVM }
+  | { status: 'success'; data: EventDetailVM; fetchedAt: number }
+  | { status: 'not-found' }
+  | { status: 'forbidden' }
+  | { status: 'error'; error: unknown; previous?: EventDetailVM };

--- a/src/pages-v2/EventList/adapters.ts
+++ b/src/pages-v2/EventList/adapters.ts
@@ -5,39 +5,20 @@ import type {
   EventSearchRequest,
   EventFilterRequest,
 } from '@/api/types';
+import {
+  toStatus,
+  toDateTimeLabels,
+  isFree,
+  isLowStock,
+} from '@/pages-v2/_shared/eventFormat';
 import type {
   EventVM,
-  EventStatus,
   EventListPage,
   EventListFilters,
 } from './types';
 
 export const DEFAULT_PAGE_SIZE = 24;
 export const DEFAULT_CATEGORY = '전체';
-
-const KNOWN_STATUSES: readonly EventStatus[] = [
-  'ON_SALE',
-  'SOLD_OUT',
-  'SALE_ENDED',
-  'CANCELLED',
-  'ENDED',
-];
-
-const pad2 = (n: number) => String(n).padStart(2, '0');
-
-const toStatus = (raw: string): EventStatus =>
-  (KNOWN_STATUSES as readonly string[]).includes(raw)
-    ? (raw as EventStatus)
-    : 'ENDED';
-
-const toDateTimeLabels = (iso: string): { dateLabel: string; timeLabel: string } => {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return { dateLabel: '', timeLabel: '' };
-  return {
-    dateLabel: `${d.getFullYear()}.${pad2(d.getMonth() + 1)}.${pad2(d.getDate())}`,
-    timeLabel: `${pad2(d.getHours())}:${pad2(d.getMinutes())}`,
-  };
-};
 
 export const toEventVM = (api: EventItem): EventVM => {
   const { dateLabel, timeLabel } = toDateTimeLabels(api.eventDateTime);
@@ -51,8 +32,8 @@ export const toEventVM = (api: EventItem): EventVM => {
     status: toStatus(api.status),
     eventDateTime: api.eventDateTime,
     thumbnailUrl: api.thumbnailUrl,
-    isFree: api.price === 0,
-    isLowStock: api.remainingQuantity > 0 && api.remainingQuantity < 10,
+    isFree: isFree(api.price),
+    isLowStock: isLowStock(api.remainingQuantity),
     dateLabel,
     timeLabel,
   };

--- a/src/pages-v2/EventList/types.ts
+++ b/src/pages-v2/EventList/types.ts
@@ -1,4 +1,6 @@
-export type EventStatus = 'ON_SALE' | 'SOLD_OUT' | 'SALE_ENDED' | 'CANCELLED' | 'ENDED';
+import type { EventStatus } from '@/types-v2/event';
+
+export type { EventStatus };
 
 export interface EventVM {
   eventId: string;

--- a/src/pages-v2/EventList/types.ts
+++ b/src/pages-v2/EventList/types.ts
@@ -1,7 +1,5 @@
 import type { EventStatus } from '@/types-v2/event';
 
-export type { EventStatus };
-
 export interface EventVM {
   eventId: string;
   title: string;

--- a/src/pages-v2/_shared/eventFormat.ts
+++ b/src/pages-v2/_shared/eventFormat.ts
@@ -1,0 +1,33 @@
+import type { EventStatus } from '@/types-v2/event';
+
+const KNOWN_STATUSES: readonly EventStatus[] = [
+  'ON_SALE',
+  'SOLD_OUT',
+  'SALE_ENDED',
+  'CANCELLED',
+  'ENDED',
+];
+
+const pad2 = (n: number) => String(n).padStart(2, '0');
+
+export const toStatus = (raw: string): EventStatus =>
+  (KNOWN_STATUSES as readonly string[]).includes(raw)
+    ? (raw as EventStatus)
+    : 'ENDED';
+
+export const toDateTimeLabels = (
+  iso: string,
+): { dateLabel: string; timeLabel: string } => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return { dateLabel: '', timeLabel: '' };
+  return {
+    dateLabel: `${d.getFullYear()}.${pad2(d.getMonth() + 1)}.${pad2(d.getDate())}`,
+    timeLabel: `${pad2(d.getHours())}:${pad2(d.getMinutes())}`,
+  };
+};
+
+export const isFree = (price: number): boolean => price === 0;
+
+// §8-항목3 결정: EventList(<10) ↔ EventDetail 임계값을 <5 로 통일.
+export const isLowStock = (remaining: number): boolean =>
+  remaining > 0 && remaining < 5;

--- a/src/styles-v2/index.css
+++ b/src/styles-v2/index.css
@@ -24,3 +24,4 @@
 
 /* Page-level styles. One file per page route. */
 @import './pages/login.css';
+@import './pages/event-detail.css';

--- a/src/styles-v2/pages/event-detail.css
+++ b/src/styles-v2/pages/event-detail.css
@@ -108,3 +108,36 @@
   font-weight: 700;
   color: var(--text);
 }
+
+/* EventHeader (§2 EventHeader) — category(mono uppercase, accent color) + StatusChip + title 28 + Chip group */
+.ed-header__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.ed-header__category {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.ed-header__title {
+  font-family: var(--font);
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 1.3;
+  margin: 0 0 14px;
+  color: var(--text);
+}
+.ed-header__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-bottom: 22px;
+}
+/* Tech stack labels reuse .chip styling but are non-interactive spans. */
+.ed-tech-chip {
+  cursor: default;
+}

--- a/src/styles-v2/pages/event-detail.css
+++ b/src/styles-v2/pages/event-detail.css
@@ -33,3 +33,31 @@
 .ed-hero {
   margin-bottom: 24px;
 }
+
+/* InfoRow (§2 InfoRow) — single row inside InfoCard. Last row drops border via :last-child. */
+.ed-info-row {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.ed-info-row:last-child {
+  border-bottom: none;
+}
+.ed-info-row__icon {
+  font-size: 17px;
+  flex-shrink: 0;
+}
+.ed-info-row__label {
+  font-family: var(--font);
+  font-size: 12.5px;
+  color: var(--text-3);
+  min-width: 66px;
+}
+.ed-info-row__value {
+  font-family: var(--font);
+  font-size: 14px;
+  color: var(--text);
+  font-weight: 500;
+}

--- a/src/styles-v2/pages/event-detail.css
+++ b/src/styles-v2/pages/event-detail.css
@@ -28,3 +28,8 @@
   color: var(--text-2);
   min-width: 0;
 }
+
+/* HeroBanner (§2 HeroBanner) — wraps AccentMediaBox size="hero" with page spacing */
+.ed-hero {
+  margin-bottom: 24px;
+}

--- a/src/styles-v2/pages/event-detail.css
+++ b/src/styles-v2/pages/event-detail.css
@@ -61,3 +61,12 @@
   color: var(--text);
   font-weight: 500;
 }
+
+/* InfoCard (§2 InfoCard) — flat card wrapping 4 InfoRows */
+.ed-info-card {
+  padding: 4px 0;
+  margin-bottom: 24px;
+}
+.ed-seat-sold {
+  color: var(--danger);
+}

--- a/src/styles-v2/pages/event-detail.css
+++ b/src/styles-v2/pages/event-detail.css
@@ -1,0 +1,30 @@
+/* DevTicket v2 — EventDetail page styles
+   Source: docs/redesign/prototype/EventDetail.jsx + docs/redesign/EventDetail.plan.md
+   Scope: classes prefixed with `ed-` are local to /events/:id (v2). */
+
+/* Breadcrumb (§2 Breadcrumb) */
+.ed-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 18px;
+  font-family: var(--font);
+  font-size: 13px;
+  color: var(--text-3);
+  min-width: 0;
+}
+.ed-breadcrumb__link {
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+.ed-breadcrumb__link:hover {
+  color: var(--text-2);
+}
+.ed-breadcrumb__sep {
+  color: var(--text-3);
+}
+.ed-breadcrumb__current {
+  color: var(--text-2);
+  min-width: 0;
+}

--- a/src/styles-v2/pages/event-detail.css
+++ b/src/styles-v2/pages/event-detail.css
@@ -87,3 +87,24 @@
   white-space: pre-wrap;
   margin: 0;
 }
+
+/* PriceSummary (§2 PriceSummary) — 합계 한 줄. price=0 / 매진 시 component 가 null 반환 */
+.ed-price-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 0 0;
+  margin-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.ed-price-summary__label {
+  font-family: var(--font);
+  font-size: 14px;
+  color: var(--text-2);
+}
+.ed-price-summary__value {
+  font-family: var(--font);
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text);
+}

--- a/src/styles-v2/pages/event-detail.css
+++ b/src/styles-v2/pages/event-detail.css
@@ -2,6 +2,17 @@
    Source: docs/redesign/prototype/EventDetail.jsx + docs/redesign/EventDetail.plan.md
    Scope: classes prefixed with `ed-` are local to /events/:id (v2). */
 
+/* Layout grid (§2 EventDetail container) — 2-column main + sticky right panel */
+.ed-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: 28px;
+  align-items: start;
+}
+.ed-main {
+  min-width: 0;
+}
+
 /* Breadcrumb (§2 Breadcrumb) */
 .ed-breadcrumb {
   display: flex;

--- a/src/styles-v2/pages/event-detail.css
+++ b/src/styles-v2/pages/event-detail.css
@@ -141,3 +141,58 @@
 .ed-tech-chip {
   cursor: default;
 }
+
+/* PurchasePanel (§2 PurchasePanel) — sticky right column */
+.ed-purchase-sticky {
+  position: sticky;
+  top: 12px;
+}
+.ed-purchase {
+  overflow: hidden;
+}
+.ed-purchase__inner {
+  padding: 20px;
+}
+.ed-price__label {
+  font-family: var(--font);
+  font-size: 12px;
+  color: var(--text-3);
+  margin-bottom: 4px;
+}
+.ed-price__amount {
+  font-family: var(--font);
+  font-size: 30px;
+  font-weight: 800;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+.ed-price__amount.is-free {
+  color: var(--term-green-dim);
+}
+.ed-quantity {
+  margin-top: 20px;
+}
+.ed-quantity__label {
+  font-family: var(--font);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-2);
+  margin-bottom: 8px;
+}
+.ed-purchase__actions {
+  margin-top: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ed-notice {
+  margin-top: 16px;
+  padding: 12px 14px;
+  background: var(--editor-line);
+  border-left: 3px solid var(--brand);
+  border-radius: 0 6px 6px 0;
+  font-family: var(--font);
+  font-size: 12.5px;
+  color: var(--text-3);
+  line-height: 1.7;
+}

--- a/src/styles-v2/pages/event-detail.css
+++ b/src/styles-v2/pages/event-detail.css
@@ -70,3 +70,20 @@
 .ed-seat-sold {
   color: var(--danger);
 }
+
+/* EventDescription (§2 EventDescription) — §8-O9 단순 h2, §8-O2 plain text + pre-wrap */
+.ed-description__title {
+  font-family: var(--font);
+  font-size: 17px;
+  font-weight: 600;
+  margin-bottom: 10px;
+  color: var(--text);
+}
+.ed-description__body {
+  font-family: var(--font);
+  font-size: 15px;
+  color: var(--text-2);
+  line-height: 1.75;
+  white-space: pre-wrap;
+  margin: 0;
+}

--- a/src/types-v2/event.ts
+++ b/src/types-v2/event.ts
@@ -1,0 +1,1 @@
+export type EventStatus = 'ON_SALE' | 'SOLD_OUT' | 'SALE_ENDED' | 'CANCELLED' | 'ENDED';


### PR DESCRIPTION
## Summary
Implements the EventDetail page for the v2 redesign, featuring a two-column layout with event information on the left and a sticky purchase panel on the right. This PR includes all UI components, styling, type definitions, and mock data needed for the initial implementation.

## Key Changes

- **New EventDetail page structure** (`src/pages-v2/EventDetail/`)
  - Main page component with grid layout (2-column: main content + sticky purchase panel)
  - Route handler with param validation and navigation fallback
  
- **Core components**
  - `EventHeader`: Displays category (accent-colored), status chip, title, and tech stack tags
  - `InfoCard`: Shows event metadata (date, location, organizer, remaining seats) in a structured card
  - `PurchasePanel`: Sticky right panel with price display, quantity selector, and action buttons
  - `HeroBanner`: Accent-colored hero media box
  - `Breadcrumb`: Navigation breadcrumb with event title
  - `EventDescription`: Event details section with pre-wrapped text
  - `PriceSummary`: Conditional total price display
  - `InfoRow`: Reusable row component for metadata display

- **Data layer**
  - `EventDetailVM` type: Comprehensive view model with computed properties (isFree, isLowStock, canBuy, isSoldOut)
  - `EventDetailQuery` union type: Handles loading, success, not-found, forbidden, and error states
  - `adapters.ts`: Converts API response to view model with status normalization and derived fields
  - `hooks.ts`: Stub hook returning mock data (to be replaced in PR 2)
  - Mock sample data with ON_SALE and SOLD_OUT variants

- **Shared utilities** (`src/pages-v2/_shared/eventFormat.ts`)
  - Extracted common formatting functions from EventList: `toStatus`, `toDateTimeLabels`, `isFree`, `isLowStock`
  - Unified low-stock threshold across pages (<5 items)

- **Styling** (`src/styles-v2/pages/event-detail.css`)
  - 209 lines of component-scoped styles with `ed-` prefix
  - Grid layout with sticky positioning for purchase panel
  - Responsive typography and spacing aligned with design system
  - Status-aware styling (free price in green, sold-out state handling)

- **Type consolidation**
  - Moved `EventStatus` to shared type file (`src/types-v2/event.ts`)
  - Updated EventList to import from shared location

## Implementation Notes

- **PR 1 scope**: Stub implementations for data fetching and purchase actions (console.log placeholders)
- **Future work** (PR 2): Real API integration, error/loading states, purchase action handlers
- **Design alignment**: Follows EventDetail.plan.md specification with section references (§2, §8, etc.)
- **Accessibility**: Semantic HTML, ARIA labels, proper heading hierarchy

https://claude.ai/code/session_019C5pqBPwdFPUbapLEPueUD