### PR TITLE
Implement purchase actions hook for event detail page

### DIFF
--- a/src/pages-v2/EventDetail/components/PurchasePanel.tsx
+++ b/src/pages-v2/EventDetail/components/PurchasePanel.tsx
@@ -5,6 +5,7 @@ import { Card } from '@/components-v2/Card';
 import { Icon } from '@/components-v2/Icon';
 import { QuantityStepper } from '@/components-v2/QuantityStepper';
 
+import { usePurchaseActions } from '../hooks';
 import type { EventDetailVM } from '../types';
 import { PriceSummary } from './PriceSummary';
 
@@ -14,16 +15,10 @@ export interface PurchasePanelProps {
 
 export function PurchasePanel({ vm }: PurchasePanelProps) {
   const [qty, setQty] = useState(1);
+  const { busy, addToCart, buyNow } = usePurchaseActions(vm.eventId);
 
   const showQuantity = !vm.isFree && vm.canBuy;
-
-  // PR 1 한정 — 실제 구매 액션은 PR 3 의 usePurchaseActions 로 교체.
-  const handleBuyNow = () => {
-    console.log('[PurchasePanel] buyNow stub', { eventId: vm.eventId, qty });
-  };
-  const handleAddToCart = () => {
-    console.log('[PurchasePanel] addToCart stub', { eventId: vm.eventId, qty });
-  };
+  const isBusy = busy !== null;
 
   return (
     <div className="ed-purchase-sticky">
@@ -43,6 +38,7 @@ export function PurchasePanel({ vm }: PurchasePanelProps) {
                 min={1}
                 max={vm.remainingQuantity}
                 size="md"
+                disabled={isBusy}
               />
             </div>
           )}
@@ -56,17 +52,19 @@ export function PurchasePanel({ vm }: PurchasePanelProps) {
                   variant="primary"
                   size="lg"
                   full
-                  onClick={handleBuyNow}
+                  onClick={() => buyNow(qty)}
+                  disabled={isBusy}
                 >
-                  바로 구매하기
+                  {busy === 'buying' ? '이동 중…' : '바로 구매하기'}
                 </Button>
                 <Button
                   variant="ghost"
                   full
                   iconStart={<Icon name="cart" size={13} />}
-                  onClick={handleAddToCart}
+                  onClick={() => addToCart(qty)}
+                  disabled={isBusy}
                 >
-                  장바구니에 담기
+                  {busy === 'adding' ? '담는 중…' : '장바구니에 담기'}
                 </Button>
               </>
             ) : (

--- a/src/pages-v2/EventDetail/hooks.ts
+++ b/src/pages-v2/EventDetail/hooks.ts
@@ -1,8 +1,12 @@
 import axios from 'axios';
 import { useCallback, useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
+import { addCartItem } from '@/api/cart.api';
 import { apiClient, unwrapApiData, type ApiResponse } from '@/api/client';
 import type { EventDetailResponse } from '@/api/types';
+import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/contexts/ToastContext';
 
 import {
   toEventDetailVM,
@@ -193,4 +197,72 @@ export function useRecommendedEvents(currentEventId: string): RecommendedQuery {
   }, [currentEventId]);
 
   return state;
+}
+
+/* ── usePurchaseActions (§6.6 합성 hook / §9.3 PR 3) ─────────────────────
+ * "장바구니에 담기" + "바로 구매하기" 두 액션을 한 hook 으로 노출. busy
+ * state 를 공유해 동시 클릭 시 두 버튼이 같이 disabled. 비로그인 시 로그인
+ * 페이지로 returnTo 인코딩해 redirect (§5-(4)). POST 는 사용자 명시 액션이라
+ * AbortController 미사용 (§6.6). */
+
+export type PurchaseBusy = 'adding' | 'buying' | null;
+
+export interface UsePurchaseActionsReturn {
+  busy: PurchaseBusy;
+  addToCart: (quantity: number) => Promise<void>;
+  buyNow: (quantity: number) => Promise<void>;
+}
+
+export function usePurchaseActions(eventId: string): UsePurchaseActionsReturn {
+  const { isLoggedIn } = useAuth();
+  const { toast } = useToast();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [busy, setBusy] = useState<PurchaseBusy>(null);
+
+  const redirectToLogin = useCallback(() => {
+    const returnTo = encodeURIComponent(location.pathname + location.search);
+    navigate(`/login?returnTo=${returnTo}`);
+  }, [location.pathname, location.search, navigate]);
+
+  const addToCart = useCallback(
+    async (quantity: number) => {
+      if (!isLoggedIn) {
+        redirectToLogin();
+        return;
+      }
+      if (busy !== null) return;
+      setBusy('adding');
+      try {
+        await addCartItem({ eventId, quantity });
+        toast('장바구니에 담았습니다', 'success');
+      } catch {
+        toast('장바구니 담기에 실패했습니다. 잠시 후 다시 시도해주세요.', 'error');
+      } finally {
+        setBusy(null);
+      }
+    },
+    [busy, eventId, isLoggedIn, redirectToLogin, toast],
+  );
+
+  const buyNow = useCallback(
+    async (quantity: number) => {
+      if (!isLoggedIn) {
+        redirectToLogin();
+        return;
+      }
+      if (busy !== null) return;
+      setBusy('buying');
+      try {
+        await addCartItem({ eventId, quantity });
+        navigate('/cart');
+      } catch {
+        toast('오류가 발생했습니다. 잠시 후 다시 시도해주세요.', 'error');
+        setBusy(null);
+      }
+    },
+    [busy, eventId, isLoggedIn, navigate, redirectToLogin, toast],
+  );
+
+  return { busy, addToCart, buyNow };
 }


### PR DESCRIPTION
## Summary
Implement the `usePurchaseActions` hook to handle "Add to Cart" and "Buy Now" functionality for event purchases, with proper authentication checks, loading states, and user feedback.

## Key Changes
- **New hook `usePurchaseActions`**: Composite hook that manages both cart and purchase flows
  - Handles authentication checks with redirect to login (encoding returnTo parameter)
  - Manages shared `busy` state to prevent simultaneous requests
  - Provides `addToCart` and `buyNow` callback functions
  - Integrates with toast notifications for user feedback
  - Does not use AbortController for explicit user actions (POST requests)

- **Updated `PurchasePanel` component**:
  - Replaced stub console.log implementations with actual hook integration
  - Added loading state indicators ("담는 중…", "이동 중…") to buttons
  - Disabled quantity stepper and buttons during active requests
  - Connected button clicks to `addToCart` and `buyNow` functions with quantity parameter

- **New imports**:
  - `useLocation`, `useNavigate` from react-router-dom for authentication flow
  - `addCartItem` from cart API
  - `useAuth`, `useToast` context hooks for authentication and notifications

## Implementation Details
- The hook prevents double-submission by checking `busy` state before executing actions
- Unauthenticated users are redirected to `/login` with the current page encoded as `returnTo` query parameter
- Both actions use the same `addCartItem` API call; "Buy Now" additionally navigates to `/cart`
- Error handling provides user-friendly messages via toast notifications
- The `busy` state is properly reset in finally blocks to ensure UI responsiveness

https://claude.ai/code/session_01VuuSfDxswbtX8oD1H32Kda