### PR TITLE
Implement Cart mutations and checkout flow (PR 2)

### DIFF
--- a/src/pages-v2/Cart/Cart.tsx
+++ b/src/pages-v2/Cart/Cart.tsx
@@ -5,9 +5,11 @@
  * 화면 컴포지션으로 변환. 데이터 페치/뮤테이션/네비게이션은 모두 컨테이너
  * (`index.tsx`)가 담당하며, 본 컴포넌트는 props 만 받아 렌더한다.
  *
- * PR 1 한정:
- * - 결제 버튼은 항상 disabled (`useCheckout` 도입은 PR 3).
- * - 에러 분기는 minimal 메시지. PR 2 에서 `onRetry`/`describeError` 패턴 도입.
+ * PR 2 부터:
+ * - `useCheckout` 도입 → 결제 버튼 disabled 강제 해제 (`submitting` 상태만 반영).
+ * - `pendingItemIds` 는 `useCartMutations` 가 채움 → row 단위 가드 활성.
+ *
+ * PR 3 예정: 에러 분기에 `onRetry` 버튼 + `describeError` 패턴 도입.
  */
 
 import type { ReactNode } from 'react';
@@ -104,8 +106,6 @@ export function Cart({
           total={cart.total}
           onCheckout={onCheckout}
           submitting={checkoutState === 'submitting'}
-          /* PR 1: 결제 흐름 미도입 → 항상 disabled. PR 3 에서 제거. */
-          disabled
         />
       </div>
     </PageShell>

--- a/src/pages-v2/Cart/adapters.ts
+++ b/src/pages-v2/Cart/adapters.ts
@@ -1,0 +1,97 @@
+/**
+ * Cart 페이지 어댑터 — API DTO ↔ 페이지 VM 변환.
+ *
+ * 설계 근거: docs/redesign/Cart.plan.md
+ *  - § 4 어댑트 매핑 (요약) 표
+ *  - § 4 표 1 (`updateCartItemQuantity` 응답은 `{ cartItemId, quantity }` 만 → 부분 머지)
+ *  - § 4 표 2 (`createOrder` → `OrderResponse`)
+ *  - § 1 (`CartVM.fee`/`discount`는 현재 백엔드 필드 부재 → 0 으로 채움. 향후 보강은 별도 PR)
+ *
+ * 이 파일은 부수효과·네트워크 호출을 포함하지 않는다.
+ * `useCart`/`useCartMutations`/`useCheckout` (hooks.ts) 가 응답을 이 함수들로 흘려보낸다.
+ */
+import type {
+  CartItemDetail,
+  CartItemQuantityResponse,
+  CartResponse,
+  OrderResponse,
+} from '@/api/types';
+
+import type { CartItemVM, CartVM, OrderResultVM } from './types';
+
+/**
+ * `CartItemDetail` → `CartItemVM`.
+ * `lineTotal = price * quantity` 파생. API는 라인 합을 내려주지 않는다.
+ */
+export const toCartItemVM = (api: CartItemDetail): CartItemVM => ({
+  cartItemId: api.cartItemId,
+  eventId: api.eventId,
+  eventTitle: api.eventTitle,
+  unitPrice: api.price,
+  quantity: api.quantity,
+  lineTotal: api.price * api.quantity,
+});
+
+/**
+ * `CartResponse` → `CartVM`.
+ *
+ * - `subtotal = res.totalAmount` (§ 4 어댑트 매핑 표 — 백엔드 합계 신뢰)
+ * - `fee` / `discount`: 백엔드 미제공 → 0. `total = subtotal`.
+ *   추후 백엔드가 fee/discount 를 내려주면 본 함수만 갱신.
+ */
+export const toCartVM = (res: CartResponse): CartVM => {
+  const fee = 0;
+  const discount = 0;
+  const subtotal = res.totalAmount;
+  return {
+    cartId: res.cartId,
+    items: res.items.map(toCartItemVM),
+    subtotal,
+    fee,
+    discount,
+    total: subtotal + fee - discount,
+  };
+};
+
+/**
+ * `updateCartItemQuantity` 응답(`{ cartItemId, quantity }`)을 직전 `CartVM` 에 부분 머지.
+ *
+ * - 매칭 키: 응답 `cartItemId` 가 `number` (api/types.ts), VM 측은 `string`.
+ *   → `String()` 으로 강제 변환 후 비교 (백엔드 타입 정정 시 본 함수만 단순화).
+ * - 일치하는 row 가 없으면 prev 그대로 (낙관적 업데이트가 이미 사라진 row 에 대한 응답일 때 안전 동작).
+ * - 라인 합/합계 재계산: `lineTotal`, `subtotal`, `total` 모두 새 quantity 기준으로 다시 산출.
+ */
+export const mergeQuantityUpdate = (
+  prev: CartVM,
+  res: CartItemQuantityResponse,
+): CartVM => {
+  const targetId = String(res.cartItemId);
+  const idx = prev.items.findIndex((i) => i.cartItemId === targetId);
+  if (idx === -1) return prev;
+
+  const target = prev.items[idx];
+  const nextItem: CartItemVM = {
+    ...target,
+    quantity: res.quantity,
+    lineTotal: target.unitPrice * res.quantity,
+  };
+  const items = prev.items.slice();
+  items[idx] = nextItem;
+
+  const subtotal = items.reduce((sum, i) => sum + i.lineTotal, 0);
+  return {
+    ...prev,
+    items,
+    subtotal,
+    total: subtotal + prev.fee - prev.discount,
+  };
+};
+
+/**
+ * `OrderResponse` → `OrderResultVM` (PaymentModal 입력용 최소 필드).
+ * § 4 표 2: `createOrder` 응답은 `ApiResponse<OrderResponse>` 래퍼로 옴 → 본 함수는 unwrap 이후 호출.
+ */
+export const toOrderResultVM = (res: OrderResponse): OrderResultVM => ({
+  orderId: res.orderId,
+  totalAmount: res.totalAmount,
+});

--- a/src/pages-v2/Cart/hooks.ts
+++ b/src/pages-v2/Cart/hooks.ts
@@ -1,29 +1,40 @@
 /**
  * Cart 페이지 훅.
  *
- * Cart.plan.md § 3 / § 10.2.
+ * Cart.plan.md § 3 / § 5 / § 10.2.
  *
- * - `useCart` — 마운트 시 1회 `getCart()` → `toCartVM` → `CartQuery` 상태 머신
- *   (loading / success / error). `refetch()` 노출.
- * - `useCartMutations` / `useCheckout` 는 후속 커밋에서 추가.
+ * - `useCart` — 마운트 시 1회 `getCart()` → `toCartVM` → `CartQuery` 상태 머신.
+ *   `refetch()` 와 `mutate(updater)` 를 노출. `mutate` 는 `useCartMutations` 가
+ *   낙관적 업데이트/롤백 시 데이터 차원만 갱신하기 위해 쓴다 (`fetchedAt` 보존).
+ * - `useCartMutations` — `pendingItemIds: Set<string>` 가드 + PATCH/DELETE 낙관적
+ *   업데이트 + 실패 시 snapshot 롤백 + 409 시 `refetch()` 1 회 호출.
+ *   `addCartItem` 은 EventDetail/`usePurchaseActions` 에서 처리하므로 여기 미포함.
+ * - `useCheckout` 는 후속 커밋에서 추가.
  *
- * 페치 실패 시 401/403/PROFILE_NOT_COMPLETED 는 `apiClient` 인터셉터가
- * 페이지 도달 전에 처리하므로 본 훅은 그 외 케이스만 `error` 로 분기 (§ 4 표 4).
- *
- * 반환 타입은 `CartQuery & { refetch }` — `useEventDetail` 와 동일 패턴.
- * 프레젠테이션(`<Cart query={...} />`)에 그대로 전달 가능하며, mutation/checkout
- * 훅이 `status === 'success'` 분기로 `data` 에 접근.
+ * 401/403/PROFILE_NOT_COMPLETED 는 `apiClient` 인터셉터가 페이지 도달 전에
+ * 처리하므로 본 훅들은 그 외 케이스만 분기 (§ 4 표 4).
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import axios from 'axios';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { getCart } from '@/api/cart.api';
+import { deleteCartItem, getCart, updateCartItemQuantity } from '@/api/cart.api';
 import { unwrapApiData } from '@/api/client';
+import { useToast } from '@/contexts/ToastContext';
 
-import { toCartVM } from './adapters';
-import type { CartQuery, CartVM } from './types';
+import { mergeQuantityUpdate, toCartVM } from './adapters';
+import type { CartItemVM, CartQuery, CartVM } from './types';
 
-export type UseCartReturn = CartQuery & { refetch: () => void };
+// ── useCart ──────────────────────────────────────────────────────────────────
+
+export type UseCartReturn = CartQuery & {
+  refetch: () => void;
+  /**
+   * `success` 일 때만 의미 있는 데이터 차원 갱신. `fetchedAt` 등 메타는 유지.
+   * mutation 훅이 낙관적 업데이트/응답 머지/롤백에서 사용.
+   */
+  mutate: (updater: (prev: CartVM) => CartVM) => void;
+};
 
 const previousFrom = (prev: CartQuery): CartVM | undefined => {
   if (prev.status === 'success') return prev.data;
@@ -60,5 +71,135 @@ export function useCart(): UseCartReturn {
     setRefreshTick((n) => n + 1);
   }, []);
 
-  return { ...state, refetch };
+  const mutate = useCallback((updater: (prev: CartVM) => CartVM) => {
+    setState((prev) =>
+      prev.status === 'success'
+        ? { ...prev, data: updater(prev.data) }
+        : prev,
+    );
+  }, []);
+
+  return { ...state, refetch, mutate };
+}
+
+// ── useCartMutations ─────────────────────────────────────────────────────────
+
+const recomputeTotals = (items: CartItemVM[], fee: number, discount: number) => {
+  const subtotal = items.reduce((sum, i) => sum + i.lineTotal, 0);
+  return { subtotal, total: subtotal + fee - discount };
+};
+
+const applyQuantityDelta = (
+  prev: CartVM,
+  cartItemId: string,
+  delta: number,
+): CartVM => {
+  const idx = prev.items.findIndex((i) => i.cartItemId === cartItemId);
+  if (idx === -1) return prev;
+  const target = prev.items[idx];
+  const nextQty = target.quantity + delta;
+  if (nextQty < 1) return prev;
+  const items = prev.items.slice();
+  items[idx] = {
+    ...target,
+    quantity: nextQty,
+    lineTotal: target.unitPrice * nextQty,
+  };
+  return { ...prev, items, ...recomputeTotals(items, prev.fee, prev.discount) };
+};
+
+const applyRemove = (prev: CartVM, cartItemId: string): CartVM => {
+  const items = prev.items.filter((i) => i.cartItemId !== cartItemId);
+  if (items.length === prev.items.length) return prev;
+  return { ...prev, items, ...recomputeTotals(items, prev.fee, prev.discount) };
+};
+
+const isStatus = (err: unknown, status: number): boolean =>
+  axios.isAxiosError(err) && err.response?.status === status;
+
+export interface UseCartMutationsReturn {
+  pendingItemIds: Set<string>;
+  setQuantityDelta: (cartItemId: string, delta: 1 | -1) => Promise<void>;
+  removeItem: (cartItemId: string) => Promise<void>;
+}
+
+export function useCartMutations(cart: UseCartReturn): UseCartMutationsReturn {
+  const { toast } = useToast();
+  const [pendingItemIds, setPendingItemIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  /** 가드를 동기적으로 읽기 위한 mirror — setState 비동기성으로 인한 동시 클릭 race 방지. */
+  const pendingRef = useRef<Set<string>>(pendingItemIds);
+
+  const lockItem = useCallback((id: string) => {
+    pendingRef.current = new Set(pendingRef.current).add(id);
+    setPendingItemIds(pendingRef.current);
+  }, []);
+  const unlockItem = useCallback((id: string) => {
+    const next = new Set(pendingRef.current);
+    next.delete(id);
+    pendingRef.current = next;
+    setPendingItemIds(next);
+  }, []);
+
+  const handleError = useCallback(
+    (err: unknown, fallbackMsg: string) => {
+      if (isStatus(err, 409)) {
+        cart.refetch();
+        toast('재고 상태가 변경되었습니다. 장바구니를 다시 불러옵니다.', 'error');
+        return;
+      }
+      // 401/403/PROFILE_NOT_COMPLETED 는 인터셉터가 처리 → 도달하지 않음 가정.
+      toast(fallbackMsg, 'error');
+    },
+    [cart, toast],
+  );
+
+  const setQuantityDelta = useCallback(
+    async (cartItemId: string, delta: 1 | -1): Promise<void> => {
+      if (pendingRef.current.has(cartItemId)) return;
+      if (cart.status !== 'success') return;
+      const snapshot = cart.data;
+      // min=1 가드 (서버에 -1 보내 422 받기 전에 클라에서 차단)
+      const target = snapshot.items.find((i) => i.cartItemId === cartItemId);
+      if (!target) return;
+      if (delta === -1 && target.quantity <= 1) return;
+
+      lockItem(cartItemId);
+      cart.mutate((prev) => applyQuantityDelta(prev, cartItemId, delta));
+      try {
+        const res = await updateCartItemQuantity(cartItemId, { quantity: delta });
+        cart.mutate((prev) => mergeQuantityUpdate(prev, res.data));
+      } catch (err) {
+        cart.mutate(() => snapshot);
+        handleError(err, '수량을 변경하지 못했습니다.');
+      } finally {
+        unlockItem(cartItemId);
+      }
+    },
+    [cart, handleError, lockItem, unlockItem],
+  );
+
+  const removeItem = useCallback(
+    async (cartItemId: string): Promise<void> => {
+      if (pendingRef.current.has(cartItemId)) return;
+      if (cart.status !== 'success') return;
+      const snapshot = cart.data;
+
+      lockItem(cartItemId);
+      cart.mutate((prev) => applyRemove(prev, cartItemId));
+      try {
+        await deleteCartItem(cartItemId);
+        // DELETE 응답은 { success } 만 → 추가 머지 없음. 낙관적 상태 유지.
+      } catch (err) {
+        cart.mutate(() => snapshot);
+        handleError(err, '삭제하지 못했습니다.');
+      } finally {
+        unlockItem(cartItemId);
+      }
+    },
+    [cart, handleError, lockItem, unlockItem],
+  );
+
+  return { pendingItemIds, setQuantityDelta, removeItem };
 }

--- a/src/pages-v2/Cart/hooks.ts
+++ b/src/pages-v2/Cart/hooks.ts
@@ -1,7 +1,7 @@
 /**
  * Cart 페이지 훅.
  *
- * Cart.plan.md § 3 / § 5 / § 10.2.
+ * Cart.plan.md § 3 / § 5 / § 7 / § 10.2.
  *
  * - `useCart` — 마운트 시 1회 `getCart()` → `toCartVM` → `CartQuery` 상태 머신.
  *   `refetch()` 와 `mutate(updater)` 를 노출. `mutate` 는 `useCartMutations` 가
@@ -9,7 +9,8 @@
  * - `useCartMutations` — `pendingItemIds: Set<string>` 가드 + PATCH/DELETE 낙관적
  *   업데이트 + 실패 시 snapshot 롤백 + 409 시 `refetch()` 1 회 호출.
  *   `addCartItem` 은 EventDetail/`usePurchaseActions` 에서 처리하므로 여기 미포함.
- * - `useCheckout` 는 후속 커밋에서 추가.
+ * - `useCheckout` — `createOrder` (POST `/orders`) + `idempotencyConfig()` 헤더 부착.
+ *   성공 시 `paymentTarget(OrderResultVM)` 노출 → 컨테이너가 `<PaymentModal>` 마운트.
  *
  * 401/403/PROFILE_NOT_COMPLETED 는 `apiClient` 인터셉터가 페이지 도달 전에
  * 처리하므로 본 훅들은 그 외 케이스만 분기 (§ 4 표 4).
@@ -19,11 +20,17 @@ import axios from 'axios';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { deleteCartItem, getCart, updateCartItemQuantity } from '@/api/cart.api';
-import { unwrapApiData } from '@/api/client';
+import {
+  apiClient,
+  idempotencyConfig,
+  unwrapApiData,
+  type ApiResponse,
+} from '@/api/client';
+import type { OrderRequest, OrderResponse } from '@/api/types';
 import { useToast } from '@/contexts/ToastContext';
 
-import { mergeQuantityUpdate, toCartVM } from './adapters';
-import type { CartItemVM, CartQuery, CartVM } from './types';
+import { mergeQuantityUpdate, toCartVM, toOrderResultVM } from './adapters';
+import type { CartItemVM, CartQuery, CartVM, OrderResultVM } from './types';
 
 // ── useCart ──────────────────────────────────────────────────────────────────
 
@@ -202,4 +209,79 @@ export function useCartMutations(cart: UseCartReturn): UseCartMutationsReturn {
   );
 
   return { pendingItemIds, setQuantityDelta, removeItem };
+}
+
+// ── useCheckout ──────────────────────────────────────────────────────────────
+
+export type CheckoutState = 'idle' | 'submitting' | 'error';
+
+export interface UseCheckoutReturn {
+  checkoutState: CheckoutState;
+  /** 성공 시 set → 컨테이너가 `<PaymentModal>` 을 마운트하는 트리거. */
+  paymentTarget: OrderResultVM | null;
+  /** 409 시 `OrderSummary` 영역에 표시할 인라인 메시지 (§ 4 표 4 (b)). */
+  inlineError: string | null;
+  /** 결제하기 버튼 핸들러. items / pending 가드 후 createOrder 호출. */
+  submit: () => Promise<void>;
+  /** PaymentModal close — paymentTarget clear (idempotency 키는 호출당 새로 발급). */
+  closeModal: () => void;
+}
+
+/**
+ * § 9.2-15: `createOrder` 에 `idempotencyConfig()` 헤더 부착.
+ * `src/api/orders.api.ts :: createOrder` 가 config 인자를 받지 않으므로
+ * (api 레이어 freeze — § 4 헤더 주석 참고) `apiClient.post` 를 직접 호출.
+ */
+const submitCreateOrder = (body: OrderRequest) =>
+  apiClient.post<ApiResponse<OrderResponse>>('/orders', body, idempotencyConfig());
+
+const isStatusCode = (err: unknown, status: number): boolean =>
+  axios.isAxiosError(err) && err.response?.status === status;
+
+export function useCheckout(
+  items: CartItemVM[],
+  refetch: () => void,
+): UseCheckoutReturn {
+  const { toast } = useToast();
+  const [checkoutState, setCheckoutState] = useState<CheckoutState>('idle');
+  const [paymentTarget, setPaymentTarget] = useState<OrderResultVM | null>(null);
+  const [inlineError, setInlineError] = useState<string | null>(null);
+
+  // 최신 items 를 submit 클로저로 흘려보내기 위한 ref. 의존성으로 잡으면
+  // 매 mutation 마다 submit 인스턴스가 재생성되어 부수효과가 큼.
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+  const stateRef = useRef(checkoutState);
+  stateRef.current = checkoutState;
+
+  const submit = useCallback(async (): Promise<void> => {
+    const list = itemsRef.current;
+    if (list.length === 0) return;
+    if (stateRef.current === 'submitting') return;
+
+    setInlineError(null);
+    setCheckoutState('submitting');
+    try {
+      const res = await submitCreateOrder({
+        cartItemIds: list.map((i) => i.cartItemId),
+      });
+      const order = toOrderResultVM(unwrapApiData(res.data));
+      setPaymentTarget(order);
+      setCheckoutState('idle');
+    } catch (err) {
+      if (isStatusCode(err, 409)) {
+        refetch();
+        setInlineError('재고가 부족하거나 일부 항목이 변경되었습니다. 장바구니를 다시 확인해주세요.');
+      } else {
+        toast('결제를 시작하지 못했습니다.', 'error');
+      }
+      setCheckoutState('error');
+    }
+  }, [refetch, toast]);
+
+  const closeModal = useCallback(() => {
+    setPaymentTarget(null);
+  }, []);
+
+  return { checkoutState, paymentTarget, inlineError, submit, closeModal };
 }

