### PR TITLE
Implement refund history tab with pagination and status display

### DIFF
--- a/src/pages-v2/MyPage/tabs/Refund/RefundTab.tsx
+++ b/src/pages-v2/MyPage/tabs/Refund/RefundTab.tsx
@@ -1,3 +1,47 @@
+import { useSearchParams } from 'react-router-dom';
+import { TabFetchState } from '../../shared/TabFetchState';
+import { useRefunds } from './hooks';
+import { EmptyRefunds } from './components/EmptyRefunds';
+import { RefundList } from './components/RefundList';
+import { RefundsPager } from './components/RefundsPager';
+import { RefundsSkeleton } from './components/RefundsSkeleton';
+
 export function RefundTab() {
-  return <div className="mypage-tab-placeholder">Refund — 준비 중</div>;
+  const [sp, setSp] = useSearchParams();
+  const rawPage = Number(sp.get('page') ?? '1');
+  const page = Number.isFinite(rawPage) && rawPage >= 1 ? rawPage : 1;
+  const state = useRefunds(page);
+
+  const onPageChange = (next: number) => {
+    setSp((prev) => {
+      const nextSp = new URLSearchParams(prev);
+      if (next <= 1) nextSp.delete('page');
+      else nextSp.set('page', String(next));
+      return nextSp;
+    });
+  };
+
+  return (
+    <TabFetchState
+      state={state}
+      skeleton={<RefundsSkeleton rows={6} />}
+      empty={{
+        when: (data) => data.rows.length === 0,
+        render: <EmptyRefunds />,
+      }}
+    >
+      {(data) => (
+        <>
+          <RefundList rows={data.rows} />
+          {data.totalPages > 1 && (
+            <RefundsPager
+              page={page}
+              totalPages={data.totalPages}
+              onPageChange={onPageChange}
+            />
+          )}
+        </>
+      )}
+    </TabFetchState>
+  );
 }

--- a/src/pages-v2/MyPage/tabs/Refund/adapters.ts
+++ b/src/pages-v2/MyPage/tabs/Refund/adapters.ts
@@ -1,0 +1,38 @@
+import type { RefundItem } from '@/api/types';
+import { fmtDate } from '@/lib/format';
+import type { RefundRowVM, RefundStatus } from './types';
+
+type StatusEntry = { variant: RefundRowVM['statusVariant']; label: string };
+
+export const REFUND_STATUS_MAP: Record<Exclude<RefundStatus, 'UNKNOWN'>, StatusEntry> = {
+  REQUESTED: { variant: 'end', label: '처리 중' },
+  APPROVED: { variant: 'end', label: '처리 중' },
+  COMPLETED: { variant: 'ok', label: '완료' },
+  REJECTED: { variant: 'sold', label: '거절됨' },
+  FAILED: { variant: 'sold', label: '취소됨' },
+};
+
+export function shortenId(raw: string): string {
+  if (raw.length <= 12) return raw;
+  return `${raw.slice(0, 8)}…${raw.slice(-4)}`;
+}
+
+function fmtRefundAmount(amount: number): string {
+  return amount === 0 ? '0원' : `${amount.toLocaleString()}원`;
+}
+
+export function toRefundRowVM(api: RefundItem): RefundRowVM {
+  const known = (REFUND_STATUS_MAP as Record<string, StatusEntry | undefined>)[api.status];
+  const status: RefundStatus = known ? (api.status as RefundStatus) : 'UNKNOWN';
+  return {
+    refundId: api.refundId,
+    orderId: api.orderId,
+    displayRefundId: shortenId(api.refundId),
+    displayOrderId: shortenId(api.orderId),
+    amountLabel: fmtRefundAmount(api.refundAmount),
+    status,
+    statusVariant: known?.variant ?? 'end',
+    statusLabel: known?.label ?? api.status,
+    dateLabel: fmtDate(api.requestedAt),
+  };
+}

--- a/src/pages-v2/MyPage/tabs/Refund/columns.ts
+++ b/src/pages-v2/MyPage/tabs/Refund/columns.ts
@@ -1,0 +1,18 @@
+import type { RefundRowVM } from './types';
+
+export interface RefundColumn {
+  key: keyof Pick<
+    RefundRowVM,
+    'displayRefundId' | 'displayOrderId' | 'amountLabel' | 'statusLabel' | 'dateLabel'
+  >;
+  label: string;
+  align: 'left' | 'right';
+}
+
+export const REFUND_COLUMNS: readonly RefundColumn[] = [
+  { key: 'displayRefundId', label: '환불번호', align: 'left' },
+  { key: 'displayOrderId', label: '주문번호', align: 'left' },
+  { key: 'amountLabel', label: '환불 금액', align: 'left' },
+  { key: 'statusLabel', label: '상태', align: 'left' },
+  { key: 'dateLabel', label: '요청일', align: 'left' },
+] as const;

