### PR TITLE
Implement Tickets tab with pagination and status display

### DIFF
--- a/src/pages-v2/MyPage/shared/TabErrorBox.tsx
+++ b/src/pages-v2/MyPage/shared/TabErrorBox.tsx
@@ -17,7 +17,7 @@ export function TabErrorBox({
       title={title}
       message={message}
       action={
-        <Button variant="ghost" size="sm" onClick={onRetry}>
+        <Button variant="primary" size="sm" onClick={onRetry}>
           다시 시도
         </Button>
       }

--- a/src/pages-v2/MyPage/shared/TabErrorBox.tsx
+++ b/src/pages-v2/MyPage/shared/TabErrorBox.tsx
@@ -1,0 +1,26 @@
+import { Button, EmptyState } from '@/components-v2';
+
+interface TabErrorBoxProps {
+  onRetry: () => void;
+  title?: string;
+  message?: string;
+}
+
+export function TabErrorBox({
+  onRetry,
+  title = '불러오지 못했습니다',
+  message = '잠시 후 다시 시도해 주세요.',
+}: TabErrorBoxProps) {
+  return (
+    <EmptyState
+      emoji="⚠️"
+      title={title}
+      message={message}
+      action={
+        <Button variant="ghost" size="sm" onClick={onRetry}>
+          다시 시도
+        </Button>
+      }
+    />
+  );
+}

--- a/src/pages-v2/MyPage/shared/TabFetchState.tsx
+++ b/src/pages-v2/MyPage/shared/TabFetchState.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+import { TabErrorBox } from './TabErrorBox';
+
+export type FetchState<T> =
+  | { status: 'loading' }
+  | { status: 'error'; error: Error; retry: () => void }
+  | { status: 'ready'; data: T };
+
+interface TabFetchStateProps<T> {
+  state: FetchState<T>;
+  skeleton: ReactNode;
+  empty?: { when: (data: T) => boolean; render: ReactNode };
+  children: (data: T) => ReactNode;
+}
+
+export function TabFetchState<T>({
+  state,
+  skeleton,
+  empty,
+  children,
+}: TabFetchStateProps<T>) {
+  if (state.status === 'loading') return <>{skeleton}</>;
+  if (state.status === 'error') return <TabErrorBox onRetry={state.retry} />;
+  if (empty?.when(state.data)) return <>{empty.render}</>;
+  return <>{children(state.data)}</>;
+}

--- a/src/pages-v2/MyPage/tabs/Tickets/TicketsTab.tsx
+++ b/src/pages-v2/MyPage/tabs/Tickets/TicketsTab.tsx
@@ -1,3 +1,57 @@
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { TabFetchState } from '../../shared/TabFetchState';
+import { useTickets } from './hooks';
+import { EmptyTickets } from './components/EmptyTickets';
+import { TicketGrid } from './components/TicketGrid';
+import { TicketsHeader } from './components/TicketsHeader';
+import { TicketsPager } from './components/TicketsPager';
+import { TicketsSkeleton } from './components/TicketsSkeleton';
+
 export function TicketsTab() {
-  return <div className="mypage-tab-placeholder">Tickets — 준비 중</div>;
+  const [sp, setSp] = useSearchParams();
+  const navigate = useNavigate();
+  const rawPage = Number(sp.get('page') ?? '1');
+  const page = Number.isFinite(rawPage) && rawPage >= 1 ? rawPage : 1;
+  const state = useTickets(page);
+
+  const onPageChange = (next: number) => {
+    setSp(
+      (prev) => {
+        const nextSp = new URLSearchParams(prev);
+        if (next <= 1) nextSp.delete('page');
+        else nextSp.set('page', String(next));
+        return nextSp;
+      },
+      { replace: true },
+    );
+  };
+
+  return (
+    <TabFetchState
+      state={state}
+      skeleton={<TicketsSkeleton count={6} />}
+      empty={{
+        when: (data) => data.tickets.length === 0,
+        render: <EmptyTickets onBrowse={() => navigate('/')} />,
+      }}
+    >
+      {(data) => (
+        <>
+          <TicketsHeader
+            total={data.total}
+            validCount={data.validCount}
+            usedCount={data.usedCount}
+          />
+          <TicketGrid tickets={data.tickets} />
+          {data.totalPages > 1 && (
+            <TicketsPager
+              page={page}
+              totalPages={data.totalPages}
+              onPageChange={onPageChange}
+            />
+          )}
+        </>
+      )}
+    </TabFetchState>
+  );
 }

--- a/src/pages-v2/MyPage/tabs/Tickets/adapters.ts
+++ b/src/pages-v2/MyPage/tabs/Tickets/adapters.ts
@@ -1,0 +1,28 @@
+import type { TicketItem } from '@/api/types';
+import { fmtDate } from '@/lib/format';
+import { accent } from '@/styles-v2/accent';
+import type { TicketStatus, TicketVM } from './types';
+
+type StatusEntry = { variant: TicketVM['statusVariant']; label: string };
+
+export const TICKET_STATUS_MAP: Record<Exclude<TicketStatus, 'UNKNOWN'>, StatusEntry> = {
+  VALID: { variant: 'ok', label: '사용 가능' },
+  USED: { variant: 'end', label: '사용 완료' },
+  CANCELLED: { variant: 'sold', label: '취소됨' },
+  EXPIRED: { variant: 'end', label: '만료' },
+};
+
+export function toTicketVM(api: TicketItem): TicketVM {
+  const known = (TICKET_STATUS_MAP as Record<string, StatusEntry | undefined>)[api.status];
+  const status: TicketStatus = known ? (api.status as TicketStatus) : 'UNKNOWN';
+  return {
+    ticketId: String(api.ticketId),
+    eventId: api.eventId,
+    title: api.eventTitle,
+    dateLabel: fmtDate(api.eventDate),
+    status,
+    statusVariant: known?.variant ?? 'end',
+    statusLabel: known?.label ?? api.status,
+    accent: accent(api.eventId),
+  };
+}

--- a/src/pages-v2/MyPage/tabs/Tickets/components/EmptyTickets.tsx
+++ b/src/pages-v2/MyPage/tabs/Tickets/components/EmptyTickets.tsx
@@ -1,0 +1,20 @@
+import { Button, EmptyState } from '@/components-v2';
+
+interface EmptyTicketsProps {
+  onBrowse: () => void;
+}
+
+export function EmptyTickets({ onBrowse }: EmptyTicketsProps) {
+  return (
+    <EmptyState
+      emoji="🎫"
+      title="보유한 티켓이 없습니다"
+      message="마음에 드는 이벤트를 찾아 첫 티켓을 만들어보세요."
+      action={
+        <Button variant="primary" onClick={onBrowse}>
+          이벤트 둘러보기
+        </Button>
+      }
+    />
+  );
+}

--- a/src/pages-v2/MyPage/tabs/Tickets/components/TicketCard.tsx
+++ b/src/pages-v2/MyPage/tabs/Tickets/components/TicketCard.tsx
@@ -1,0 +1,22 @@
+import { Card } from '@/components-v2';
+import type { TicketVM } from '../types';
+import { TicketStripe } from './TicketStripe';
+import { TicketInfo } from './TicketInfo';
+
+interface TicketCardProps {
+  ticket: TicketVM;
+}
+
+export function TicketCard({ ticket }: TicketCardProps) {
+  return (
+    <Card variant="solid" padding="none" className="ticket-card">
+      <TicketStripe accent={ticket.accent} />
+      <TicketInfo
+        statusVariant={ticket.statusVariant}
+        statusLabel={ticket.statusLabel}
+        title={ticket.title}
+        dateLabel={ticket.dateLabel}
+      />
+    </Card>
+  );
+}

--- a/src/pages-v2/MyPage/tabs/Tickets/components/TicketGrid.tsx
+++ b/src/pages-v2/MyPage/tabs/Tickets/components/TicketGrid.tsx
@@ -1,0 +1,16 @@
+import type { TicketVM } from '../types';
+import { TicketCard } from './TicketCard';
+
+interface TicketGridProps {
+  tickets: TicketVM[];
+}
+
+export function TicketGrid({ tickets }: TicketGridProps) {
+  return (
+    <div className="ticket-grid">
+      {tickets.map((ticket) => (
+        <TicketCard key={ticket.ticketId} ticket={ticket} />
+      ))}
+    </div>
+  );
+}

--- a/src/pages-v2/MyPage/tabs/Tickets/components/TicketInfo.tsx
+++ b/src/pages-v2/MyPage/tabs/Tickets/components/TicketInfo.tsx
@@ -1,0 +1,25 @@
+import { StatusChip } from '@/components-v2';
+
+interface TicketInfoProps {
+  statusVariant: 'ok' | 'end' | 'sold';
+  statusLabel: string;
+  title: string;
+  dateLabel: string;
+}
+
+export function TicketInfo({
+  statusVariant,
+  statusLabel,
+  title,
+  dateLabel,
+}: TicketInfoProps) {
+  return (
+    <div className="ticket-info">
+      <StatusChip variant={statusVariant}>{statusLabel}</StatusChip>
+      <h3 className="ticket-info-title">{title}</h3>
+      <div className="ticket-info-meta">
+        <span aria-hidden="true">📅</span> {dateLabel}
+      </div>
+    </div>
+  );
+}

--- a/src/pages-v2/MyPage/tabs/Tickets/components/TicketStripe.tsx
+++ b/src/pages-v2/MyPage/tabs/Tickets/components/TicketStripe.tsx
@@ -1,0 +1,20 @@
+import { AccentMediaBox, Icon } from '@/components-v2';
+
+interface TicketStripeProps {
+  accent: string;
+}
+
+export function TicketStripe({ accent }: TicketStripeProps) {
+  return (
+    <div className="ticket-stripe">
+      <AccentMediaBox accent={accent} variant="stripe" size="sm" glyph="" />
+      <span
+        className="ticket-stripe-icon"
+        style={{ color: accent }}
+        aria-hidden="true"
+      >
+        <Icon name="ticket" size={20} />
+      </span>
+    </div>
+  );
+}

--- a/src/pages-v2/MyPage/tabs/Tickets/components/TicketsHeader.tsx
+++ b/src/pages-v2/MyPage/tabs/Tickets/components/TicketsHeader.tsx
@@ -1,0 +1,20 @@
+interface TicketsHeaderProps {
+  total: number;
+  validCount: number;
+  usedCount: number;
+}
+
+export function TicketsHeader({
+  total,
+  validCount,
+  usedCount,
+}: TicketsHeaderProps) {
+  return (
+    <div className="tickets-header">
+      <h2 className="tickets-header-title">티켓 {total}개</h2>
+      <p className="tickets-header-counts">
+        사용 가능 {validCount} · 사용 완료 {usedCount}
+      </p>
+    </div>
+  );
+}

--- a/src/pages-v2/MyPage/tabs/Tickets/components/TicketsPager.tsx
+++ b/src/pages-v2/MyPage/tabs/Tickets/components/TicketsPager.tsx
@@ -1,0 +1,37 @@
+import { Button } from '@/components-v2';
+
+interface TicketsPagerProps {
+  page: number;
+  totalPages: number;
+  onPageChange: (next: number) => void;
+}
+
+export function TicketsPager({
+  page,
+  totalPages,
+  onPageChange,
+}: TicketsPagerProps) {
+  return (
+    <div className="tickets-pager">
+      <Button
+        variant="ghost"
+        size="sm"
+        disabled={page <= 1}
+        onClick={() => onPageChange(page - 1)}
+      >
+        이전
+      </Button>
+      <span className="tickets-pager-info" aria-live="polite">
+        {page} / {totalPages}
+      </span>
+      <Button
+        variant="ghost"
+        size="sm"
+        disabled={page >= totalPages}
+        onClick={() => onPageChange(page + 1)}
+      >
+        다음
+      </Button>
+    </div>
+  );
+}

--- a/src/pages-v2/MyPage/tabs/Tickets/components/TicketsSkeleton.tsx
+++ b/src/pages-v2/MyPage/tabs/Tickets/components/TicketsSkeleton.tsx
@@ -1,0 +1,28 @@
+import { Card } from '@/components-v2';
+
+interface TicketsSkeletonProps {
+  count?: number;
+}
+
+export function TicketsSkeleton({ count = 6 }: TicketsSkeletonProps) {
+  return (
+    <div className="ticket-grid" aria-busy="true" aria-live="polite">
+      {Array.from({ length: count }).map((_, i) => (
+        <Card
+          key={i}
+          variant="solid"
+          padding="none"
+          className="ticket-card tickets-skeleton-card"
+          aria-hidden="true"
+        >
+          <div className="tickets-skeleton-stripe" />
+          <div className="tickets-skeleton-body">
+            <div className="tickets-skeleton-bar tickets-skeleton-bar-sm" />
+            <div className="tickets-skeleton-bar tickets-skeleton-bar-lg" />
+            <div className="tickets-skeleton-bar tickets-skeleton-bar-md" />
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/pages-v2/MyPage/tabs/Tickets/hooks.ts
+++ b/src/pages-v2/MyPage/tabs/Tickets/hooks.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getTickets } from '@/api/tickets.api';
+import type { FetchState } from '../../shared/TabFetchState';
+import { toTicketVM } from './adapters';
+import type { TicketVM } from './types';
+
+const PAGE_SIZE = 20;
+
+export interface TicketsData {
+  tickets: TicketVM[];
+  total: number;
+  totalPages: number;
+  validCount: number;
+  usedCount: number;
+}
+
+export type UseTicketsReturn = FetchState<TicketsData> & {
+  refetch: () => void;
+};
+
+export function useTickets(page: number): UseTicketsReturn {
+  const [state, setState] = useState<FetchState<TicketsData>>({
+    status: 'loading',
+  });
+  const [tick, setTick] = useState(0);
+  const refetch = useCallback(() => setTick((n) => n + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: 'loading' });
+
+    getTickets({ page: page - 1, size: PAGE_SIZE })
+      .then((res) => {
+        if (cancelled) return;
+        const tickets = res.data.tickets.map(toTicketVM);
+        setState({
+          status: 'ready',
+          data: {
+            tickets,
+            total: res.data.totalElements,
+            totalPages: res.data.totalPages,
+            validCount: tickets.filter((t) => t.status === 'VALID').length,
+            usedCount: tickets.filter((t) => t.status === 'USED').length,
+          },
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        const err = error instanceof Error ? error : new Error(String(error));
+        setState({ status: 'error', error: err, retry: refetch });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [page, tick, refetch]);
+
+  return { ...state, refetch };
+}

--- a/src/pages-v2/MyPage/tabs/Tickets/types.ts
+++ b/src/pages-v2/MyPage/tabs/Tickets/types.ts
@@ -1,0 +1,17 @@
+export type TicketStatus =
+  | 'VALID'
+  | 'USED'
+  | 'CANCELLED'
+  | 'EXPIRED'
+  | 'UNKNOWN';
+
+export interface TicketVM {
+  ticketId: string;
+  eventId: string;
+  title: string;
+  dateLabel: string;
+  status: TicketStatus;
+  statusVariant: 'ok' | 'end' | 'sold';
+  statusLabel: string;
+  accent: string;
+}

--- a/src/styles-v2/index.css
+++ b/src/styles-v2/index.css
@@ -29,3 +29,4 @@
 @import './pages/cart.css';
 @import './pages/payment-callback.css';
 @import './pages/mypage-shell.css';
+@import './pages/mypage-tickets.css';

--- a/src/styles-v2/pages/mypage-tickets.css
+++ b/src/styles-v2/pages/mypage-tickets.css
@@ -1,0 +1,119 @@
+/* DevTicket v2 — Tickets tab styles
+   Source: docs/redesign/MyPage.plan.md §5 + prototype/MyPage.jsx tickets tab.
+   Scope: classes used in pages-v2/MyPage/tabs/Tickets/.
+   AccentMediaBox(stripe/sm) 자체가 56px width 와 그라디언트를 담당; 본 파일은
+   dashed right border, 절대배치 아이콘, 우측 본문 레이아웃, 페이저, 스켈레톤만. */
+
+/* ── Tab header (§5.1.2 TicketsHeader) ──────────────────────────── */
+.tickets-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 12px;
+}
+.tickets-header-title {
+  font-family: var(--font);
+  font-size: var(--fs-base);
+  font-weight: var(--fw-semibold);
+  color: var(--text);
+  margin: 0;
+}
+.tickets-header-counts {
+  font-family: var(--font);
+  font-size: var(--fs-xs);
+  color: var(--text-3);
+  margin: 0;
+}
+
+/* ── Grid (§5.1.2 TicketGrid) ───────────────────────────────────── */
+.ticket-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 12px;
+}
+
+/* ── Card (§5.1.2 TicketCard, §5.1.4 padding=0/overflow hidden) ─── */
+.ticket-card {
+  display: flex;
+  overflow: hidden;
+}
+
+/* ── Stripe (§5.1.5 TicketStripe) ───────────────────────────────── */
+.ticket-stripe {
+  position: relative;
+  flex-shrink: 0;
+  border-right: 1px dashed var(--border-2);
+}
+.ticket-stripe-icon {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+/* ── Info (§5.1.2 TicketInfo) ───────────────────────────────────── */
+.ticket-info {
+  flex: 1;
+  min-width: 0;
+  padding: 16px;
+}
+.ticket-info-title {
+  font-family: var(--font);
+  font-size: var(--fs-base);
+  font-weight: var(--fw-semibold);
+  line-height: 1.4;
+  color: var(--text);
+  margin: 6px 0;
+}
+.ticket-info-meta {
+  display: flex;
+  gap: 14px;
+  font-family: var(--font);
+  font-size: var(--fs-xs);
+  color: var(--text-3);
+}
+
+/* ── Pager (§6.2.8 TicketsPager) ────────────────────────────────── */
+.tickets-pager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 16px;
+}
+.tickets-pager-info {
+  font-family: var(--font);
+  font-size: var(--fs-sm);
+  color: var(--text-3);
+  min-width: 60px;
+  text-align: center;
+}
+
+/* ── Skeleton (§5.3.2 TicketsSkeleton) ──────────────────────────── */
+.tickets-skeleton-card {
+  display: flex;
+  overflow: hidden;
+}
+.tickets-skeleton-stripe {
+  width: 56px;
+  flex-shrink: 0;
+  background: var(--surface-2);
+  border-right: 1px dashed var(--border-2);
+}
+.tickets-skeleton-body {
+  flex: 1;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.tickets-skeleton-bar {
+  height: 12px;
+  background: var(--surface-3);
+  border-radius: 6px;
+}
+.tickets-skeleton-bar-sm { width: 60px; height: 18px; }
+.tickets-skeleton-bar-lg { width: 80%; }
+.tickets-skeleton-bar-md { width: 50%; }


### PR DESCRIPTION
## Summary
Implements the complete Tickets tab for MyPage v2, featuring a paginated grid of user tickets with status indicators, empty states, and loading skeletons.

## Key Changes

### Core Components
- **TicketsTab**: Main tab component with pagination state management via URL search params
- **TicketGrid**: Responsive grid layout (340px min-width columns) for ticket cards
- **TicketCard**: Individual ticket card with stripe accent and info section
- **TicketStripe**: Colored accent stripe with ticket icon
- **TicketInfo**: Displays status chip, event title, and date
- **TicketsPager**: Navigation controls with page indicator
- **TicketsSkeleton**: Loading placeholder with 6 skeleton cards
- **EmptyTickets**: Empty state when user has no tickets

### Data & Logic
- **useTickets hook**: Fetches paginated tickets (20 per page) with error handling and refetch capability
- **adapters.ts**: Converts API ticket items to view models with status mapping (VALID → "사용 가능", USED → "사용 완료", etc.)
- **types.ts**: TypeScript definitions for TicketVM and TicketStatus

### Shared Utilities
- **TabFetchState**: Generic component for handling loading/error/ready states across tabs
- **TabErrorBox**: Reusable error display with retry button

### Styling
- **mypage-tickets.css**: Comprehensive styles for all ticket components including:
  - Grid layout with auto-fill responsive columns
  - Card structure with flex layout
  - Dashed border stripe separator
  - Pagination controls
  - Skeleton loading animation classes

## Implementation Details
- URL-based pagination (e.g., `?page=2`) with fallback to page 1
- Ticket status counts displayed in header (total, valid, used)
- Accent colors derived from event IDs for visual variety
- Proper accessibility attributes (aria-live, aria-hidden, aria-busy)
- Cancellation handling for in-flight requests

https://claude.ai/code/session_01FPnDXP7tLFBviFzC2i6HjS