--- a/src/pages-v2/Cart/hooks.ts
+++ b/src/pages-v2/Cart/hooks.ts
@@ -1,18 +1,64 @@
 /**
  * Cart 페이지 훅.
  *
- * **PR 1 placeholder** — `useCart` 만 정의하며 항상 `{ status: 'loading' }` 을 반환.
- * 실제 `getCart()` 페치 / 캐시 / refetch 는 PR 2 에서 본문 교체 (시그니처 유지).
- * `useCartMutations` (수량/삭제) 와 `useCheckout` (주문/결제 트리거) 도 PR 2·3 에서 추가.
+ * Cart.plan.md § 3 / § 10.2.
  *
- * 시그니처를 미리 노출하는 이유: 컨테이너(`index.tsx`)가 PR 2 로 넘어가도
- * import 문 변경 없이 본문 교체만으로 동작하도록.
+ * - `useCart` — 마운트 시 1회 `getCart()` → `toCartVM` → `CartQuery` 상태 머신
+ *   (loading / success / error). `refetch()` 노출.
+ * - `useCartMutations` / `useCheckout` 는 후속 커밋에서 추가.
  *
- * Cart.plan.md § 3 / § 10.1.
+ * 페치 실패 시 401/403/PROFILE_NOT_COMPLETED 는 `apiClient` 인터셉터가
+ * 페이지 도달 전에 처리하므로 본 훅은 그 외 케이스만 `error` 로 분기 (§ 4 표 4).
+ *
+ * 반환 타입은 `CartQuery & { refetch }` — `useEventDetail` 와 동일 패턴.
+ * 프레젠테이션(`<Cart query={...} />`)에 그대로 전달 가능하며, mutation/checkout
+ * 훅이 `status === 'success'` 분기로 `data` 에 접근.
  */
 
