### PR TITLE
feat: Add v2 payment callback pages (success/fail/complete)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,11 +18,14 @@ import NotFound          from './pages/NotFound'
 const OAuthCallback       = lazy(() => import('./pages/OAuthCallback'))
 const SocialProfileSetup  = lazy(() => import('./pages/SocialProfileSetup'))
 
-// lazy – v2 재구축 (router-toggle.plan, Login.plan §6, EventList.plan §10 PR 1, Cart.plan §10.1)
+// lazy – v2 재구축 (router-toggle.plan, Login.plan §6, EventList.plan §10 PR 1, Cart.plan §10.1 / §10.3 PR 5)
 const LoginV2             = lazy(() => import('./pages-v2/Login'))
 const EventListV2         = lazy(() => import('./pages-v2/EventList'))
 const EventDetailV2       = lazy(() => import('./pages-v2/EventDetail'))
 const CartV2              = lazy(() => import('./pages-v2/Cart'))
+const PaymentSuccessV2    = lazy(() => import('./pages-v2/PaymentCallback/PaymentSuccessPage'))
+const PaymentFailV2       = lazy(() => import('./pages-v2/PaymentCallback/PaymentFailPage'))
+const PaymentCompleteV2   = lazy(() => import('./pages-v2/PaymentCallback/PaymentCompletePage'))
 
 // lazy – 로그인 후 접근
 const SignupComplete      = lazy(() => import('./pages/SignupComplete'))