--- a/src/pages-v2/MyPage/tabs/Refund/components/EmptyRefunds.tsx
+++ b/src/pages-v2/MyPage/tabs/Refund/components/EmptyRefunds.tsx
@@ -1,0 +1,16 @@
+import { EmptyState } from '@/components-v2';
+
+export function EmptyRefunds() {
+  return (
+    <EmptyState
+      emoji="💳"
+      title="환불 내역이 없습니다"
+      message={
+        <>
+          환불은 <strong>내 티켓</strong> 탭에서 각 티켓의 환불 요청 버튼으로
+          시작할 수 있습니다.
+        </>
+      }
+    />
+  );
+}

--- a/src/pages-v2/MyPage/tabs/Refund/components/RefundList.tsx
+++ b/src/pages-v2/MyPage/tabs/Refund/components/RefundList.tsx
@@ -1,0 +1,23 @@
+import { Card } from '@/components-v2';
+import type { RefundRowVM } from '../types';
+import { RefundRow } from './RefundRow';
+import { RefundTableHeader } from './RefundTableHeader';
+
+interface RefundListProps {
+  rows: RefundRowVM[];
+}
+
+export function RefundList({ rows }: RefundListProps) {
+  return (
+    <Card variant="solid" padding="none" className="refunds-card">
+      <table className="refunds-table">
+        <RefundTableHeader />
+        <tbody>
+          {rows.map((row) => (
+            <RefundRow key={row.refundId} row={row} />
+          ))}
+        </tbody>
+      </table>
+    </Card>
+  );
+}

--- a/src/pages-v2/MyPage/tabs/Refund/components/RefundRow.tsx
+++ b/src/pages-v2/MyPage/tabs/Refund/components/RefundRow.tsx
@@ -1,0 +1,24 @@
+import { StatusChip } from '@/components-v2';
+import type { RefundRowVM } from '../types';
+
+interface RefundRowProps {
+  row: RefundRowVM;
+}
+
+export function RefundRow({ row }: RefundRowProps) {
+  return (
+    <tr className="refund-row">
+      <td className="refund-cell refund-cell-id" title={row.refundId}>
+        {row.displayRefundId}
+      </td>
+      <td className="refund-cell refund-cell-id" title={row.orderId}>
+        {row.displayOrderId}
+      </td>
+      <td className="refund-cell refund-cell-amount">{row.amountLabel}</td>
+      <td className="refund-cell refund-cell-status">
+        <StatusChip variant={row.statusVariant}>{row.statusLabel}</StatusChip>
+      </td>
+      <td className="refund-cell refund-cell-date">{row.dateLabel}</td>
+    </tr>
+  );
+}

--- a/src/pages-v2/MyPage/tabs/Refund/components/RefundTableHeader.tsx
+++ b/src/pages-v2/MyPage/tabs/Refund/components/RefundTableHeader.tsx
@@ -1,0 +1,20 @@
+import { REFUND_COLUMNS } from '../columns';
+
+export function RefundTableHeader() {
+  return (
+    <thead className="refunds-table-header">
+      <tr>
+        {REFUND_COLUMNS.map((col) => (
+          <th
+            key={col.key}
+            scope="col"
+            className={`refunds-th refunds-th-${col.key}`}
+            style={{ textAlign: col.align }}
+          >
+            {col.label}
+          </th>
+        ))}
+      </tr>
+    </thead>
+  );
+}

--- a/src/pages-v2/MyPage/tabs/Refund/components/RefundsPager.tsx
+++ b/src/pages-v2/MyPage/tabs/Refund/components/RefundsPager.tsx
@@ -1,0 +1,37 @@
+import { Button } from '@/components-v2';
+
+interface RefundsPagerProps {
+  page: number;
+  totalPages: number;
+  onPageChange: (next: number) => void;
+}
+
+export function RefundsPager({
+  page,
+  totalPages,
+  onPageChange,
+}: RefundsPagerProps) {
+  return (
+    <div className="refunds-pager">
+      <Button
+        variant="ghost"
+        size="sm"
+        disabled={page <= 1}
+        onClick={() => onPageChange(page - 1)}
+      >
+        이전
+      </Button>
+      <span className="refunds-pager-info" aria-live="polite">
+        {page} / {totalPages}
+      </span>
+      <Button
+        variant="ghost"
+        size="sm"
+        disabled={page >= totalPages}
+        onClick={() => onPageChange(page + 1)}
+      >
+        다음
+      </Button>
+    </div>
+  );
+}