-import type { CartQuery } from './types';
+import { useCallback, useEffect, useState } from 'react';
 
-export function useCart(): CartQuery {
-  return { status: 'loading' };
+import { getCart } from '@/api/cart.api';
+import { unwrapApiData } from '@/api/client';
+
+import { toCartVM } from './adapters';
+import type { CartQuery, CartVM } from './types';
+
+export type UseCartReturn = CartQuery & { refetch: () => void };
+
+const previousFrom = (prev: CartQuery): CartVM | undefined => {
+  if (prev.status === 'success') return prev.data;
+  return prev.previous;
+};
+
+export function useCart(): UseCartReturn {
+  const [state, setState] = useState<CartQuery>({ status: 'loading' });
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    setState((prev) => ({ status: 'loading', previous: previousFrom(prev) }));
+
+    getCart()
+      .then((res) => {
+        if (ctrl.signal.aborted) return;
+        const data = toCartVM(unwrapApiData(res.data));
+        setState({ status: 'success', data, fetchedAt: Date.now() });
+      })
+      .catch((err) => {
+        if (ctrl.signal.aborted) return;
+        setState((prev) => ({
+          status: 'error',
+          error: err,
+          previous: previousFrom(prev),
+        }));
+      });
+
+    return () => ctrl.abort();
+  }, [refreshTick]);
+
+  const refetch = useCallback(() => {
+    setRefreshTick((n) => n + 1);
+  }, []);
+
+  return { ...state, refetch };
 }

