### PR TITLE
feat: implement Cart page v2 with skeleton loading and order summary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,10 +18,11 @@ import NotFound          from './pages/NotFound'
 const OAuthCallback       = lazy(() => import('./pages/OAuthCallback'))
 const SocialProfileSetup  = lazy(() => import('./pages/SocialProfileSetup'))
 
-// lazy – v2 재구축 (router-toggle.plan, Login.plan §6, EventList.plan §10 PR 1)
+// lazy – v2 재구축 (router-toggle.plan, Login.plan §6, EventList.plan §10 PR 1, Cart.plan §10.1)
 const LoginV2             = lazy(() => import('./pages-v2/Login'))
 const EventListV2         = lazy(() => import('./pages-v2/EventList'))
 const EventDetailV2       = lazy(() => import('./pages-v2/EventDetail'))
+const CartV2              = lazy(() => import('./pages-v2/Cart'))
 
 // lazy – 로그인 후 접근
 const SignupComplete      = lazy(() => import('./pages/SignupComplete'))
@@ -90,7 +91,7 @@ export default function App() {
         <Route element={<Layout />}>
           <Route path="/"                       element={<VersionedRoute v1={<EventList />} v2={<EventListV2 />} />} />
           <Route path="/events/:id"             element={<VersionedRoute v1={<EventDetail />} v2={<EventDetailV2 />} />} />
-          <Route path="/cart"                   element={<RequireAuth><Cart /></RequireAuth>} />
+          <Route path="/cart"                   element={<RequireAuth><VersionedRoute v1={<Cart />} v2={<CartV2 />} /></RequireAuth>} />
           <Route path="/payment"                element={<RequireAuth><Payment /></RequireAuth>} />
           <Route path="/payment/complete"       element={<RequireAuth><PaymentComplete /></RequireAuth>} />
           <Route path="/mypage"                 element={<RequireAuth><MyPage /></RequireAuth>} />

--- a/src/pages-v2/Cart/Cart.tsx
+++ b/src/pages-v2/Cart/Cart.tsx
@@ -1,0 +1,115 @@
+/**
+ * Cart 페이지 프레젠테이션.
+ *
+ * `CartQuery` 분기 (loading / error / success(empty) / success(non-empty))를
+ * 화면 컴포지션으로 변환. 데이터 페치/뮤테이션/네비게이션은 모두 컨테이너
+ * (`index.tsx`)가 담당하며, 본 컴포넌트는 props 만 받아 렌더한다.
+ *
+ * PR 1 한정:
+ * - 결제 버튼은 항상 disabled (`useCheckout` 도입은 PR 3).
+ * - 에러 분기는 minimal 메시지. PR 2 에서 `onRetry`/`describeError` 패턴 도입.
+ */
+
+import type { ReactNode } from 'react';
+
+import { Card } from '@/components-v2/Card';
+
+import { CartHeader } from './components/CartHeader';
+import { CartItemList } from './components/CartItemList';
+import { CartSkeleton } from './components/CartSkeleton';
+import { EmptyCart } from './components/EmptyCart';
+import { OrderSummary } from './components/OrderSummary';
+import type { CartQuery } from './types';
+
+export type CheckoutState = 'idle' | 'submitting' | 'error';
+
+export interface CartProps {
+  query: CartQuery;
+  onQuantityChange: (itemId: string, next: number) => void;
+  onRemove: (itemId: string) => void;
+  onCheckout: () => void;
+  onBrowse: () => void;
+  checkoutState: CheckoutState;
+  pendingItemIds?: Set<string>;
+}
+
+function PageShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="editor-scroll">
+      <div className="gutter" aria-hidden="true">
+        {Array.from({ length: 50 }, (_, i) => (
+          <span key={i} className={`ln${i === 0 ? ' active' : ''}`}>
+            {i + 1}
+          </span>
+        ))}
+      </div>
+      <div className="editor-body cart-page">{children}</div>
+    </div>
+  );
+}
+
+export function Cart({
+  query,
+  onQuantityChange,
+  onRemove,
+  onCheckout,
+  onBrowse,
+  checkoutState,
+  pendingItemIds,
+}: CartProps) {
+  if (query.status === 'loading') {
+    return (
+      <PageShell>
+        <CartSkeleton />
+      </PageShell>
+    );
+  }
+
+  if (query.status === 'error') {
+    return (
+      <PageShell>
+        <CartHeader itemCount={0} />
+        <Card variant="solid" className="cart-error">
+          <p>장바구니를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.</p>
+        </Card>
+      </PageShell>
+    );
+  }
+
+  const cart = query.data;
+
+  if (cart.items.length === 0) {
+    return (
+      <PageShell>
+        <CartHeader itemCount={0} />
+        <EmptyCart onBrowse={onBrowse} />
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell>
+      <CartHeader itemCount={cart.items.length} />
+      <div className="cart-grid">
+        <CartItemList
+          items={cart.items}
+          onQuantityChange={onQuantityChange}
+          onRemove={onRemove}
+          pendingItemIds={pendingItemIds}
+        />
+        <OrderSummary
+          subtotal={cart.subtotal}
+          fee={cart.fee}
+          discount={cart.discount}
+          total={cart.total}
+          onCheckout={onCheckout}
+          submitting={checkoutState === 'submitting'}
+          /* PR 1: 결제 흐름 미도입 → 항상 disabled. PR 3 에서 제거. */
+          disabled
+        />
+      </div>
+    </PageShell>
+  );
+}
+
+Cart.displayName = 'Cart';

--- a/src/pages-v2/Cart/components/CartHeader.tsx
+++ b/src/pages-v2/Cart/components/CartHeader.tsx
@@ -1,0 +1,21 @@
+/**
+ * 페이지 상단 타이틀 + 부제.
+ *
+ * 프로토타입 Cart.jsx:19-22 의 인라인 스타일을 BEM 클래스로 변환.
+ * 시각: h1 26px/700 text, 부제 14px text-3 (CSS는 styles-v2/pages/cart.css).
+ */
+
+export interface CartHeaderProps {
+  itemCount: number;
+}
+
+export function CartHeader({ itemCount }: CartHeaderProps) {
+  return (
+    <header className="cart-header">
+      <h1 className="cart-header__title">장바구니</h1>
+      <p className="cart-header__subtitle">
+        담긴 티켓 {itemCount}개 · 결제 전 최종 수량을 확인해주세요.
+      </p>
+    </header>
+  );
+}

--- a/src/pages-v2/Cart/components/CartItem.tsx
+++ b/src/pages-v2/Cart/components/CartItem.tsx
@@ -1,0 +1,75 @@
+/**
+ * 장바구니 한 줄.
+ *
+ * 좌측 72×72 accent 박스 / 가운데 제목 + 수량 컨트롤 + 삭제 / 우측 합계.
+ * 프로토타입 Cart.jsx:34-56 의 인라인 스타일을 BEM + 공용 컴포넌트로 분해.
+ *
+ * `pending`은 본 PR(R1) 한정으로 수량 mutation / 삭제 mutation 양쪽을 단일
+ * 플래그로 묶음 — § 5에서 두 흐름을 분리한 `pendingItemIds` 가드는 PR 2.
+ *
+ * 📅 날짜 라인 미렌더: `CartItemVM`에 `dateLabel` 보강 필드가 없음 (§ 1
+ * "보강 필드는 § 3·§ 9에서 결정 후 추가"). PR 2 이후 보강 전략 결정 시 추가.
+ */
+
+import { AccentMediaBox } from '@/components-v2/AccentMediaBox';
+import { Button } from '@/components-v2/Button';
+import { Card } from '@/components-v2/Card';
+import { Icon } from '@/components-v2/Icon';
+import { QuantityStepper } from '@/components-v2/QuantityStepper';
+import { accent } from '@/styles-v2/accent';
+
+import type { CartItemVM } from '../types';
+
+export interface CartItemProps {
+  item: CartItemVM;
+  onQuantityChange: (next: number) => void;
+  onRemove: () => void;
+  pending?: boolean;
+}
+
+export function CartItem({
+  item,
+  onQuantityChange,
+  onRemove,
+  pending = false,
+}: CartItemProps) {
+  const className = ['cart-item', pending && 'is-pending']
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <Card variant="solid" className={className}>
+      <AccentMediaBox
+        accent={accent(item.eventId)}
+        size="sm"
+        glyph="</>"
+        className="cart-item__media"
+      />
+      <div className="cart-item__main">
+        <div className="cart-item__title">{item.eventTitle}</div>
+        <div className="cart-item__controls">
+          <QuantityStepper
+            value={item.quantity}
+            onChange={onQuantityChange}
+            min={1}
+            size="sm"
+            disabled={pending}
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onRemove}
+            disabled={pending}
+            iconStart={<Icon name="trash" size={12} />}
+            className="cart-item__remove"
+          >
+            삭제
+          </Button>
+        </div>
+      </div>
+      <div className="cart-item__total">
+        {item.lineTotal.toLocaleString()}원
+      </div>
+    </Card>
+  );
+}