--- a/src/pages-v2/MyPage/tabs/Refund/components/RefundsSkeleton.tsx
+++ b/src/pages-v2/MyPage/tabs/Refund/components/RefundsSkeleton.tsx
@@ -1,0 +1,43 @@
+import { Card } from '@/components-v2';
+import { RefundTableHeader } from './RefundTableHeader';
+
+interface RefundsSkeletonProps {
+  rows?: number;
+}
+
+export function RefundsSkeleton({ rows = 6 }: RefundsSkeletonProps) {
+  return (
+    <Card
+      variant="solid"
+      padding="none"
+      className="refunds-card refunds-skeleton"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <table className="refunds-table">
+        <RefundTableHeader />
+        <tbody>
+          {Array.from({ length: rows }).map((_, i) => (
+            <tr key={i} className="refund-row refund-row-skeleton" aria-hidden="true">
+              <td className="refund-cell refund-cell-id">
+                <span className="refunds-skeleton-bar refunds-skeleton-bar-sm" />
+              </td>
+              <td className="refund-cell refund-cell-id">
+                <span className="refunds-skeleton-bar refunds-skeleton-bar-sm" />
+              </td>
+              <td className="refund-cell refund-cell-amount">
+                <span className="refunds-skeleton-bar refunds-skeleton-bar-md" />
+              </td>
+              <td className="refund-cell refund-cell-status">
+                <span className="refunds-skeleton-bar refunds-skeleton-bar-chip" />
+              </td>
+              <td className="refund-cell refund-cell-date">
+                <span className="refunds-skeleton-bar refunds-skeleton-bar-md" />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Card>
+  );
+}

--- a/src/pages-v2/MyPage/tabs/Refund/hooks.ts
+++ b/src/pages-v2/MyPage/tabs/Refund/hooks.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getRefunds } from '@/api/refunds.api';
+import type { FetchState } from '../../shared/TabFetchState';
+import { toRefundRowVM } from './adapters';
+import type { RefundRowVM } from './types';
+
+const PAGE_SIZE = 20;
+
+export interface RefundsData {
+  rows: RefundRowVM[];
+  page: number;
+  totalPages: number;
+  totalElements: number;
+}
+
+export type UseRefundsReturn = FetchState<RefundsData> & {
+  refetch: () => void;
+};
+
+export function useRefunds(page: number): UseRefundsReturn {
+  const [state, setState] = useState<FetchState<RefundsData>>({
+    status: 'loading',
+  });
+  const [tick, setTick] = useState(0);
+  const refetch = useCallback(() => setTick((n) => n + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: 'loading' });
+
+    getRefunds({ page: page - 1, size: PAGE_SIZE })
+      .then((res) => {
+        if (cancelled) return;
+        const list = res.data;
+        const rows = list.content.map(toRefundRowVM);
+        setState({
+          status: 'ready',
+          data: {
+            rows,
+            page,
+            totalPages: list.totalPages,
+            totalElements: list.totalElements,
+          },
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        const err = error instanceof Error ? error : new Error(String(error));
+        setState({ status: 'error', error: err, retry: refetch });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [page, tick, refetch]);
+
+  return { ...state, refetch };
+}

--- a/src/pages-v2/MyPage/tabs/Refund/types.ts
+++ b/src/pages-v2/MyPage/tabs/Refund/types.ts
@@ -1,0 +1,19 @@
+export type RefundStatus =
+  | 'REQUESTED'
+  | 'APPROVED'
+  | 'COMPLETED'
+  | 'REJECTED'
+  | 'FAILED'
+  | 'UNKNOWN';
+
+export interface RefundRowVM {
+  refundId: string;
+  orderId: string;
+  displayRefundId: string;
+  displayOrderId: string;
+  amountLabel: string;
+  status: RefundStatus;
+  statusVariant: 'ok' | 'end' | 'sold';
+  statusLabel: string;
+  dateLabel: string;
+}

--- a/src/styles-v2/index.css
+++ b/src/styles-v2/index.css
@@ -32,3 +32,4 @@
 @import './pages/mypage-tickets.css';
 @import './pages/mypage-orders.css';
 @import './pages/mypage-wallet.css';
+@import './pages/mypage-refund.css';

--- a/src/styles-v2/pages/mypage-refund.css
+++ b/src/styles-v2/pages/mypage-refund.css
@@ -1,0 +1,93 @@
+/* DevTicket v2 — Refund tab styles
+   Source: docs/redesign/MyPage.plan.md §8 + §12.5.
+   Scope: classes used in pages-v2/MyPage/tabs/Refund/.
+   5컬럼 표 (환불번호 / 주문번호 / 환불 금액 / 상태 / 요청일). */
+
+/* ── Card shell ────────────────────────────────────────────────── */
+.refunds-card {
+  overflow: hidden;
+}
+
+/* ── Table ─────────────────────────────────────────────────────── */
+.refunds-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+/* ── Header (thead surface-2 uppercase mono 11.5px) ────────────── */
+.refunds-table-header {
+  background: var(--surface-2);
+}
+.refunds-th {
+  padding: 10px 14px;
+  font-family: var(--font);
+  font-size: 11.5px;
+  font-weight: var(--fw-semibold);
+  color: var(--text-3);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--border);
+}
+
+/* ── Rows (tbody border-top) ───────────────────────────────────── */
+.refund-row + .refund-row > .refund-cell {
+  border-top: 1px solid var(--border);
+}
+.refund-cell {
+  padding: 12px 14px;
+  font-family: var(--font);
+  font-size: var(--fs-base);
+  color: var(--text);
+  vertical-align: middle;
+}
+
+/* ── Cell variants (§8.1.3 mono syn-fn 색) ─────────────────────── */
+.refund-cell-id {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--syn-fn);
+  white-space: nowrap;
+}
+.refund-cell-amount {
+  font-weight: var(--fw-semibold);
+  white-space: nowrap;
+}
+.refund-cell-status {
+  white-space: nowrap;
+}
+.refund-cell-date {
+  font-size: var(--fs-sm);
+  color: var(--text-3);
+  white-space: nowrap;
+}
+
+/* ── Pager ─────────────────────────────────────────────────────── */
+.refunds-pager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 16px;
+}
+.refunds-pager-info {
+  font-family: var(--font);
+  font-size: var(--fs-sm);
+  color: var(--text-3);
+  min-width: 60px;
+  text-align: center;
+}
+
+/* ── Skeleton (§8.1.8 RefundsSkeleton — 빈 tr × 6) ─────────────── */
+.refunds-skeleton .refund-row-skeleton .refund-cell {
+  height: 44px;
+}
+.refunds-skeleton-bar {
+  display: inline-block;
+  height: 12px;
+  background: var(--surface-3);
+  border-radius: var(--r-sm);
+  vertical-align: middle;
+}
+.refunds-skeleton-bar-sm   { width: 80px; }
+.refunds-skeleton-bar-md   { width: 60%; }
+.refunds-skeleton-bar-chip { width: 64px; height: 18px; border-radius: var(--r-full); }


### PR DESCRIPTION
## Summary
Implements the Refund tab in MyPage with a complete refund history interface, including data fetching, pagination, and status visualization.

## Key Changes

- **Refund Tab Component** (`RefundTab.tsx`): Main tab component with URL-based pagination state management and conditional rendering for loading, empty, and data states
- **Data Fetching Hook** (`hooks.ts`): `useRefunds` hook that fetches paginated refund data with error handling and retry capability
- **Data Adapter** (`adapters.ts`): Converts API refund items to view models with formatted display values (shortened IDs, localized amounts, status labels)
- **Table Components**:
  - `RefundList`: Renders the refund table with header and rows
  - `RefundRow`: Individual refund row with ID, order ID, amount, status chip, and request date
  - `RefundTableHeader`: Reusable table header using column definitions
  - `RefundsSkeleton`: Loading skeleton with 6 placeholder rows
- **Pagination Component** (`RefundsPager.tsx`): Previous/next navigation with page indicator
- **Empty State** (`EmptyRefunds.tsx`): User-friendly message when no refunds exist
- **Styling** (`mypage-refund.css`): Complete table styling including header, rows, cells, pagination, and skeleton loaders
- **Type Definitions** (`types.ts`, `columns.ts`): TypeScript types for refund data and column configuration

## Implementation Details

- Pagination state is managed via URL search parameters (`?page=N`) for bookmarkable/shareable links
- Refund IDs and order IDs are shortened with ellipsis for long values while preserving full text in title attributes
- Status mapping supports 5 states (REQUESTED, APPROVED, COMPLETED, REJECTED, FAILED) with appropriate visual variants
- Skeleton loader matches the table structure with 6 placeholder rows by default
- Uses existing `TabFetchState` component for consistent loading/error/empty state handling across MyPage tabs

https://claude.ai/code/session_015eY7DdGSnvqzuBgsxTA9Bx