--- a/src/pages-v2/Cart/index.tsx
+++ b/src/pages-v2/Cart/index.tsx
@@ -1,35 +1,77 @@
 /**
  * Cart 페이지 컨테이너 — 라우트 진입점.
  *
- * 책임 (Cart.plan.md § 1):
- * - 데이터 페치: `useCart()` (PR 1 placeholder; PR 2 에서 실제 GET /cart 로 교체)
- * - 네비게이션: `useNavigate` 보유 → `onBrowse`/(PR 2 이후) `onQuantityChange/onRemove/onCheckout` 콜백을 leaf 페이지에 주입
- * - 인증 가드: `App.tsx` 의 `<RequireAuth>` 가 라우트 진입 차단 (§ 8.2) → 본 컨테이너는 무지
+ * Cart.plan.md § 1 / § 5 / § 10.2 step 7.
  *
- * **PR 1 한정**: `useCart()` 가 항상 `loading` 을 반환하므로 mutation 콜백
- * (`onQuantityChange/onRemove/onCheckout`) 은 사용자에게 도달하지 않음.
- * 시그니처 보장을 위해 no-op 으로 박아두며, PR 2/3 에서 실제 mutation 으로 교체.
+ * - 데이터 페치 / 뮤테이션 / 결제 트리거: `useCart` + `useCartMutations` + `useCheckout`
+ * - 인증 가드: `App.tsx` 의 `<RequireAuth>` 가 라우트 진입 차단 (§ 8.2) → 본 컨테이너는 무지
+ * - QuantityStepper 는 절대 next quantity (`(itemId, next)`) 를 보내지만 mutation 훅은
+ *   delta 기반(`setQuantityDelta(id, ±1)`) 이라 본 컨테이너에서 변환.
+ *
+ * **PR 2 한정 — v1 PaymentModal 임시 브리지**
+ * `import PaymentModal from '@/components/PaymentModal'` 한 줄을 PR 3 에서 v2
+ * 모달로 교체. 그 외 로직은 그대로 유지된다.
+ *
+ * 결제 성공(`onSuccess`)은 v1 PaymentModal 의 WALLET-only 즉시 결제 경로에서만
+ * 발화. PG 경로는 SDK 가 브라우저를 redirect 시키므로 Cart 자체는 unmount.
+ * `/payment/complete` 의 state shape 은 v1 Cart 와 동일하게 `{ orderId, amount }`
+ * 로 맞춘다 (PaymentComplete 페이지가 그 키를 읽음).
  */
 
 import { useNavigate } from 'react-router-dom';
 