--- a/src/pages-v2/Cart/components/CartItemList.tsx
+++ b/src/pages-v2/Cart/components/CartItemList.tsx
@@ -1,0 +1,41 @@
+/**
+ * 카트 아이템 세로 스택. 각 row 의 cartItemId 를 콜백에 바인딩한다.
+ *
+ * 페이지 측 핸들러는 `(itemId, next)` / `(itemId)` 시그니처를 쓰지만 leaf
+ * `CartItem` 은 자기 itemId를 모르므로 List가 클로저로 주입.
+ *
+ * `pendingItemIds` 가드 (§ 3 / § 5)는 PR 2의 mutation 도입 시 채워짐.
+ * PR 1 단계에서도 prop 자체는 받아들여 호출자 구현이 미리 동작하도록 둠.
+ */
+
+import type { CartItemVM } from '../types';
+import { CartItem } from './CartItem';
+
+export interface CartItemListProps {
+  items: CartItemVM[];
+  onQuantityChange: (itemId: string, next: number) => void;
+  onRemove: (itemId: string) => void;
+  pendingItemIds?: Set<string>;
+}
+
+export function CartItemList({
+  items,
+  onQuantityChange,
+  onRemove,
+  pendingItemIds,
+}: CartItemListProps) {
+  return (
+    <ul className="cart-list" role="list">
+      {items.map((item) => (
+        <li key={item.cartItemId} className="cart-list__row">
+          <CartItem
+            item={item}
+            onQuantityChange={(next) => onQuantityChange(item.cartItemId, next)}
+            onRemove={() => onRemove(item.cartItemId)}
+            pending={pendingItemIds?.has(item.cartItemId) ?? false}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/pages-v2/Cart/components/CartSkeleton.tsx
+++ b/src/pages-v2/Cart/components/CartSkeleton.tsx
@@ -1,0 +1,49 @@
+/**
+ * 페이지 진입 페치 인플라이트 스켈레톤.
+ *
+ * 헤더 + 2-column 그리드(좌측 아이템 3개 / 우측 요약 카드) 골격을 그대로
+ * 유지해 success 전환 시 레이아웃 시프트 방지 (§ 6.2).
+ *
+ * BEM prefix `cart-skel-*`. 실제 placeholder shimmer/색상은
+ * styles-v2/pages/cart.css 에 정의 (EventDetailSkeleton 패턴 동일).
+ */
+
+import { Card } from '@/components-v2/Card';
+
+const ITEM_COUNT = 3;
+const SUMMARY_ROW_COUNT = 4;
+
+export function CartSkeleton() {
+  return (
+    <div className="cart-page" aria-busy="true">
+      <div className="cart-skel cart-skel-title" />
+      <div className="cart-skel cart-skel-subtitle" />
+      <div className="cart-grid">
+        <ul className="cart-list" role="list">
+          {Array.from({ length: ITEM_COUNT }, (_, i) => (
+            <li key={i} className="cart-list__row">
+              <Card variant="solid" className="cart-skel-item">
+                <div className="cart-skel cart-skel-thumb" />
+                <div className="cart-skel-item__main">
+                  <div className="cart-skel cart-skel-line cart-skel-line--title" />
+                  <div className="cart-skel cart-skel-line cart-skel-line--meta" />
+                  <div className="cart-skel cart-skel-controls" />
+                </div>
+                <div className="cart-skel cart-skel-total" />
+              </Card>
+            </li>
+          ))}
+        </ul>
+        <Card variant="solid" className="cart-summary">
+          <div className="cart-skel cart-skel-line cart-skel-line--summary-title" />
+          {Array.from({ length: SUMMARY_ROW_COUNT }, (_, i) => (
+            <div key={i} className="cart-skel cart-skel-line cart-skel-line--summary-row" />
+          ))}
+          <div className="cart-skel cart-skel-button" />
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+CartSkeleton.displayName = 'CartSkeleton';

--- a/src/pages-v2/Cart/components/EmptyCart.tsx
+++ b/src/pages-v2/Cart/components/EmptyCart.tsx
@@ -1,0 +1,32 @@
+/**
+ * 장바구니 빈 상태 카드.
+ *
+ * 공용 `EmptyState` + `Button` 조합. 네비게이션은 호출자가 `onBrowse`로 주입
+ * (페이지 컴포넌트가 react-router의 `useNavigate`를 보유하므로 leaf는 무지).
+ *
+ * § 9.2-10 결정으로 variant 분기 없이 단일 메시지. 결제 직후 빈 상태
+ * 시나리오는 결제 완료 페이지 흐름으로 흡수됨.
+ */
+
+import { Button } from '@/components-v2/Button';
+import { EmptyState } from '@/components-v2/EmptyState';
+
+export interface EmptyCartProps {
+  onBrowse: () => void;
+}
+
+export function EmptyCart({ onBrowse }: EmptyCartProps) {
+  return (
+    <EmptyState
+      className="cart-empty"
+      emoji="🛒"
+      title="장바구니가 비어있습니다"
+      message="마음에 드는 이벤트를 찾아 티켓을 담아보세요."
+      action={
+        <Button variant="primary" onClick={onBrowse}>
+          이벤트 둘러보기
+        </Button>
+      }
+    />
+  );
+}

--- a/src/pages-v2/Cart/components/OrderSummary.tsx
+++ b/src/pages-v2/Cart/components/OrderSummary.tsx
@@ -1,0 +1,69 @@
+/**
+ * 우측 sticky 주문 요약 카드.
+ *
+ * 합계 / 수수료 / 할인 라인 + 구분선 + 총 결제금액 + 결제하기 버튼 + 약관 caption.
+ * 프로토타입 Cart.jsx:60-74 의 인라인 스타일을 BEM 으로 변환.
+ *
+ * 금액 산출(subtotal/fee/discount/total)은 호출자(adapters/hooks) 책임.
+ * 본 컴포넌트는 표시만 담당.
+ *
+ * PR 1: `disabled` 가 페이지에서 true 로 강제됨 (실제 결제 흐름은 PR 3).
+ * `submitting` 은 PR 3 에서 `useCheckout` 도입 후 활성화.
+ */
+
+import { Button } from '@/components-v2/Button';
+import { Card } from '@/components-v2/Card';
+
+import { SummaryRow } from './SummaryRow';
+
+export interface OrderSummaryProps {
+  subtotal: number;
+  fee: number;
+  discount: number;
+  total: number;
+  onCheckout: () => void;
+  submitting?: boolean;
+  disabled?: boolean;
+}
+
+const formatWon = (n: number): string => `${n.toLocaleString()}원`;
+
+export function OrderSummary({
+  subtotal,
+  fee,
+  discount,
+  total,
+  onCheckout,
+  submitting = false,
+  disabled = false,
+}: OrderSummaryProps) {
+  return (
+    <Card variant="solid" className="cart-summary">
+      <h3 className="cart-summary__title">주문 요약</h3>
+
+      <SummaryRow label="상품 합계" value={formatWon(subtotal)} />
+      <SummaryRow label="수수료" value={formatWon(fee)} />
+      <SummaryRow label="할인" value={formatWon(discount)} />
+
+      <div className="cart-summary__divider" role="separator" />
+
+      <SummaryRow label="총 결제금액" value={formatWon(total)} bold />
+
+      <Button
+        variant="primary"
+        size="lg"
+        full
+        loading={submitting}
+        disabled={disabled}
+        onClick={onCheckout}
+        className="cart-summary__checkout"
+      >
+        결제하기
+      </Button>
+
+      <p className="cart-summary__caption">
+        결제 후 티켓은 즉시 발급되며, 행사 7일 전까지 전액 환불이 가능합니다.
+      </p>
+    </Card>
+  );
+}

--- a/src/pages-v2/Cart/components/SummaryRow.tsx
+++ b/src/pages-v2/Cart/components/SummaryRow.tsx
@@ -1,0 +1,27 @@
+/**
+ * 주문 요약(`OrderSummary`) 내부 한 줄 — 라벨 / 값 페어.
+ *
+ * 프로토타입 `Row` (Cart.jsx:89-95)의 인라인 스타일을 BEM 클래스로 변환.
+ * 시각 토큰: 일반 13.5px / text-2, bold 15px / text + fontWeight 700,
+ * marginBottom 8 (CSS는 styles-v2/pages/cart.css에 정의).
+ *
+ * `value`는 string으로 받아 포맷 책임을 호출자에게 둔다 (예: `total.toLocaleString() + '원'`).
+ */
+
+export interface SummaryRowProps {
+  label: string;
+  value: string;
+  bold?: boolean;
+}
+
+export function SummaryRow({ label, value, bold = false }: SummaryRowProps) {
+  const className = ['cart-summary-row', bold && 'cart-summary-row--bold']
+    .filter(Boolean)
+    .join(' ');
+  return (
+    <div className={className}>
+      <span className="cart-summary-row__label">{label}</span>
+      <span className="cart-summary-row__value">{value}</span>
+    </div>
+  );
+}

--- a/src/pages-v2/Cart/hooks.ts
+++ b/src/pages-v2/Cart/hooks.ts
@@ -1,0 +1,18 @@
+/**
+ * Cart 페이지 훅.
+ *
+ * **PR 1 placeholder** — `useCart` 만 정의하며 항상 `{ status: 'loading' }` 을 반환.
+ * 실제 `getCart()` 페치 / 캐시 / refetch 는 PR 2 에서 본문 교체 (시그니처 유지).
+ * `useCartMutations` (수량/삭제) 와 `useCheckout` (주문/결제 트리거) 도 PR 2·3 에서 추가.
+ *
+ * 시그니처를 미리 노출하는 이유: 컨테이너(`index.tsx`)가 PR 2 로 넘어가도
+ * import 문 변경 없이 본문 교체만으로 동작하도록.
+ *
+ * Cart.plan.md § 3 / § 10.1.
+ */
+
+import type { CartQuery } from './types';
+
+export function useCart(): CartQuery {
+  return { status: 'loading' };
+}

--- a/src/pages-v2/Cart/index.tsx
+++ b/src/pages-v2/Cart/index.tsx
@@ -1,0 +1,35 @@
+/**
+ * Cart 페이지 컨테이너 — 라우트 진입점.
+ *
+ * 책임 (Cart.plan.md § 1):
+ * - 데이터 페치: `useCart()` (PR 1 placeholder; PR 2 에서 실제 GET /cart 로 교체)
+ * - 네비게이션: `useNavigate` 보유 → `onBrowse`/(PR 2 이후) `onQuantityChange/onRemove/onCheckout` 콜백을 leaf 페이지에 주입
+ * - 인증 가드: `App.tsx` 의 `<RequireAuth>` 가 라우트 진입 차단 (§ 8.2) → 본 컨테이너는 무지
+ *
+ * **PR 1 한정**: `useCart()` 가 항상 `loading` 을 반환하므로 mutation 콜백
+ * (`onQuantityChange/onRemove/onCheckout`) 은 사용자에게 도달하지 않음.
+ * 시그니처 보장을 위해 no-op 으로 박아두며, PR 2/3 에서 실제 mutation 으로 교체.
+ */
+
+import { useNavigate } from 'react-router-dom';
+
+import { Cart } from './Cart';
+import { useCart } from './hooks';
+
+const noop = () => {};
+
+export default function CartPage() {
+  const navigate = useNavigate();
+  const query = useCart();
+
+  return (
+    <Cart
+      query={query}
+      onQuantityChange={noop}
+      onRemove={noop}
+      onCheckout={noop}
+      onBrowse={() => navigate('/events')}
+      checkoutState="idle"
+    />
+  );
+}

--- a/src/pages-v2/Cart/types.ts
+++ b/src/pages-v2/Cart/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Cart 페이지 v2 타입.
+ *
+ * 설계 근거: docs/redesign/Cart.plan.md
+ *  - § 1 (디렉토리 구조 / 신규 정의가 필요한 이유)
+ *  - § 3 (서버 only · CartQuery 디스크리미네이티드 유니온)
+ *  - § 9.2-18 (클라 stock 상한 가드 미사용 → max 필드 부재)
+ *
+ * `CartItemVM`은 API `CartItemDetail`로부터 직접 만들 수 있는 최소 필드만 정의.
+ * 보강 필드(`accentIndex`, `dateLabel`)는 색상은 `accent(eventId)` 유틸로 런타임 산출,
+ * 날짜 라벨은 API가 내려주지 않으므로 PR 2 이후 별도 보강 전략에서 결정.
+ */
+
+export interface CartItemVM {
+  cartItemId: string;
+  eventId: string;
+  eventTitle: string;
+  unitPrice: number;
+  quantity: number;
+  lineTotal: number;
+}
+
+export interface CartVM {
+  cartId: string | null;
+  items: CartItemVM[];
+  subtotal: number;
+  fee: number;
+  discount: number;
+  total: number;
+}
+
+/**
+ * 페이지 진입 페치 상태. mutation 인플라이트(`pendingItemIds`)와
+ * 결제 진행(`checkoutState`)는 별도 페이지 로컬 상태로 다룬다 (§ 3, § 5).
+ */
+export type CartQuery =
+  | { status: 'loading'; previous?: CartVM }
+  | { status: 'success'; data: CartVM; fetchedAt: number }
+  | { status: 'error'; error: unknown; previous?: CartVM };

--- a/src/pages-v2/EventDetail/adapters.ts
+++ b/src/pages-v2/EventDetail/adapters.ts
@@ -3,6 +3,11 @@ import { toStatus, toDateTimeLabels, isFree, isLowStock } from '@/pages-v2/_shar
 import type { EventStatus } from '@/types-v2/event';
 import type { EventDetailVM } from './types';
 
+/**
+ * 추천 카드 어댑터(`RecommendedCardVM`, `toRecommendedCards`, ...)는
+ * `@/pages-v2/_shared/recommendation`으로 승격됨 (Cart 와 공유 — Cart.plan.md § 9.2-17).
+ */
+
 const toTechStackNames = (items: TechStackItem[]): string[] =>
   items.map((t) => t.name);
 
@@ -35,57 +40,3 @@ export const toEventDetailVM = (api: EventDetailResponse): EventDetailVM => {
   };
 };
 
-/* Recommended events (§3 표 2-B). Narrow types live here — `src/api/types.ts`
- * has no formal RecommendationResponse and SPEC §0 keeps the api/types
- * file untouched. */
-
-export interface RawRecommendedEvent {
-  eventId: string;
-  title: string;
-  price?: number;
-  eventDateTime?: string;
-  category?: string;
-}
-
-export interface RecommendationResponse {
-  events?: RawRecommendedEvent[];
-}
-
-export interface RecommendedCardVM {
-  eventId: string;
-  title: string;
-  category: string;
-  price: number;
-  isFree: boolean;
-  eventDateTime?: string;
-  dateLabel: string;
-}
-
-const RECOMMEND_LIMIT = 5;
-const FALLBACK_CATEGORY = '추천';
-const FALLBACK_DATE_LABEL = '일정 확인';
-
-const toRecommendedCardVM = (raw: RawRecommendedEvent): RecommendedCardVM => {
-  const price = raw.price ?? 0;
-  const dateLabel = raw.eventDateTime
-    ? (toDateTimeLabels(raw.eventDateTime).dateLabel || FALLBACK_DATE_LABEL)
-    : FALLBACK_DATE_LABEL;
-  return {
-    eventId: raw.eventId,
-    title: raw.title,
-    category: raw.category ?? FALLBACK_CATEGORY,
-    price,
-    isFree: isFree(price),
-    eventDateTime: raw.eventDateTime,
-    dateLabel,
-  };
-};
-
-export const toRecommendedCards = (
-  api: RecommendationResponse,
-  currentEventId: string,
-): RecommendedCardVM[] =>
-  (api.events ?? [])
-    .filter((e) => e.eventId !== currentEventId)
-    .slice(0, RECOMMEND_LIMIT)
-    .map(toRecommendedCardVM);

--- a/src/pages-v2/EventDetail/components/RecommendedCard.tsx
+++ b/src/pages-v2/EventDetail/components/RecommendedCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 
-import type { RecommendedCardVM } from '../adapters';
+import type { RecommendedCardVM } from '@/pages-v2/_shared/recommendation';
 
 export interface RecommendedCardProps {
   vm: RecommendedCardVM;

--- a/src/pages-v2/EventDetail/components/RecommendedSection.tsx
+++ b/src/pages-v2/EventDetail/components/RecommendedSection.tsx
@@ -1,6 +1,6 @@
 import { SectionHead } from '@/components-v2/SectionHead';
 
-import type { RecommendedCardVM } from '../adapters';
+import type { RecommendedCardVM } from '@/pages-v2/_shared/recommendation';
 import { RecommendedCard } from './RecommendedCard';
 
 export interface RecommendedSectionProps {

--- a/src/pages-v2/EventDetail/hooks.ts
+++ b/src/pages-v2/EventDetail/hooks.ts
@@ -9,11 +9,12 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/contexts/ToastContext';
 
 import {
-  toEventDetailVM,
   toRecommendedCards,
   type RecommendationResponse,
   type RecommendedCardVM,
-} from './adapters';
+} from '@/pages-v2/_shared/recommendation';
+
+import { toEventDetailVM } from './adapters';
 import type { EventDetailQuery, EventDetailVM } from './types';
 
 const STALE_MS = 60_000;

--- a/src/pages-v2/_shared/recommendation.ts
+++ b/src/pages-v2/_shared/recommendation.ts
@@ -1,0 +1,63 @@
+/**
+ * Recommended events 어댑터.
+ *
+ * EventDetail 와 Cart 두 페이지가 `recommendEvents()` 응답을 공유하므로
+ * `_shared/`로 승격 (Cart.plan.md § 1, § 9.2-17, § 10.1 step 3).
+ *
+ * `src/api/types.ts`에 동명 `RecommendationResponse`가 있지만 그것은
+ * `{ userId, eventIdList }` 형태(다른 엔드포인트 가정). 본 모듈은
+ * EventDetail/Cart 가 실제 사용하는 narrow 응답 형태를 별도로 정의한다.
+ */
+
+import { toDateTimeLabels, isFree } from './eventFormat';
+
+export interface RawRecommendedEvent {
+  eventId: string;
+  title: string;
+  price?: number;
+  eventDateTime?: string;
+  category?: string;
+}
+
+export interface RecommendationResponse {
+  events?: RawRecommendedEvent[];
+}
+
+export interface RecommendedCardVM {
+  eventId: string;
+  title: string;
+  category: string;
+  price: number;
+  isFree: boolean;
+  eventDateTime?: string;
+  dateLabel: string;
+}
+
+const RECOMMEND_LIMIT = 5;
+const FALLBACK_CATEGORY = '추천';
+const FALLBACK_DATE_LABEL = '일정 확인';
+
+const toRecommendedCardVM = (raw: RawRecommendedEvent): RecommendedCardVM => {
+  const price = raw.price ?? 0;
+  const dateLabel = raw.eventDateTime
+    ? (toDateTimeLabels(raw.eventDateTime).dateLabel || FALLBACK_DATE_LABEL)
+    : FALLBACK_DATE_LABEL;
+  return {
+    eventId: raw.eventId,
+    title: raw.title,
+    category: raw.category ?? FALLBACK_CATEGORY,
+    price,
+    isFree: isFree(price),
+    eventDateTime: raw.eventDateTime,
+    dateLabel,
+  };
+};
+
+export const toRecommendedCards = (
+  api: RecommendationResponse,
+  currentEventId: string,
+): RecommendedCardVM[] =>
+  (api.events ?? [])
+    .filter((e) => e.eventId !== currentEventId)
+    .slice(0, RECOMMEND_LIMIT)
+    .map(toRecommendedCardVM);

--- a/src/styles-v2/index.css
+++ b/src/styles-v2/index.css
@@ -25,3 +25,4 @@
 /* Page-level styles. One file per page route. */
 @import './pages/login.css';
 @import './pages/event-detail.css';
+@import './pages/cart.css';

--- a/src/styles-v2/pages/cart.css
+++ b/src/styles-v2/pages/cart.css
@@ -1,0 +1,228 @@
+/* DevTicket v2 — Cart page styles
+   Source: docs/redesign/prototype/Cart.jsx + docs/redesign/Cart.plan.md
+   Scope: classes prefixed with `cart-` are local to /cart (v2). */
+
+/* ── Page container ───────────────────────────────────────────────── */
+.cart-page {
+  max-width: 980px;
+}
+
+/* ── Header (§2 CartHeader) ───────────────────────────────────────── */
+.cart-header {
+  margin-bottom: 22px;
+}
+.cart-header__title {
+  font-family: var(--font);
+  font-size: var(--fs-h1);
+  font-weight: var(--fw-bold);
+  color: var(--text);
+  margin: 0 0 6px;
+}
+.cart-header__subtitle {
+  font-family: var(--font);
+  font-size: var(--fs-base);
+  color: var(--text-3);
+  margin: 0;
+}
+
+/* ── Grid (§2 Cart) — 2-column main + sticky right ────────────────── */
+.cart-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 20px;
+  align-items: start;
+}
+@media (max-width: 640px) {
+  .cart-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+/* ── Item list (§2 CartItemList) ──────────────────────────────────── */
+.cart-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+.cart-list__row {
+  min-width: 0;
+}
+
+/* ── CartItem (§2 CartItem) — flex 3-column row ───────────────────── */
+.cart-item {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  transition: opacity var(--dur-base) var(--ease);
+}
+.cart-item.is-pending {
+  opacity: 0.6;
+  pointer-events: none;
+}
+.cart-item__media {
+  flex-shrink: 0;
+}
+.cart-item__main {
+  flex: 1;
+  min-width: 0;
+}
+.cart-item__title {
+  font-family: var(--font);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
+  color: var(--text);
+  margin-bottom: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cart-item__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.cart-item__remove {
+  margin-left: auto;
+}
+.cart-item__total {
+  font-family: var(--font);
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-bold);
+  color: var(--text);
+  text-align: right;
+  min-width: 96px;
+  flex-shrink: 0;
+}
+
+/* ── Empty / Error ────────────────────────────────────────────────── */
+.cart-empty {
+  padding: 40px;
+}
+.cart-error {
+  padding: 24px;
+  text-align: center;
+  color: var(--text-2);
+  font-family: var(--font);
+  font-size: var(--fs-base);
+}
+.cart-error p {
+  margin: 0;
+}
+
+/* ── OrderSummary (§2 OrderSummary) ───────────────────────────────── */
+.cart-summary {
+  position: sticky;
+  top: 12px;
+  padding: 20px;
+}
+.cart-summary__title {
+  font-family: var(--font);
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-semibold);
+  color: var(--text);
+  margin: 0 0 14px;
+}
+.cart-summary__divider {
+  height: 1px;
+  background: var(--border);
+  margin: 14px 0;
+}
+.cart-summary__checkout {
+  margin-top: 16px;
+}
+.cart-summary__caption {
+  margin: 10px 0 0;
+  font-family: var(--font);
+  font-size: var(--fs-xs);
+  color: var(--text-3);
+  line-height: var(--lh-body);
+}
+
+/* ── SummaryRow (§2 SummaryRow) ───────────────────────────────────── */
+.cart-summary-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--font);
+  font-size: 13.5px;
+  color: var(--text-2);
+  font-weight: var(--fw-regular);
+  margin-bottom: 8px;
+}
+.cart-summary-row--bold {
+  font-size: var(--fs-md);
+  color: var(--text);
+  font-weight: var(--fw-bold);
+}
+
+/* ── Skeleton (§6.2 CartSkeleton) — mirrors layout to prevent shift ── */
+@keyframes cart-skel-shimmer {
+  0%   { opacity: 0.55; }
+  50%  { opacity: 1; }
+  100% { opacity: 0.55; }
+}
+.cart-skel {
+  background: var(--surface-3);
+  border-radius: var(--r-sm);
+  animation: cart-skel-shimmer 1.4s ease-in-out infinite;
+}
+.cart-skel-title {
+  height: 28px;
+  width: 30%;
+  margin-bottom: 10px;
+}
+.cart-skel-subtitle {
+  height: 14px;
+  width: 55%;
+  margin-bottom: 22px;
+}
+.cart-skel-item {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+}
+.cart-skel-thumb {
+  width: 72px;
+  height: 72px;
+  border-radius: var(--r-md);
+  flex-shrink: 0;
+}
+.cart-skel-item__main {
+  flex: 1;
+  min-width: 0;
+}
+.cart-skel-line {
+  height: 14px;
+  margin-bottom: 8px;
+}
+.cart-skel-line--title { width: 70%; }
+.cart-skel-line--meta  { width: 40%; }
+.cart-skel-line--summary-title {
+  height: 16px;
+  width: 40%;
+  margin-bottom: 14px;
+}
+.cart-skel-line--summary-row {
+  height: 13px;
+  width: 100%;
+  margin-bottom: 10px;
+}
+.cart-skel-controls {
+  height: 28px;
+  width: 60%;
+  margin-top: 10px;
+}
+.cart-skel-total {
+  height: 18px;
+  width: 80px;
+  flex-shrink: 0;
+}
+.cart-skel-button {
+  height: 44px;
+  border-radius: var(--r-md);
+  margin-top: 16px;
+}


### PR DESCRIPTION
## Summary
Implements the Cart page v2 with complete UI components, styling, and data flow structure. This PR establishes the page layout, loading states, and component hierarchy as specified in the Cart redesign plan, with placeholder hooks for data fetching and mutations to be filled in subsequent PRs.

## Key Changes

### New Cart Page Components
- **Cart.tsx**: Main presentation component handling loading/error/empty/success states with a 2-column grid layout (items list + sticky order summary)
- **CartHeader.tsx**: Page title and item count subtitle
- **CartItemList.tsx**: Vertical stack of cart items with quantity/remove callbacks
- **CartItem.tsx**: Individual cart line item with accent media box, title, quantity stepper, delete button, and line total
- **OrderSummary.tsx**: Sticky right-side summary card with subtotal/fee/discount/total rows and checkout button (disabled in PR 1)
- **SummaryRow.tsx**: Reusable label/value pair component for order summary rows
- **EmptyCart.tsx**: Empty state with emoji and browse action
- **CartSkeleton.tsx**: Layout-preserving skeleton loader mirroring the full page structure

### Styling
- **cart.css** (228 lines): Complete BEM-based styling for all cart components including:
  - 2-column responsive grid (collapses to single column on mobile)
  - Skeleton shimmer animation
  - Pending state opacity transitions
  - Sticky positioning for order summary
  - Typography and spacing tokens

### Type System
- **types.ts**: Defines `CartItemVM`, `CartVM`, and `CartQuery` discriminated union for loading/success/error states
- Minimal field set aligned with API capabilities (no stock limits, date labels deferred to PR 2)

### Hooks & Adapters
- **hooks.ts**: Placeholder `useCart()` returning loading state (to be replaced with actual GET /cart in PR 2)
- **recommendation.ts** (new shared module): Extracted `RecommendedCardVM`, `toRecommendedCards()` from EventDetail adapters for reuse across pages

### Integration
- **index.tsx**: Container component with navigation and no-op mutation callbacks (to be wired in PR 2/3)
- Updated App.tsx to lazy-load Cart page
- Updated EventDetail imports to use shared recommendation module
- Added cart.css to global stylesheet

## Notable Implementation Details

- **PR 1 Constraints**: Checkout button hardcoded as disabled; mutation callbacks are no-ops; `useCart()` always returns loading state
- **Layout Stability**: Skeleton maintains exact grid/flex structure to prevent CLS on data load
- **Pending States**: Single `pendingItemIds` Set guards both quantity and delete mutations (to be split in PR 2)
- **Shared Recommendation Logic**: Extracted to `_shared/` module to support both EventDetail and Cart pages per redesign plan
- **BEM Naming**: All cart-specific classes prefixed with `cart-` for local scope isolation
- **Accessibility**: Semantic HTML (header, ul/li, role="list"), aria-busy on skeleton, role="separator" on divider

https://claude.ai/code/session_01NBdkPC2yV278ojX9kLZMdd