@@ -93,11 +96,11 @@ export default function App() {
           <Route path="/events/:id"             element={<VersionedRoute v1={<EventDetail />} v2={<EventDetailV2 />} />} />
           <Route path="/cart"                   element={<RequireAuth><VersionedRoute v1={<Cart />} v2={<CartV2 />} /></RequireAuth>} />
           <Route path="/payment"                element={<RequireAuth><Payment /></RequireAuth>} />
-          <Route path="/payment/complete"       element={<RequireAuth><PaymentComplete /></RequireAuth>} />
+          <Route path="/payment/complete"       element={<RequireAuth><VersionedRoute v1={<PaymentComplete />} v2={<PaymentCompleteV2 />} /></RequireAuth>} />
           <Route path="/mypage"                 element={<RequireAuth><MyPage /></RequireAuth>} />
           <Route path="/seller-apply"           element={<RequireAuth><SellerApply /></RequireAuth>} />
-          <Route path="/payment/success"        element={<RequireAuth><PaymentSuccess /></RequireAuth>} />
-          <Route path="/payment/fail"           element={<RequireAuth><PaymentFail /></RequireAuth>} />
+          <Route path="/payment/success"        element={<RequireAuth><VersionedRoute v1={<PaymentSuccess />} v2={<PaymentSuccessV2 />} /></RequireAuth>} />
+          <Route path="/payment/fail"           element={<RequireAuth><VersionedRoute v1={<PaymentFail />} v2={<PaymentFailV2 />} /></RequireAuth>} />
           <Route path="/wallet/charge/success"  element={<RequireAuth><WalletChargeSuccess /></RequireAuth>} />
           <Route path="/wallet/charge/fail"     element={<RequireAuth><WalletChargeFail /></RequireAuth>} />
         </Route>

--- a/src/pages-v2/PaymentCallback/PaymentComplete.tsx
+++ b/src/pages-v2/PaymentCallback/PaymentComplete.tsx
@@ -1,0 +1,74 @@
+/**
+ * `/payment/complete` 시각 컴포넌트.
+ *
+ * Cart.plan.md § 9.1-8. v1 (`pages/PaymentComplete.tsx`) 영수증 화면을
+ * v2 톤으로 이전 — 큰 ✓ 아이콘 + 카피 + 영수증 카드 + CTA 2개.
+ *
+ * `PaymentCompleteVM` 의 method/approvedAt 은 옵션이라(§ types.ts) 본 파일
+ * 에서 라벨/일시 fallback 을 채운다. 단, 누락된 데이터 자체는 컨테이너가
+ * 진입 시점에 처리(예: location.state 이 없으면 / 로 redirect).
+ */
+
+import type { PaymentCompleteVM, PaymentMethod } from './types';
+import { PaymentActions } from './components/PaymentActions';
+import { PaymentCallbackLayout } from './components/PaymentCallbackLayout';
+import { PaymentReceipt } from './components/PaymentReceipt';
+import { PaymentStatusIcon } from './components/PaymentStatusIcon';
+
+export interface PaymentCompleteProps {
+  data: PaymentCompleteVM;
+  onOrders: () => void;
+  onTickets: () => void;
+}
+
+const METHOD_LABEL: Record<PaymentMethod, string> = {
+  WALLET: '예치금',
+  WALLET_PG: '복합 결제 (예치금 + 카드)',
+  PG: '카드/계좌이체',
+};
+
+/** 식별자 길이가 유동적이라 첫 20 자만 모노스페이스로 노출(v1 동일). */
+const truncateOrderId = (orderId: string): string =>
+  orderId.length > 20 ? `${orderId.slice(0, 20)}...` : orderId;
+
+const formatApprovedAt = (iso: string | undefined): string => {
+  const date = iso ? new Date(iso) : new Date();
+  return date.toLocaleString('ko-KR');
+};
+
+export function PaymentComplete({
+  data,
+  onOrders,
+  onTickets,
+}: PaymentCompleteProps) {
+  const methodLabel = METHOD_LABEL[data.method ?? 'PG'];
+  return (
+    <PaymentCallbackLayout
+      size="md"
+      icon={<PaymentStatusIcon status="success" size="lg" />}
+      title="결제 완료!"
+      description="티켓이 발급되었습니다. 마이페이지에서 확인하세요."
+      actions={
+        <PaymentActions
+          actions={[
+            { label: '주문 상세', variant: 'ghost', onClick: onOrders },
+            { label: '내 티켓 보기', variant: 'primary', onClick: onTickets },
+          ]}
+        />
+      }
+    >
+      <PaymentReceipt
+        rows={[
+          {
+            label: '결제 금액',
+            value: `${data.amount.toLocaleString()}원`,
+            bold: true,
+          },
+          { label: '결제 수단', value: methodLabel },
+          { label: '주문번호', value: truncateOrderId(data.orderId), mono: true },
+          { label: '결제 일시', value: formatApprovedAt(data.approvedAt) },
+        ]}
+      />
+    </PaymentCallbackLayout>
+  );
+}

--- a/src/pages-v2/PaymentCallback/PaymentCompletePage.tsx
+++ b/src/pages-v2/PaymentCallback/PaymentCompletePage.tsx
@@ -1,0 +1,38 @@
+/**
+ * `/payment/complete` 컨테이너 — 라우트 진입점.
+ *
+ * Cart.plan.md § 9.1-8 / § 10.3.6 PR 5.
+ *
+ * 책임 분리:
+ *  - 데이터: `useCompletePayload` (location.state → PaymentCompleteVM 정규화)
+ *  - 시각: `<PaymentComplete>` (presentation)
+ *  - state 누락(직접 진입) 시 `/` 로 redirect — v1 동작 보존(`if (!state) navigate('/')`).
+ *  - CTA: 주문 상세(/mypage?tab=orders) / 내 티켓 보기(/mypage?tab=tickets)
+ *
+ * 인증 가드는 App.tsx 의 `<RequireAuth>` 가 라우트 진입 차단.
+ */
+
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { PaymentComplete } from './PaymentComplete';
+import { useCompletePayload } from './hooks';
+
+export default function PaymentCompletePage() {
+  const navigate = useNavigate();
+  const data = useCompletePayload();
+
+  useEffect(() => {
+    if (data === null) navigate('/', { replace: true });
+  }, [data, navigate]);
+
+  if (data === null) return null;
+
+  return (
+    <PaymentComplete
+      data={data}
+      onOrders={() => navigate('/mypage?tab=orders')}
+      onTickets={() => navigate('/mypage?tab=tickets')}
+    />
+  );
+}

--- a/src/pages-v2/PaymentCallback/PaymentFail.tsx
+++ b/src/pages-v2/PaymentCallback/PaymentFail.tsx
@@ -1,0 +1,42 @@
+/**
+ * `/payment/fail` 시각 컴포넌트.
+ *
+ * Cart.plan.md § 9.1-8 / § 10.3.6 PR 5 시나리오 — "사유 표시 + 장바구니로
+ * 돌아가기 CTA → /cart?v=2".  v1 (`pages/PaymentFail.tsx`) 의 카피와
+ * 동작을 보존하되 "홈으로" 단독 CTA 대신 "장바구니로 돌아가기" 를
+ * 1차 CTA 로 둔다 — 결제 실패 직후 사용자가 가장 자연스럽게 돌아갈
+ * 위치가 카트이므로.
+ *
+ * `failPayment` 부수 호출 / sessionStorage 정리는 컨테이너 책임. 본
+ * 파일은 표시만.
+ */
+
+import type { PaymentFailVM } from './types';
+import { PaymentActions } from './components/PaymentActions';
+import { PaymentCallbackLayout } from './components/PaymentCallbackLayout';
+import { PaymentStatusIcon } from './components/PaymentStatusIcon';
+
+export interface PaymentFailProps {
+  data: PaymentFailVM;
+  onCart: () => void;
+  onHome: () => void;
+}
+
+export function PaymentFail({ data, onCart, onHome }: PaymentFailProps) {
+  return (
+    <PaymentCallbackLayout
+      icon={<PaymentStatusIcon status="error" />}
+      title="결제 실패"
+      description={data.message}
+      meta={`오류 코드: ${data.code}`}
+      actions={
+        <PaymentActions
+          actions={[
+            { label: '홈으로', variant: 'ghost', onClick: onHome },
+            { label: '장바구니로 돌아가기', variant: 'primary', onClick: onCart },
+          ]}
+        />
+      }
+    />
+  );
+}

--- a/src/pages-v2/PaymentCallback/PaymentFailPage.tsx
+++ b/src/pages-v2/PaymentCallback/PaymentFailPage.tsx
@@ -1,0 +1,30 @@
+/**
+ * `/payment/fail` 컨테이너 — 라우트 진입점.
+ *
+ * Cart.plan.md § 9.1-8 / § 10.3.6 PR 5.
+ *
+ * 책임 분리:
+ *  - 데이터/부수효과: `usePaymentFail` (URL 파싱 + sessionStorage 정리 + failPayment fire-and-forget)
+ *  - 시각: `<PaymentFail>` (presentation)
+ *  - CTA navigate 콜백 주입 — "장바구니로 돌아가기"(/cart) / "홈으로"(/) (§ 10.3.6 PR 5 시나리오)
+ *
+ * 인증 가드는 App.tsx 의 `<RequireAuth>` 가 라우트 진입 차단.
+ */
+
+import { useNavigate } from 'react-router-dom';
+
+import { PaymentFail } from './PaymentFail';
+import { usePaymentFail } from './hooks';
+
+export default function PaymentFailPage() {
+  const navigate = useNavigate();
+  const data = usePaymentFail();
+
+  return (
+    <PaymentFail
+      data={data}
+      onCart={() => navigate('/cart', { replace: true })}
+      onHome={() => navigate('/', { replace: true })}
+    />
+  );
+}

--- a/src/pages-v2/PaymentCallback/PaymentSuccess.tsx
+++ b/src/pages-v2/PaymentCallback/PaymentSuccess.tsx
@@ -1,0 +1,56 @@
+/**
+ * `/payment/success` 시각 컴포넌트.
+ *
+ * Cart.plan.md § 9.1-8. Toss redirect 직후 confirm API 호출 결과를
+ * 3 단계(loading/success/error) 로 표시. 본 파일은 **표현만** 책임지고,
+ * `confirmPayment` 호출과 `/payment/complete` 자동 이동은 컨테이너
+ * (`index.tsx` PR 5 step 11)에서 처리한다.
+ *
+ * v1 (`pages/PaymentSuccess.tsx`) 동일 스코프 + 동일 카피. 톤만 v2.
+ */
+
+import type { ConfirmQuery } from './types';
+import { PaymentActions } from './components/PaymentActions';
+import { PaymentCallbackLayout } from './components/PaymentCallbackLayout';
+import { PaymentStatusIcon } from './components/PaymentStatusIcon';
+
+export interface PaymentSuccessProps {
+  query: ConfirmQuery;
+  /** 에러 화면의 "홈으로 돌아가기" CTA. */
+  onHome: () => void;
+}
+
+export function PaymentSuccess({ query, onHome }: PaymentSuccessProps) {
+  if (query.status === 'loading') {
+    return (
+      <PaymentCallbackLayout
+        icon={<PaymentStatusIcon status="loading" />}
+        title="결제 승인 처리 중..."
+        description="잠시만 기다려주세요."
+      />
+    );
+  }
+
+  if (query.status === 'success') {
+    return (
+      <PaymentCallbackLayout
+        icon={<PaymentStatusIcon status="success" />}
+        title="결제 승인 완료!"
+        description="잠시 후 결제 완료 페이지로 이동합니다."
+      />
+    );
+  }
+
+  return (
+    <PaymentCallbackLayout
+      icon={<PaymentStatusIcon status="error" />}
+      title="결제 승인 실패"
+      description={query.message}
+      actions={
+        <PaymentActions
+          actions={[{ label: '홈으로 돌아가기', variant: 'primary', onClick: onHome }]}
+        />
+      }
+    />
+  );
+}

--- a/src/pages-v2/PaymentCallback/PaymentSuccessPage.tsx
+++ b/src/pages-v2/PaymentCallback/PaymentSuccessPage.tsx
@@ -1,0 +1,44 @@
+/**
+ * `/payment/success` 컨테이너 — 라우트 진입점.
+ *
+ * Cart.plan.md § 9.1-8 / § 10.3.6 PR 5.
+ *
+ * 책임 분리:
+ *  - 데이터/검증/API: `usePaymentConfirm` (sessionStorage + Toss 쿼리 + confirm 호출)
+ *  - 자동 이동: 본 컨테이너가 `completePayload` 가 채워지면 1.5s setTimeout 후
+ *    `/payment/complete` 로 navigate(replace) — v1 동작 보존.
+ *  - 시각: `<PaymentSuccess>` (presentation)
+ *
+ * 인증 가드는 App.tsx 의 `<RequireAuth>` 가 라우트 진입 차단.
+ */
+
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { PaymentSuccess } from './PaymentSuccess';
+import { usePaymentConfirm } from './hooks';
+
+const REDIRECT_DELAY_MS = 1500;
+
+export default function PaymentSuccessPage() {
+  const navigate = useNavigate();
+  const { query, completePayload } = usePaymentConfirm();
+
+  useEffect(() => {
+    if (!completePayload) return;
+    const t = window.setTimeout(() => {
+      navigate('/payment/complete', {
+        state: completePayload,
+        replace: true,
+      });
+    }, REDIRECT_DELAY_MS);
+    return () => window.clearTimeout(t);
+  }, [completePayload, navigate]);
+
+  return (
+    <PaymentSuccess
+      query={query}
+      onHome={() => navigate('/', { replace: true })}
+    />
+  );
+}

--- a/src/pages-v2/PaymentCallback/__mocks__/paymentFixtures.ts
+++ b/src/pages-v2/PaymentCallback/__mocks__/paymentFixtures.ts
@@ -1,0 +1,52 @@
+/**
+ * 결제 콜백 v2 시각 검증용 fixture.
+ *
+ * Cart.plan.md § 10.1 의 `cartFixtures` 패턴을 차용 — `?paymentFixture=...`
+ * 쿼리로 컨테이너가 시각 분기 3종(success: confirm 진행/완료, fail, complete)
+ * 을 mock 으로 토글할 수 있게 한다. 실제 hooks 는 PR 후속 단계에서
+ * sessionStorage·API 결과로 채운다.
+ *
+ * 인라인 mock 금지(@docs/CLAUDE.md). 페이지/컴포넌트는 본 파일이나
+ * `hooks.ts` placeholder 만 참조한다.
+ */
+
+import type {
+  ConfirmQuery,
+  PaymentCompleteVM,
+  PaymentFailVM,
+  PaymentSuccessVM,
+} from '../types';
+
+const SAMPLE_ORDER_ID = 'ord_2026Q2_demo_0001abcd1234efgh5678';
+const SAMPLE_PAYMENT_ID = 'pay_2026Q2_demo_0001wxyz';
+
+export const mockConfirmSuccessData: PaymentSuccessVM = {
+  orderId: SAMPLE_ORDER_ID,
+  amount: 45_000,
+  method: 'PG',
+};
+
+export const mockConfirmLoading: ConfirmQuery = { status: 'loading' };
+
+export const mockConfirmSuccess: ConfirmQuery = {
+  status: 'success',
+  data: mockConfirmSuccessData,
+};
+
+export const mockConfirmError: ConfirmQuery = {
+  status: 'error',
+  message: '결제 승인 처리에 실패했습니다.',
+};
+
+export const mockFail: PaymentFailVM = {
+  code: 'USER_CANCEL',
+  message: '사용자가 결제를 취소했습니다.',
+};
+
+export const mockComplete: PaymentCompleteVM = {
+  paymentId: SAMPLE_PAYMENT_ID,
+  orderId: SAMPLE_ORDER_ID,
+  amount: 45_000,
+  method: 'WALLET_PG',
+  approvedAt: '2026-04-26T11:23:00+09:00',
+};

--- a/src/pages-v2/PaymentCallback/components/PaymentActions.tsx
+++ b/src/pages-v2/PaymentCallback/components/PaymentActions.tsx
@@ -1,0 +1,53 @@
+/**
+ * 결제 콜백 페이지 하단 CTA 버튼 그룹.
+ *
+ * Cart.plan.md § 9.1-8. 1~2 개 버튼을 가로 정렬로 깔아두는 공통 영역.
+ *
+ *  - PaymentFail:    "뒤로가기" (ghost) + "홈으로" (primary)
+ *  - PaymentComplete: "주문 상세" (ghost) + "내 티켓 보기" (primary)
+ *  - PaymentSuccess error: "홈으로 돌아가기" (primary, 단일)
+ *
+ * v1 의 `'secondary'` 는 v2 Button 에 존재하지 않으므로 `'ghost'` 로 매핑.
+ * 단일 버튼일 땐 페이지 폭 가득 채우도록 `full` 자동 적용 — 시각적 톤이
+ * EmptyCart CTA 와 일관.
+ */
+
+import { Button } from '@/components-v2/Button';
+
+export type PaymentActionVariant = 'primary' | 'ghost';
+
+export interface PaymentAction {
+  label: string;
+  variant: PaymentActionVariant;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+export interface PaymentActionsProps {
+  actions: PaymentAction[];
+}
+
+export function PaymentActions({ actions }: PaymentActionsProps) {
+  if (actions.length === 0) return null;
+  const single = actions.length === 1;
+  return (
+    <div
+      className={['payment-actions', single && 'payment-actions--single']
+        .filter(Boolean)
+        .join(' ')}
+    >
+      {actions.map((a) => (
+        <Button
+          key={a.label}
+          variant={a.variant}
+          size="lg"
+          full={single}
+          disabled={a.disabled}
+          onClick={a.onClick}
+        >
+          {a.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/src/pages-v2/PaymentCallback/components/PaymentCallbackLayout.tsx
+++ b/src/pages-v2/PaymentCallback/components/PaymentCallbackLayout.tsx
@@ -1,0 +1,64 @@
+/**
+ * 결제 콜백 3 페이지(PaymentSuccess / PaymentFail / PaymentComplete) 공통
+ * 중앙 정렬 레이아웃.
+ *
+ * Cart.plan.md § 9.1-8. v1 의 `min-height: 80vh; flex; align/justify center;
+ * padding: 24` 인라인 패턴을 단일 BEM 컨테이너로 추출 — 페이지마다 같은
+ * 시각 위계를 유지한다.
+ *
+ * 슬롯:
+ *  - `icon`        상단 PaymentStatusIcon
+ *  - `title`       h1 (성공 화면은 "결제 완료!" 처럼 강조)
+ *  - `description` p 본문 안내
+ *  - `meta`        보조 라인(예: "오류 코드: ABC", v1 PaymentFail)
+ *  - `children`    영수증 카드 같은 카드형 콘텐츠 (선택)
+ *  - `actions`     하단 CTA(PaymentActions) (선택)
+ *
+ * 페이지 자체는 본 레이아웃을 한 번 감싸기만 하면 됨 — Layout(공용 chrome)
+ * 안쪽 라우트라 헤더/푸터는 따로 신경 쓸 필요 없음.
+ */
+
+import type { ReactNode } from 'react';
+
+export interface PaymentCallbackLayoutProps {
+  icon: ReactNode;
+  title: string;
+  description?: ReactNode;
+  meta?: ReactNode;
+  children?: ReactNode;
+  actions?: ReactNode;
+  /** 영수증처럼 정보량이 많은 경우 컨테이너 폭을 넓혀 사용. 기본 400px. */
+  size?: 'sm' | 'md';
+}
+
+export function PaymentCallbackLayout({
+  icon,
+  title,
+  description,
+  meta,
+  children,
+  actions,
+  size = 'sm',
+}: PaymentCallbackLayoutProps) {
+  return (
+    <section className="payment-callback">
+      <div
+        className={[
+          'payment-callback__inner',
+          size === 'md' && 'payment-callback__inner--md',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        <div className="payment-callback__icon">{icon}</div>
+        <h1 className="payment-callback__title">{title}</h1>
+        {description && (
+          <p className="payment-callback__desc">{description}</p>
+        )}
+        {meta && <p className="payment-callback__meta">{meta}</p>}
+        {children && <div className="payment-callback__content">{children}</div>}
+        {actions && <div className="payment-callback__actions">{actions}</div>}
+      </div>
+    </section>
+  );
+}

--- a/src/pages-v2/PaymentCallback/components/PaymentReceipt.tsx
+++ b/src/pages-v2/PaymentCallback/components/PaymentReceipt.tsx
@@ -1,0 +1,51 @@
+/**
+ * 결제 완료 영수증 카드.
+ *
+ * Cart.plan.md § 9.1-8. v1 `pages/PaymentComplete.tsx` 의 인라인 스타일
+ * `Row` 를 v2 톤으로 이전 — 라벨/값 페어를 BEM 으로 표시하고 카드 자체는
+ * 공용 `Card variant="solid"` 를 사용한다.
+ *
+ * 값은 string 또는 ReactNode — 주문번호처럼 모노스페이스 마스킹이 필요한
+ * 케이스를 위해 row 단위 `mono` 옵션 제공. 포맷(원화/일시) 책임은 호출자
+ * (페이지 컴포넌트)로 둔다.
+ */
+
+import type { ReactNode } from 'react';
+
+import { Card } from '@/components-v2/Card';
+
+export interface PaymentReceiptRow {
+  label: string;
+  value: ReactNode;
+  bold?: boolean;
+  /** 주문번호 등 식별자 라인에 모노스페이스/축약 스타일 적용. */
+  mono?: boolean;
+}
+
+export interface PaymentReceiptProps {
+  rows: PaymentReceiptRow[];
+}
+
+export function PaymentReceipt({ rows }: PaymentReceiptProps) {
+  return (
+    <Card variant="solid" className="payment-receipt">
+      <dl className="payment-receipt__list">
+        {rows.map((row) => {
+          const valueClass = [
+            'payment-receipt__value',
+            row.bold && 'payment-receipt__value--bold',
+            row.mono && 'payment-receipt__value--mono',
+          ]
+            .filter(Boolean)
+            .join(' ');
+          return (
+            <div className="payment-receipt__row" key={row.label}>
+              <dt className="payment-receipt__label">{row.label}</dt>
+              <dd className={valueClass}>{row.value}</dd>
+            </div>
+          );
+        })}
+      </dl>
+    </Card>
+  );
+}

--- a/src/pages-v2/PaymentCallback/components/PaymentStatusIcon.tsx
+++ b/src/pages-v2/PaymentCallback/components/PaymentStatusIcon.tsx
@@ -1,0 +1,44 @@
+/**
+ * 결제 콜백 상태 아이콘 — `loading` 스피너 / `success` 체크 / `error` X.
+ *
+ * Cart.plan.md § 9.1-8 (3 페이지 톤 통일). 공용 `Icon` 의 `check`/`x` 글리프
+ * 를 그대로 사용하고, loading 은 styles-v2/global.css 의 `@keyframes spin`
+ * 을 재사용한 원형 스피너로 표시.
+ *
+ * v1(`pages/PaymentSuccess.tsx` 외)의 인라인 style 분기와 동일 시각 의도,
+ * 단 색·크기·여백은 토큰(--success / --danger) + payment-callback.css 의
+ * BEM 클래스로 이전.
+ */
+
+import { Icon } from '@/components-v2/Icon';
+
+export type PaymentStatusTone = 'loading' | 'success' | 'error';
+
+export interface PaymentStatusIconProps {
+  status: PaymentStatusTone;
+  /** 영수증 페이지처럼 더 크게 보여줘야 하는 경우 사용 (기본 64, 큰 사이즈 80). */
+  size?: 'md' | 'lg';
+}
+
+export function PaymentStatusIcon({
+  status,
+  size = 'md',
+}: PaymentStatusIconProps) {
+  const className = [
+    'payment-status-icon',
+    `payment-status-icon--${status}`,
+    size === 'lg' && 'payment-status-icon--lg',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={className} role="presentation">
+      {status === 'loading' && (
+        <span className="payment-status-icon__spinner" aria-hidden="true" />
+      )}
+      {status === 'success' && <Icon name="check" size={size === 'lg' ? 36 : 28} />}
+      {status === 'error' && <Icon name="x" size={size === 'lg' ? 36 : 28} />}
+    </div>
+  );
+}

--- a/src/pages-v2/PaymentCallback/hooks.ts
+++ b/src/pages-v2/PaymentCallback/hooks.ts
@@ -1,0 +1,207 @@
+/**
+ * 결제 콜백 페이지 훅.
+ *
+ * Cart.plan.md § 9.1-8 / § 10.3.6 PR 5.
+ *
+ * - `usePaymentConfirm` — `/payment/success` 진입 시 sessionStorage
+ *   `payment_context` + URL 쿼리(paymentKey/orderId/amount) 검증 → confirm
+ *   API 호출 → `ConfirmQuery` 노출. 성공 시 `/payment/complete` 로 보낼
+ *   `completePayload` 도 함께 채운다(컨테이너가 1.5s 후 navigate).
+ *
+ * - `usePaymentFail` — `/payment/fail` 진입 시 URL 의 code/message 와
+ *   sessionStorage 컨텍스트로 `failPayment` fire-and-forget 호출 후
+ *   `PaymentFailVM` 반환.
+ *
+ * - `useCompletePayload` — `/payment/complete` 의 location.state 를
+ *   `PaymentCompleteVM` 으로 정규화. state 가 없으면 `null` 을 반환하고
+ *   컨테이너가 `/` 로 redirect 처리.
+ *
+ * 모든 훅은 `?paymentFixture=...` 쿼리로 mock fixture 토글을 지원
+ * (Cart.plan.md § 10.1 cartFixture 패턴). 후속 PR 에서 fixture 핫셀
+ * 제거.
+ *
+ * v1 의 직접 호출(`pages/Payment{Success,Fail,Complete}.tsx`) 과 동일한
+ * 부수효과·검증 로직을 그대로 옮긴 것 — UI 만 v2 로 이전된다.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { useLocation, useSearchParams } from 'react-router-dom';
+
+import { confirmPayment, failPayment } from '@/api/payments.api';
+
+import {
+  mockComplete,
+  mockConfirmError,
+  mockConfirmLoading,
+  mockConfirmSuccess,
+  mockFail,
+} from './__mocks__/paymentFixtures';
+import type {
+  ConfirmQuery,
+  PaymentCompleteVM,
+  PaymentFailVM,
+  PaymentMethod,
+  PaymentSuccessVM,
+} from './types';
+
+const PAYMENT_CONTEXT_KEY = 'payment_context';
+
+interface SessionPaymentContext {
+  paymentId: string;
+  orderId: string;
+  totalAmount?: number;
+  method?: PaymentMethod;
+}
+
+const readPaymentContext = (): SessionPaymentContext | null => {
+  const raw = sessionStorage.getItem(PAYMENT_CONTEXT_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as SessionPaymentContext;
+  } catch {
+    return null;
+  }
+};
+
+const clearPaymentContext = () =>
+  sessionStorage.removeItem(PAYMENT_CONTEXT_KEY);
+
+const errorMessageOf = (e: unknown): string => {
+  const fallback = '결제 승인 처리에 실패했습니다.';
+  if (typeof e !== 'object' || e === null) return fallback;
+  const data = (e as { response?: { data?: { message?: string } } }).response
+    ?.data;
+  return data?.message ?? fallback;
+};
+
+// ── usePaymentConfirm ────────────────────────────────────────────────────────
+
+export interface UsePaymentConfirmReturn {
+  query: ConfirmQuery;
+  /** confirm 성공 시 채워짐. 컨테이너가 1.5s 지연 후 navigate(state). */
+  completePayload: PaymentCompleteVM | null;
+}
+
+export function usePaymentConfirm(): UsePaymentConfirmReturn {
+  const [searchParams] = useSearchParams();
+  const fixture = searchParams.get('paymentFixture');
+  const [query, setQuery] = useState<ConfirmQuery>(() =>
+    fixture === 'success'
+      ? mockConfirmSuccess
+      : fixture === 'error'
+        ? mockConfirmError
+        : mockConfirmLoading,
+  );
+  const [completePayload, setCompletePayload] =
+    useState<PaymentCompleteVM | null>(() =>
+      fixture === 'success' ? mockComplete : null,
+    );
+
+  useEffect(() => {
+    if (fixture) return; // QA 모드 — 실제 호출 건너뜀
+
+    const paymentKey = searchParams.get('paymentKey');
+    const tossOrderId = searchParams.get('orderId'); // = 우리 paymentId
+    const amountStr = searchParams.get('amount');
+    const ctx = readPaymentContext();
+
+    if (!paymentKey || !tossOrderId || !amountStr || !ctx) {
+      setQuery({ status: 'error', message: '결제 정보가 유효하지 않습니다.' });
+      clearPaymentContext();
+      return;
+    }
+
+    const amount = Number(amountStr);
+    let cancelled = false;
+
+    confirmPayment({
+      paymentId: ctx.paymentId,
+      paymentKey,
+      orderId: ctx.orderId,
+      amount,
+    })
+      .then(() => {
+        if (cancelled) return;
+        const method = ctx.method ?? 'PG';
+        const data: PaymentSuccessVM = {
+          orderId: ctx.orderId,
+          amount: ctx.totalAmount ?? amount,
+          method,
+        };
+        setQuery({ status: 'success', data });
+        setCompletePayload({
+          paymentId: ctx.paymentId,
+          orderId: ctx.orderId,
+          amount: ctx.totalAmount ?? amount,
+          method,
+          approvedAt: new Date().toISOString(),
+        });
+        clearPaymentContext();
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setQuery({ status: 'error', message: errorMessageOf(err) });
+        clearPaymentContext();
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fixture, searchParams]);
+
+  return { query, completePayload };
+}
+
+// ── usePaymentFail ───────────────────────────────────────────────────────────
+
+export function usePaymentFail(): PaymentFailVM {
+  const [searchParams] = useSearchParams();
+  const fixture = searchParams.get('paymentFixture');
+
+  const data = useMemo<PaymentFailVM>(() => {
+    if (fixture === 'fail') return mockFail;
+    return {
+      code: searchParams.get('code') ?? '알 수 없는 오류',
+      message:
+        searchParams.get('message') ?? '결제 처리 중 문제가 발생했습니다.',
+    };
+  }, [fixture, searchParams]);
+
+  useEffect(() => {
+    if (fixture) return; // QA 모드 — 실제 호출 건너뜀
+    const ctx = readPaymentContext();
+    if (ctx?.paymentId && ctx?.orderId) {
+      failPayment({
+        paymentId: ctx.paymentId,
+        orderId: ctx.orderId,
+        code: data.code,
+        message: data.message,
+      }).catch(() => {
+        /* fire-and-forget — v1 동작 유지 */
+      });
+    }
+    clearPaymentContext();
+  }, [fixture, data.code, data.message]);
+
+  return data;
+}
+
+// ── useCompletePayload ───────────────────────────────────────────────────────
+
+export function useCompletePayload(): PaymentCompleteVM | null {
+  const [searchParams] = useSearchParams();
+  const fixture = searchParams.get('paymentFixture');
+  const { state } = useLocation();
+
+  if (fixture === 'complete') return mockComplete;
+  if (!state || typeof state !== 'object') return null;
+  const s = state as Partial<PaymentCompleteVM>;
+  if (!s.orderId || typeof s.amount !== 'number') return null;
+  return {
+    paymentId: s.paymentId,
+    orderId: s.orderId,
+    amount: s.amount,
+    method: s.method,
+    approvedAt: s.approvedAt,
+  };
+}

--- a/src/pages-v2/PaymentCallback/types.ts
+++ b/src/pages-v2/PaymentCallback/types.ts
@@ -1,0 +1,69 @@
+/**
+ * 결제 콜백 페이지 v2 타입.
+ *
+ * 설계 근거: docs/redesign/Cart.plan.md
+ *  - § 9.1-8 (결제 완료/실패 페이지를 v2 톤앤매너로 리스킨)
+ *  - § 9.4 (신규 PR: /payment/{success,fail,complete} 3개를 VersionedRoute 로 토글)
+ *  - § 10.3.1 PR 5 (별도 plan 문서로 분리 권장 — 본 PR 은 시각 골격만)
+ *
+ * 스코프: PaymentSuccess(Toss redirect 직후 confirm 처리) / PaymentFail
+ * (Toss failUrl) / PaymentComplete(승인 후 영수증) 3개 페이지의 표현 VM.
+ *
+ * v1 동작 보존: API 호출(`confirmPayment` / `failPayment`)·sessionStorage
+ * `payment_context` 복구·Toss 쿼리 파싱은 hooks 단에서 그대로 재사용한다.
+ * 본 타입은 화면이 표시할 정보만 정의 — Toss 의 paymentKey 같은 내부 키는
+ * VM 에 흘리지 않는다.
+ */
+
+/** v1 `PaymentRequest`/`PaymentConfirmResponse` 과 일치. */
+export type PaymentMethod = 'PG' | 'WALLET' | 'WALLET_PG';
+
+/**
+ * `/payment/success` 진입 시 Toss 가 붙여주는 쿼리 + sessionStorage 컨텍스트
+ * 를 합쳐 confirm API 가 요구하는 형태로 정규화한 입력. hooks 가 검증 후
+ * 만든다 (URL/세션 누락 시 `null`).
+ */
+export interface PaymentConfirmInput {
+  paymentId: string;
+  paymentKey: string;
+  orderId: string;
+  amount: number;
+  method: PaymentMethod;
+}
+
+/**
+ * confirm 진행 상태. 페이지는 status 만으로 시각 분기. error 메시지는
+ * 사용자 표시 문구 — 응답 raw 메시지는 hooks 에서 가공한 뒤 넣는다.
+ */
+export type ConfirmQuery =
+  | { status: 'loading' }
+  | { status: 'success'; data: PaymentSuccessVM }
+  | { status: 'error'; message: string };
+
+/** 승인 직후 짧게 보여주는 "결제 승인 완료!" 화면용. */
+export interface PaymentSuccessVM {
+  orderId: string;
+  amount: number;
+  method: PaymentMethod;
+}
+
+/** `/payment/fail` 진입 시 쿼리 파싱 + 부수 호출 결과. */
+export interface PaymentFailVM {
+  code: string;
+  message: string;
+}
+
+/**
+ * `/payment/complete` 진입 시 location.state 로 받는 영수증 데이터.
+ * v1 PaymentComplete 가 동일한 키 셋을 사용 — 호환 유지를 위해 동일 shape.
+ * (Cart v2 컨테이너 onSuccess 에서는 `{ orderId, amount }` 만 보내므로
+ * `method`/`paymentId` 는 옵션. 누락 시 PG 가정 + 마스킹 표시.)
+ */
+export interface PaymentCompleteVM {
+  paymentId?: string;
+  orderId: string;
+  amount: number;
+  method?: PaymentMethod;
+  /** 표시용 — 승인 시각. 없으면 페이지가 진입 시각으로 채움. */
+  approvedAt?: string;
+}

--- a/src/styles-v2/index.css
+++ b/src/styles-v2/index.css
@@ -27,3 +27,4 @@
 @import './pages/login.css';
 @import './pages/event-detail.css';
 @import './pages/cart.css';
+@import './pages/payment-callback.css';

--- a/src/styles-v2/pages/payment-callback.css
+++ b/src/styles-v2/pages/payment-callback.css
@@ -1,0 +1,162 @@
+/* DevTicket v2 — Payment callback page styles
+   Source: docs/redesign/Cart.plan.md § 9.1-8 (decision row)
+           + v1 pages/Payment{Success,Fail,Complete}.tsx visual intent
+   Scope:  classes prefixed with `payment-callback`, `payment-status-icon`,
+           `payment-receipt`, `payment-actions` are local to the three v2
+           callback routes. */
+
+/* ── Page wrapper (PaymentCallbackLayout) ─────────────────────────── */
+.payment-callback {
+  min-height: 80vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 16px;
+}
+.payment-callback__inner {
+  width: 100%;
+  max-width: 400px;
+  text-align: center;
+}
+.payment-callback__inner--md {
+  max-width: 440px;
+}
+
+.payment-callback__icon {
+  margin: 0 auto 20px;
+  display: inline-flex;
+}
+.payment-callback__title {
+  font-family: var(--font);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-bold);
+  color: var(--text);
+  margin: 0 0 8px;
+  letter-spacing: -0.01em;
+}
+.payment-callback__inner--md .payment-callback__title {
+  font-size: var(--fs-h1);
+}
+.payment-callback__desc {
+  font-family: var(--font);
+  font-size: var(--fs-md);
+  color: var(--text-3);
+  margin: 0 0 4px;
+  line-height: 1.5;
+}
+.payment-callback__meta {
+  font-family: var(--font);
+  font-size: var(--fs-xs);
+  color: var(--text-4);
+  margin: 0 0 8px;
+}
+.payment-callback__content {
+  margin-top: 24px;
+  text-align: left;
+}
+.payment-callback__actions {
+  margin-top: 24px;
+}
+
+/* ── Status icon (PaymentStatusIcon) ──────────────────────────────── */
+.payment-status-icon {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.payment-status-icon--lg {
+  width: 80px;
+  height: 80px;
+}
+.payment-status-icon--success {
+  background: var(--success-bg);
+  color: var(--success);
+}
+.payment-status-icon--error {
+  background: var(--danger-bg);
+  color: var(--danger);
+}
+.payment-status-icon--loading {
+  background: var(--surface-2);
+  color: var(--brand);
+}
+
+.payment-status-icon__spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid var(--border-2);
+  border-right-color: var(--brand);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+.payment-status-icon--lg .payment-status-icon__spinner {
+  width: 36px;
+  height: 36px;
+}
+
+/* ── Receipt (PaymentReceipt) ─────────────────────────────────────── */
+.payment-receipt {
+  text-align: left;
+}
+.payment-receipt__list {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+.payment-receipt__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+.payment-receipt__row:last-child {
+  border-bottom: 0;
+}
+.payment-receipt__label {
+  font-family: var(--font);
+  font-size: var(--fs-sm);
+  color: var(--text-3);
+  margin: 0;
+  flex-shrink: 0;
+}
+.payment-receipt__value {
+  font-family: var(--font);
+  font-size: var(--fs-base);
+  font-weight: var(--fw-medium);
+  color: var(--text);
+  margin: 0;
+  text-align: right;
+  word-break: break-all;
+}
+.payment-receipt__value--bold {
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-bold);
+}
+.payment-receipt__value--mono {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--text-2);
+  font-weight: var(--fw-regular);
+}
+
+/* ── CTA group (PaymentActions) ───────────────────────────────────── */
+.payment-actions {
+  display: flex;
+  gap: 10px;
+}
+.payment-actions :where(.btn) {
+  flex: 1;
+  justify-content: center;
+}
+.payment-actions--single {
+  display: block;
+}
+.payment-actions--single :where(.btn) {
+  flex: initial;
+}


### PR DESCRIPTION
## Summary

Implements the v2 redesign of payment callback pages (`/payment/success`, `/payment/fail`, `/payment/complete`) as specified in Cart.plan.md § 9.1-8 and § 10.3.6 PR 5. Migrates the visual presentation and interaction patterns from v1 to v2 design language while preserving all existing business logic (API calls, sessionStorage validation, Toss query parsing).

## Key Changes

- **New hooks** (`src/pages-v2/PaymentCallback/hooks.ts`):
  - `usePaymentConfirm`: Validates Toss redirect parameters + sessionStorage context, calls confirm API, manages loading/success/error states
  - `usePaymentFail`: Parses failure URL parameters, fires failPayment API (fire-and-forget), clears session
  - `useCompletePayload`: Normalizes location.state to PaymentCompleteVM, handles missing state redirect

- **Page components**:
  - `PaymentSuccessPage.tsx`: Container managing confirm flow with 1.5s auto-redirect to `/payment/complete`
  - `PaymentFailPage.tsx`: Container for failure display with cart/home navigation
  - `PaymentCompletePage.tsx`: Container for receipt display with order/ticket navigation
  - `PaymentSuccess.tsx`, `PaymentFail.tsx`, `PaymentComplete.tsx`: Presentation components for 3-state UI

- **Shared components**:
  - `PaymentCallbackLayout`: Centered layout wrapper (icon/title/description/content/actions slots)
  - `PaymentStatusIcon`: Loading spinner / success checkmark / error X icon with color variants
  - `PaymentReceipt`: Receipt card with label/value rows (supports bold/mono styling)
  - `PaymentActions`: CTA button group (1-2 buttons, auto-full-width for single button)

- **Types** (`types.ts`): PaymentMethod, ConfirmQuery, PaymentSuccessVM, PaymentFailVM, PaymentCompleteVM

- **Styles** (`payment-callback.css`): BEM-scoped layout, icon, receipt, and action styles with CSS variables for colors/typography

- **Fixtures** (`__mocks__/paymentFixtures.ts`): Mock data for QA mode (`?paymentFixture=success|error|fail|complete`)

- **App.tsx**: Added lazy-loaded route entries for v2 payment pages (VersionedRoute toggle pending)

## Implementation Details

- **v1 compatibility**: All API calls, sessionStorage key names, and validation logic preserved from v1 implementation
- **Fixture pattern**: Follows Cart.plan.md § 10.1 cartFixture pattern for visual testing without backend
- **Error handling**: User-friendly error messages extracted from API responses with fallback text
- **Data normalization**: Toss query parameters (paymentKey, orderId, amount) + sessionStorage context merged into confirm API payload
- **Auto-navigation**: Success page automatically redirects to complete page after 1.5s (v1 behavior)
- **State validation**: Complete page validates location.state shape; missing/invalid state triggers redirect to home

https://claude.ai/code/session_0124EzH7KtHevCRTnrju3yBm