-import { Cart } from './Cart';
-import { useCart } from './hooks';
+import PaymentModal from '@/components/PaymentModal';
 
-const noop = () => {};
+import { Cart } from './Cart';
+import { useCart, useCartMutations, useCheckout } from './hooks';
 
 export default function CartPage() {
   const navigate = useNavigate();
-  const query = useCart();
+  const cart = useCart();
+  const mut = useCartMutations(cart);
+  const items = cart.status === 'success' ? cart.data.items : [];
+  const co = useCheckout(items, cart.refetch);
+
+  const handleQuantityChange = (itemId: string, next: number) => {
+    if (cart.status !== 'success') return;
+    const item = cart.data.items.find((i) => i.cartItemId === itemId);
+    if (!item) return;
+    const delta = next - item.quantity;
+    if (delta === 1 || delta === -1) {
+      void mut.setQuantityDelta(itemId, delta);
+    }
+  };
+
+  const target = co.paymentTarget;
 
   return (
-    <Cart
-      query={query}
-      onQuantityChange={noop}
-      onRemove={noop}
-      onCheckout={noop}
-      onBrowse={() => navigate('/events')}
-      checkoutState="idle"
-    />
+    <>
+      <Cart
+        query={cart}
+        onQuantityChange={handleQuantityChange}
+        onRemove={(id) => {
+          void mut.removeItem(id);
+        }}
+        onCheckout={() => {
+          void co.submit();
+        }}
+        onBrowse={() => navigate('/events')}
+        checkoutState={co.checkoutState}
+        pendingItemIds={mut.pendingItemIds}
+      />
+      {target && (
+        <PaymentModal
+          open
+          orderId={target.orderId}
+          totalAmount={target.totalAmount}
+          onClose={co.closeModal}
+          onSuccess={() =>
+            navigate('/payment/complete', {
+              state: { orderId: target.orderId, amount: target.totalAmount },
+            })
+          }
+        />
+      )}
+    </>
   );
 }

--- a/src/pages-v2/Cart/types.ts
+++ b/src/pages-v2/Cart/types.ts
@@ -4,6 +4,7 @@
  * 설계 근거: docs/redesign/Cart.plan.md
  *  - § 1 (디렉토리 구조 / 신규 정의가 필요한 이유)
  *  - § 3 (서버 only · CartQuery 디스크리미네이티드 유니온)
+ *  - § 4 (어댑트 매핑 · OrderResultVM)
  *  - § 9.2-18 (클라 stock 상한 가드 미사용 → max 필드 부재)
  *
  * `CartItemVM`은 API `CartItemDetail`로부터 직접 만들 수 있는 최소 필드만 정의.
@@ -37,3 +38,12 @@ export type CartQuery =
   | { status: 'loading'; previous?: CartVM }
   | { status: 'success'; data: CartVM; fetchedAt: number }
   | { status: 'error'; error: unknown; previous?: CartVM };
+
+/**
+ * `createOrder` 응답을 `PaymentModal`(v1 브리지 / 추후 v2)로 넘기기 위한 최소 형태.
+ * § 4 표 2 / § 5(4) 결제 흐름에서 모달이 요구하는 것은 `orderId`, `totalAmount` 두 가지.
+ */
+export interface OrderResultVM {
+  orderId: string;
+  totalAmount: number;
+}


### PR DESCRIPTION
## Summary
Implements the core Cart page functionality including item quantity/deletion mutations, checkout order creation, and payment modal integration. Replaces placeholder hooks with full implementations following the Cart.plan.md specification.

## Key Changes

### Hooks Implementation (`src/pages-v2/Cart/hooks.ts`)
- **`useCart()`**: Fetches cart data on mount, transforms via `toCartVM()`, manages loading/success/error states with `previous` fallback. Exposes `refetch()` and `mutate()` for mutation hooks to update data without losing metadata.
- **`useCartMutations()`**: Implements optimistic updates for quantity changes (PATCH) and item deletion (DELETE) with snapshot rollback on failure. Guards against concurrent mutations via `pendingItemIds` Set. Handles 409 conflict by triggering `refetch()` and showing inventory change toast.
- **`useCheckout()`**: Creates orders via POST `/orders` with idempotency headers. Exposes `paymentTarget` (triggers PaymentModal mount) and `inlineError` for 409 conflicts. Manages `checkoutState` ('idle'/'submitting'/'error').

### Adapters (`src/pages-v2/Cart/adapters.ts`)
- `toCartVM()`: Converts `CartResponse` to `CartVM`, computing `lineTotal` per item and totals. Sets `fee`/`discount` to 0 (backend fields pending).
- `mergeQuantityUpdate()`: Partially merges quantity response into cart state, recalculating line totals and aggregates.
- `toOrderResultVM()`: Extracts minimal order data for PaymentModal.

### Container (`src/pages-v2/Cart/index.tsx`)
- Wires `useCart` + `useCartMutations` + `useCheckout` hooks
- Converts QuantityStepper's absolute quantity to delta for mutation hook
- Mounts PaymentModal on successful order creation, navigates to `/payment/complete` on payment success
- Passes `pendingItemIds` to Cart component for row-level UI feedback

### Component & Types Updates
- **`Cart.tsx`**: Removes hardcoded `disabled` prop on checkout button; now respects `submitting` state only
- **`types.ts`**: Adds `OrderResultVM` interface for payment modal data

## Implementation Details

- **Optimistic Updates**: Mutations apply changes immediately via `mutate()`, then rollback snapshot on error
- **Concurrency Guard**: `pendingRef` mirrors state to prevent race conditions on rapid clicks
- **409 Handling**: Inventory conflicts trigger full `refetch()` and user-facing messages (inline for checkout, toast for mutations)
- **Idempotency**: `createOrder` uses `idempotencyConfig()` headers to prevent duplicate orders on retry
- **Abort Cleanup**: `useCart` effect cancels in-flight requests on unmount/refresh
- **v1 Bridge**: PaymentModal temporarily imported from v1; will be replaced in PR 3

## Notes
- 401/403/PROFILE_NOT_COMPLETED errors handled by `apiClient` interceptor before reaching these hooks
- `addCartItem` (EventDetail flow) not included; handled separately via `usePurchaseActions`
- Backend `fee`/`discount` fields currently absent; adapters default to 0 for forward compatibility

https://claude.ai/code/session_01AbkPUCkDuCPWr1KrCMrKg3