### PR TITLE
feat: implement Hero and Stats sections for Landing v2 (PR 2)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,8 @@ const MyPageV2            = lazy(() => import('./pages-v2/MyPage'))
 
 // lazy – v2 dev showcase (Landing.plan §12.1 PR 1; cutover/PR 4 cleanup 시 제거)
 const TypedTerminalShowcase = lazy(() => import('./pages-v2/_dev/TypedTerminalShowcase'))
+// lazy – v2 dev showcase (Landing.plan §12.2 PR 2; cutover/PR 4 cleanup 시 제거)
+const HeroStatsShowcase     = lazy(() => import('./pages-v2/_dev/HeroStatsShowcase'))
 
 // lazy – 로그인 후 접근
 const SignupComplete      = lazy(() => import('./pages/SignupComplete'))
@@ -95,7 +97,8 @@ export default function App() {
         <Route path="/social/profile-setup" element={<SocialProfileSetup />} />
 
         {/* v2 dev showcase (cutover/PR 4 cleanup 시 제거) */}
-        <Route path="/_dev/typed-terminal" element={<TypedTerminalShowcase />} />
+        <Route path="/_dev/typed-terminal"    element={<TypedTerminalShowcase />} />
+        <Route path="/_dev/landing-hero-stats" element={<HeroStatsShowcase />} />
 
         {/* 일반 사용자 */}
         <Route element={<Layout />}>

--- a/src/pages-v2/Landing/adapters.ts
+++ b/src/pages-v2/Landing/adapters.ts
@@ -1,0 +1,57 @@
+/**
+ * Landing 페이지 어댑터.
+ * PR 2 (Hero + Stats) — Landing.plan.md §12.2.
+ *
+ * - `toStatsVM(firstPage)` — Stats 4 카드 합성 (§4 표 1, §11 #3).
+ *   1=totalElements, 2=ON_SALE 길이, 3=remainingQuantity 합, 4='24+' 하드코딩.
+ * - `buildTerminalLines(totalCount)` — TypedTerminal 라인 합성 (§11 #1).
+ *   라인 1 의 카운트만 동적, 라인 2 는 프로토타입 하드코딩 유지.
+ *
+ * (PR 3 진입 시 toFeaturedItemVM / toCategoryCountVM 추가)
+ */
+
+import type { EventListPage } from '@/pages-v2/EventList/types';
+import type { StatVM, TerminalLine } from './types';
+
+/**
+ * 4번 카드 ('참여 커뮤니티') v1 하드코딩 값.
+ * §4 표 1 옵션 A — 백엔드 카운트 엔드포인트 부재. 합의되면 어댑터만 교체.
+ */
+const HOSTS_HARDCODED = '24+';
+
+export const toStatsVM = (firstPage: EventListPage): StatVM[] => {
+  const items = firstPage.items;
+  const onSaleCount = items.filter((e) => e.status === 'ON_SALE').length;
+  const remainingSum = items.reduce((acc, e) => acc + e.remainingQuantity, 0);
+  return [
+    { hint: '// active events',  num: firstPage.totalElements, unit: '개', label: '진행 중인 이벤트' },
+    { hint: '// on sale',        num: onSaleCount,             unit: '매', label: '판매중인 티켓'   },
+    { hint: '// seats left',     num: remainingSum,            unit: '+', label: '전체 잔여 좌석'   },
+    { hint: '// communities',    num: HOSTS_HARDCODED,         unit: '팀', label: '참여 커뮤니티'   },
+  ];
+};
+
+/**
+ * TypedTerminal 라인 합성.
+ * 라인 1 의 out 만 totalCount 로 합성. 미수신(undefined) 시 §6.1 보강에 따라
+ * "다양한" 으로 fallback (라인 자체는 정적 노출 유지).
+ * 라인 2 는 프로토타입 그대로 하드코딩 (§3 라인 데이터, §12.2 검증 케이스 4).
+ */
+export const buildTerminalLines = (
+  totalCount: number | undefined,
+): TerminalLine[] => {
+  const countText =
+    typeof totalCount === 'number' ? `${totalCount}개의` : '다양한';
+  return [
+    {
+      prompt: '~',
+      cmd: 'devticket search --stack=react --near=seoul',
+      out: `→ ${countText} 이벤트를 찾았어요`,
+    },
+    {
+      prompt: '~',
+      cmd: 'devticket book "React Korea 18차 밋업"',
+      out: '✓ 티켓 1매가 발급되었습니다',
+    },
+  ];
+};

--- a/src/pages-v2/Landing/components/Stat.tsx
+++ b/src/pages-v2/Landing/components/Stat.tsx
@@ -1,0 +1,49 @@
+/**
+ * Stats 섹션의 단일 카드.
+ * PR 2 (Hero + Stats) — Landing.plan.md §12.2 / §6.2.
+ *
+ * - 정상: hint(mono) + num+unit + label 3줄.
+ * - 스켈레톤: StatSkeleton 별도 export. 구조 동일, 텍스트 자리는 --surface-3 블록.
+ *   카드 높이가 정상 카드와 동일해야 CLS 0 (높이 고정은 landing.css 에서).
+ * - 클릭 인터랙션 / 키보드 포커스 없음 (§D, §6.2).
+ *
+ * 마크업/스타일 클래스만 노출하고 애니메이션은 없음 — prefers-reduced-motion
+ * 분기는 본 컴포넌트 차원에서 불필요.
+ */
+
+export interface StatProps {
+  hint: string;
+  num: string | number;
+  unit: string;
+  label: string;
+}
+
+const formatNum = (n: string | number): string =>
+  typeof n === 'number' ? n.toLocaleString('ko-KR') : n;
+
+export function Stat({ hint, num, unit, label }: StatProps) {
+  return (
+    <div className="stat-card">
+      <div className="stat-card__hint">{hint}</div>
+      <div className="stat-card__num-row">
+        <span className="stat-card__num">{formatNum(num)}</span>
+        {unit && <span className="stat-card__unit">{unit}</span>}
+      </div>
+      <div className="stat-card__label">{label}</div>
+    </div>
+  );
+}
+
+/**
+ * 스켈레톤 변형. SR 노이즈 방지 위해 aria-hidden.
+ * 부모 (StatsSection) 가 aria-busy 로 로딩 상태를 알린다.
+ */
+export function StatSkeleton() {
+  return (
+    <div className="stat-card stat-card--skeleton" aria-hidden="true">
+      <div className="stat-skeleton__hint" />
+      <div className="stat-skeleton__num" />
+      <div className="stat-skeleton__label" />
+    </div>
+  );
+}

--- a/src/pages-v2/Landing/hooks.ts
+++ b/src/pages-v2/Landing/hooks.ts
@@ -1,0 +1,152 @@
+/**
+ * Landing 데이터 훅.
+ * PR 2 (Hero + Stats) — Landing.plan.md §12.2 / §5.
+ *
+ * - getFirstPage: 1차 응답 공유 fetcher. 모듈 캐시 + in-flight 프로미스 reuse
+ *   로 같은 응답이 필요한 훅들이 호출해도 네트워크 1회 (§5.5).
+ * - useFirstPage: raw EventListPage 를 LandingFirstPageQuery 로 노출.
+ * - useLandingStats: useFirstPage 결과를 toStatsVM 으로 변환 (§5.5).
+ *
+ * 패턴은 EventList 의 useEvents 와 동일 (useState + useEffect + 캐시).
+ * 단, 공유 in-flight 프로미스가 여러 컨슈머에게 reuse 되므로
+ * AbortController 로 fetch 자체를 끊으면 다른 컨슈머가 죽는다.
+ * 따라서 unmount 처리는 cancelled 플래그로 결과 무시 방식 (§5.5).
+ *
+ * (PR 3 진입 시 useLandingCategories / useFeaturedEvents 추가 — §5.3 참조.
+ *  키가 4종으로 늘면 LRU 도 함께 도입 — 현재는 1종이라 생략, §12.2 트리밍 힌트.)
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { apiClient, unwrapApiData, type ApiResponse } from '@/api/client';
+import type { EventListResponse } from '@/api/types';
+import { toEventListPage } from '@/pages-v2/EventList/adapters';
+import type { EventListPage } from '@/pages-v2/EventList/types';
+import { toStatsVM } from './adapters';
+import type { LandingFirstPageQuery, StatVM } from './types';
+
+const FIRST_PAGE_SIZE = 10;
+const FIRST_PAGE_KEY = `landing:events:firstpage:size=${FIRST_PAGE_SIZE}`;
+const STALE_MS = 5 * 60_000;
+
+// Landing 전용 모듈 캐시. EventList 캐시와 분리 (§5.2 키 네임스페이스).
+const cache = new Map<string, { data: EventListPage; fetchedAt: number }>();
+
+let firstPageInFlight: Promise<EventListPage> | null = null;
+
+const fetchFirstPage = async (): Promise<EventListPage> => {
+  const res = await apiClient.get<ApiResponse<EventListResponse>>('/events', {
+    params: { page: 0, size: FIRST_PAGE_SIZE },
+  });
+  return toEventListPage(unwrapApiData(res.data));
+};
+
+export const getFirstPage = (): Promise<EventListPage> => {
+  const hit = cache.get(FIRST_PAGE_KEY);
+  if (hit && Date.now() - hit.fetchedAt < STALE_MS) {
+    return Promise.resolve(hit.data);
+  }
+  if (firstPageInFlight) return firstPageInFlight;
+  firstPageInFlight = fetchFirstPage()
+    .then((page) => {
+      cache.set(FIRST_PAGE_KEY, { data: page, fetchedAt: Date.now() });
+      return page;
+    })
+    .finally(() => {
+      firstPageInFlight = null;
+    });
+  return firstPageInFlight;
+};
+
+export const invalidateFirstPage = (): void => {
+  cache.delete(FIRST_PAGE_KEY);
+};
+
+export type UseFirstPageReturn = LandingFirstPageQuery & {
+  refetch: () => void;
+};
+
+export function useFirstPage(): UseFirstPageReturn {
+  const [state, setState] = useState<LandingFirstPageQuery>(() => {
+    const hit = cache.get(FIRST_PAGE_KEY);
+    return hit
+      ? { status: 'success', data: hit.data, fetchedAt: hit.fetchedAt }
+      : { status: 'loading' };
+  });
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  useEffect(() => {
+    const hit = cache.get(FIRST_PAGE_KEY);
+    if (hit && Date.now() - hit.fetchedAt < STALE_MS) {
+      setState({ status: 'success', data: hit.data, fetchedAt: hit.fetchedAt });
+      return;
+    }
+    setState((prev) => ({
+      status: 'loading',
+      previous: 'data' in prev ? prev.data : prev.previous,
+    }));
+
+    let cancelled = false;
+    getFirstPage()
+      .then((data) => {
+        if (cancelled) return;
+        setState({ status: 'success', data, fetchedAt: Date.now() });
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setState((prev) => ({
+          status: 'error',
+          error,
+          previous: 'data' in prev ? prev.data : prev.previous,
+        }));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshTick]);
+
+  const refetch = useCallback(() => {
+    invalidateFirstPage();
+    setRefreshTick((n) => n + 1);
+  }, []);
+
+  return { ...state, refetch };
+}
+
+export type UseLandingStatsReturn =
+  | { status: 'loading'; previous?: StatVM[]; refetch: () => void }
+  | {
+      status: 'success';
+      data: StatVM[];
+      fetchedAt: number;
+      refetch: () => void;
+    }
+  | {
+      status: 'error';
+      error: unknown;
+      previous?: StatVM[];
+      refetch: () => void;
+    };
+
+export function useLandingStats(): UseLandingStatsReturn {
+  const q = useFirstPage();
+  const previous =
+    'previous' in q && q.previous ? toStatsVM(q.previous) : undefined;
+  if (q.status === 'success') {
+    return {
+      status: 'success',
+      data: toStatsVM(q.data),
+      fetchedAt: q.fetchedAt,
+      refetch: q.refetch,
+    };
+  }
+  if (q.status === 'loading') {
+    return { status: 'loading', previous, refetch: q.refetch };
+  }
+  return {
+    status: 'error',
+    error: q.error,
+    previous,
+    refetch: q.refetch,
+  };
+}

--- a/src/pages-v2/Landing/sections/HeroSection.tsx
+++ b/src/pages-v2/Landing/sections/HeroSection.tsx
@@ -1,0 +1,121 @@
+/**
+ * Hero 섹션 — 좌(카피·CTA·메타) + 우(TypedTerminal).
+ * PR 2 (Hero + Stats) — Landing.plan.md §12.2 / §6.1 / §7.
+ *
+ * - 좌측: 정적 컨텐츠. 로딩/에러 상태 없음 (LCP 즉시).
+ * - 우측: TypedTerminal. 라인 1 의 카운트만 totalElements 로 동적 합성 (§11 #1).
+ *   카운트 미수신 시 buildTerminalLines 가 '다양한' fallback (§6.1 보강).
+ * - prefers-reduced-motion / Page Visibility 처리는 TypedTerminal 자체 책임 (PR 1).
+ *
+ * CTA props (§7.5):
+ * - onBrowseEvents: 필수. '/events?v=2' navigate 핸들러.
+ * - onOpenPalette: 선택. 미주입 시 onBrowseEvents 로 fallback (§7.2).
+ *
+ * tuning props (typingSpeedMs/outputDelayMs/...) 는 TypedTerminal 로 그대로 forward.
+ */
+
+import { useFirstPage } from '../hooks';
+import { buildTerminalLines } from '../adapters';
+import { TypedTerminal } from '../components/TypedTerminal';
+
+export interface HeroSectionProps {
+  onBrowseEvents: () => void;
+  onOpenPalette?: () => void;
+  /** TypedTerminal 라인별 cmd 타이핑 ms. 기본은 TypedTerminal 내부 default 사용 */
+  typingSpeedMs?: number;
+  /** cmd 완료 후 out 노출까지 ms */
+  outputDelayMs?: number;
+  /** out 완료 후 다음 라인 시작까지 ms */
+  nextLineDelayMs?: number;
+  /** 마지막 라인 후 처음으로 돌아가기까지 ms */
+  restartDelayMs?: number;
+  /** TypedTerminal 루프 여부. default true */
+  loop?: boolean;
+}
+
+const META_NOTES = ['// 키보드 친화적', '// 수수료 없음', '// 즉시 환불'];
+
+export function HeroSection({
+  onBrowseEvents,
+  onOpenPalette,
+  typingSpeedMs,
+  outputDelayMs,
+  nextLineDelayMs,
+  restartDelayMs,
+  loop,
+}: HeroSectionProps) {
+  const firstPage = useFirstPage();
+  // success / loading-with-previous / error-with-previous 모두에서 카운트 노출.
+  // 미수신 시 undefined → buildTerminalLines 가 '다양한' fallback.
+  const totalCount =
+    firstPage.status === 'success'
+      ? firstPage.data.totalElements
+      : 'previous' in firstPage && firstPage.previous
+        ? firstPage.previous.totalElements
+        : undefined;
+  const lines = buildTerminalLines(totalCount);
+
+  // §7.2 fallback: onOpenPalette 미주입 시 onBrowseEvents 동일 동작.
+  const onPalette = onOpenPalette ?? onBrowseEvents;
+
+  return (
+    <section className="hero-section" aria-label="개발자 이벤트 플랫폼 소개">
+      <div className="hero-section__left">
+        <div className="hero-section__eyebrow">
+          <span className="hero-section__eyebrow-dot" aria-hidden="true" />
+          v1.0 · 베타 서비스 운영 중
+        </div>
+
+        <h1 className="hero-section__h1">
+          개발자의 다음 한 줄을 바꿀
+          <br />
+          <span className="hero-section__h1-accent">이벤트와 티켓</span>, 한 곳에서.
+        </h1>
+
+        <p className="hero-section__subcopy">
+          컨퍼런스부터 밋업·해커톤·스터디까지. 관심 있는 기술 스택으로 바로 찾고,
+          몇 번의 클릭으로 티켓을 예매하세요.
+        </p>
+
+        <div className="hero-section__cta">
+          <button
+            type="button"
+            className="btn btn-primary btn-lg"
+            onClick={onBrowseEvents}
+          >
+            이벤트 둘러보기 <span aria-hidden="true">→</span>
+          </button>
+          <button
+            type="button"
+            className="btn btn-ghost btn-lg hero-section__cta-palette"
+            onClick={onPalette}
+          >
+            빠른 검색{' '}
+            <kbd className="hero-section__kbd" aria-label="단축키 커맨드 K">
+              ⌘K
+            </kbd>
+          </button>
+        </div>
+
+        <div className="hero-section__meta" aria-hidden="true">
+          {META_NOTES.map((note) => (
+            <span key={note} className="hero-section__meta-item">
+              {note}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="hero-section__right">
+        <TypedTerminal
+          lines={lines}
+          typingSpeedMs={typingSpeedMs}
+          outputDelayMs={outputDelayMs}
+          nextLineDelayMs={nextLineDelayMs}
+          restartDelayMs={restartDelayMs}
+          loop={loop}
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/pages-v2/Landing/sections/StatsSection.tsx
+++ b/src/pages-v2/Landing/sections/StatsSection.tsx
@@ -1,0 +1,78 @@
+/**
+ * Stats 섹션 — 4 카드 grid + 상태 분기.
+ * PR 2 (Hero + Stats) — Landing.plan.md §12.2 / §6.2.
+ *
+ * - 로딩 (previous 없음): 4 × StatSkeleton.
+ * - 로딩 (previous 보유): 이전 숫자 그대로 노출 (refetch 깜빡임 방지).
+ * - 성공: 4 × Stat.
+ * - 에러 (previous 없음): 인라인 메시지 + 다시 시도 버튼 (§6.2).
+ * - 에러 (previous 보유): 이전 숫자 + 우상단 stale 인디케이터는 v1 생략 (선택사항).
+ *
+ * 접근성:
+ * - 로딩 중에는 section 에 aria-busy="true". StatSkeleton 은 aria-hidden.
+ * - 에러 메시지는 aria-live="polite" 로 SR 에 1회 알림.
+ * - Stats 카드는 클릭 동선 없음 → 키보드 포커스 대상 아님 (§D).
+ */
+
+import { Stat, StatSkeleton } from '../components/Stat';
+import type { UseLandingStatsReturn } from '../hooks';
+
+export interface StatsSectionProps {
+  query: UseLandingStatsReturn;
+}
+
+export function StatsSection({ query }: StatsSectionProps) {
+  const previous =
+    'previous' in query && query.previous ? query.previous : undefined;
+  const data = query.status === 'success' ? query.data : previous;
+  const isError = query.status === 'error' && !data;
+  const isLoading = query.status === 'loading' && !data;
+
+  return (
+    <section
+      className="stats-section"
+      aria-label="이벤트 통계"
+      aria-busy={query.status === 'loading' || undefined}
+    >
+      {isLoading && (
+        <div className="stats-section__grid">
+          {Array.from({ length: 4 }, (_, i) => (
+            <StatSkeleton key={i} />
+          ))}
+        </div>
+      )}
+
+      {data && (
+        <div className="stats-section__grid">
+          {data.map((s, i) => (
+            <Stat
+              key={i}
+              hint={s.hint}
+              num={s.num}
+              unit={s.unit}
+              label={s.label}
+            />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <div className="stats-section__error" role="status" aria-live="polite">
+          <span className="stats-section__error-text">
+            <span className="stats-section__error-prefix">
+              // stats unavailable
+            </span>{' '}
+            통계를 불러올 수 없습니다
+          </span>
+          <button
+            type="button"
+            className="stats-section__retry"
+            onClick={query.refetch}
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/pages-v2/Landing/types.ts
+++ b/src/pages-v2/Landing/types.ts
@@ -1,9 +1,12 @@
 /**
  * Landing 페이지 전용 타입.
- * PR 1 (TypedTerminal) 단계에서는 `TerminalLine` 만 정의.
- * StatVM / CategoryTileVM / FeaturedItemVM / LandingFirstPageQuery 등은
- * PR 2~3 진입 시 본 파일에 추가 (Landing.plan.md §12.2~).
+ * PR 1 (TypedTerminal) 에서 `TerminalLine` 정의.
+ * PR 2 (Hero + Stats) 에서 `StatVM`, `LandingFirstPageQuery` 추가
+ * (Landing.plan.md §12.2).
+ * CategoryTileVM / FeaturedItemVM 등은 PR 3 진입 시 추가.
  */
+
+import type { EventListPage } from '@/pages-v2/EventList/types';
 
 export interface TerminalLine {
   /** 프롬프트 표시용 ('~' 등) */
@@ -13,3 +16,32 @@ export interface TerminalLine {
   /** cmd 완료 후 노출되는 출력 라인 */
   out: string;
 }
+
+/**
+ * Stats 섹션 4 카드의 단일 view model.
+ * `num` 은 number/string 모두 허용 — 4번 카드는 `'24+'` 하드코딩 (§4 표1, §11 #3).
+ * 0 vs 미수신 구분: 데이터 단계의 query.status 로만 판단 (§6.2).
+ */
+export interface StatVM {
+  /** 카드 상단 mono 힌트 (예: "// active events") */
+  hint: string;
+  /** 큰 숫자 블록 (number 또는 '24+' 같은 string) */
+  num: number | string;
+  /** 숫자 뒤 단위 ('개' / '+' 등). 없으면 빈 문자열 */
+  unit: string;
+  /** 하단 라벨 (예: "진행 중인 이벤트") */
+  label: string;
+}
+
+/**
+ * Landing 의 1차 응답(`getEvents({ page:0, size:10 })`) query state.
+ * EventList 의 `EventsQuery` 와 같은 차별 유니온 패턴 — `loading`/`error` 시
+ * `previous` 를 보존해 UI 깜빡임을 막는다 (§5.1).
+ *
+ * Stats 와 (PR 3 의) Featured 가 같은 응답을 공유하기 때문에
+ * raw `EventListPage` 단위로 보관한다.
+ */
+export type LandingFirstPageQuery =
+  | { status: 'loading'; previous?: EventListPage }
+  | { status: 'success'; data: EventListPage; fetchedAt: number }
+  | { status: 'error'; error: unknown; previous?: EventListPage };

--- a/src/pages-v2/_dev/HeroStatsShowcase.tsx
+++ b/src/pages-v2/_dev/HeroStatsShowcase.tsx
@@ -1,0 +1,35 @@
+/**
+ * 임시 dev 라우트 (`/_dev/landing-hero-stats`).
+ * Landing.plan.md §12.2 검증 절차 A~D 를 라이브로 확인하기 위한 마운트 셸.
+ * 실제 API 와 결선된 <HeroSection> + <StatsSection> 단독 렌더.
+ *
+ * - onBrowseEvents 는 alert stub. 실제 navigate 는 PR 4 통합 단계에서 연결.
+ * - onOpenPalette 미주입 → §7.2 fallback (onBrowseEvents 동일 동작) 검증.
+ *
+ * cutover 또는 PR 4 cleanup 커밋에서 제거 예정.
+ */
+
+import { HeroSection } from '../Landing/sections/HeroSection';
+import { StatsSection } from '../Landing/sections/StatsSection';
+import { useLandingStats } from '../Landing/hooks';
+
+export default function HeroStatsShowcase() {
+  const stats = useLandingStats();
+  const onBrowseEvents = () => {
+    alert('onBrowseEvents → /events?v=2 (stub)');
+  };
+
+  return (
+    <div style={{ maxWidth: 1100, margin: '0 auto', padding: '24px 24px 64px' }}>
+      <header style={{ marginBottom: 16 }}>
+        <h1 style={{ fontSize: 18, margin: 0 }}>Landing Hero + Stats — dev showcase</h1>
+        <p style={{ fontSize: 12, color: 'var(--text-3)', margin: '4px 0 0' }}>
+          Landing.plan.md §12.2 검증. <code>/_dev/landing-hero-stats</code>
+        </p>
+      </header>
+
+      <HeroSection onBrowseEvents={onBrowseEvents} />
+      <StatsSection query={stats} />
+    </div>
+  );
+}

--- a/src/styles-v2/pages/landing.css
+++ b/src/styles-v2/pages/landing.css
@@ -2,10 +2,11 @@
    Landing page — v2
    Tokens: src/styles-v2/tokens.css
    Spec:   docs/redesign/Spec.md § 6
-   Plan:   docs/redesign/Landing.plan.md § 3 (TypedTerminal), § 12.1 (PR 1)
+   Plan:   docs/redesign/Landing.plan.md § 3 (TypedTerminal), § 12.1 (PR 1),
+                                          § 12.2 (Hero + Stats, PR 2)
 
-   PR 1 scope: TypedTerminal classes only.
-   Hero / Stats / Categories / Featured / CTA classes append in PR 2~4.
+   Sections appear top-to-bottom: TypedTerminal → Hero → Stats.
+   Categories / Featured / CTA classes append in PR 3~4.
    ========================================================================== */
 
 /* ----- TypedTerminal -------------------------------------------------------
@@ -87,3 +88,210 @@
     animation: none;
   }
 }
+
+/* ----- Hero section --------------------------------------------------------
+   2-col grid (carry-over from prototype/Landing.jsx L182). Right column 은
+   TypedTerminal slot 만 가지므로 추가 스타일 불필요.
+   --------------------------------------------------------------------------*/
+
+.hero-section {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 36px;
+  align-items: center;
+  padding: 28px 0 44px;
+}
+
+.hero-section__left { min-width: 0; }
+.hero-section__right { min-width: 0; }
+
+.hero-section__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 11px;
+  border-radius: 999px;
+  background: var(--term-green-soft);
+  color: var(--term-green-dim);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-weight: 600;
+  margin-bottom: 18px;
+}
+
+.hero-section__eyebrow-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--term-green);
+}
+
+.hero-section__h1 {
+  font-family: var(--font);
+  font-size: 44px;
+  font-weight: 800;
+  line-height: 1.15;
+  letter-spacing: -0.025em;
+  color: var(--text);
+  margin: 0 0 16px;
+}
+.hero-section__h1-accent { color: var(--brand); }
+
+.hero-section__subcopy {
+  font-family: var(--font);
+  font-size: 16px;
+  color: var(--text-3);
+  line-height: 1.65;
+  margin: 0 0 24px;
+  max-width: 480px;
+}
+
+.hero-section__cta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.hero-section__cta-palette {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.hero-section__kbd {
+  margin-left: 4px;
+  padding: 1px 6px;
+  border: 1px solid var(--border-2);
+  border-radius: 4px;
+  background: var(--surface-2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-2);
+  line-height: 1.2;
+}
+
+.hero-section__meta {
+  margin-top: 20px;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-4);
+}
+
+/* ----- Stats section -------------------------------------------------------
+   4-col fixed grid. .stat-card 와 .stat-card--skeleton 의 외곽 박스가
+   동일 height 이라 로딩 ↔ 정상 전환 시 CLS = 0 (§ 6.2).
+   --------------------------------------------------------------------------*/
+
+.stats-section {
+  margin-bottom: 44px;
+}
+
+.stats-section__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.stat-card {
+  padding: 18px 20px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  min-height: 98px;
+}
+
+.stat-card__hint {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-4);
+  letter-spacing: 0.04em;
+  margin-bottom: 6px;
+}
+
+.stat-card__num-row {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  margin-bottom: 2px;
+}
+
+.stat-card__num {
+  font-family: var(--font);
+  font-size: 30px;
+  font-weight: 800;
+  color: var(--text);
+  letter-spacing: -0.02em;
+}
+
+.stat-card__unit {
+  font-family: var(--font);
+  font-size: 14px;
+  color: var(--text-3);
+  font-weight: 500;
+}
+
+.stat-card__label {
+  font-family: var(--font);
+  font-size: 13px;
+  color: var(--text-2);
+}
+
+/* skeleton variant — placeholder blocks of text-equivalent heights. */
+.stat-card--skeleton { background: var(--surface); }
+
+.stat-skeleton__hint,
+.stat-skeleton__num,
+.stat-skeleton__label {
+  background: var(--surface-3);
+  border-radius: 4px;
+  animation: stat-skeleton-pulse 1.4s ease-in-out infinite;
+}
+
+.stat-skeleton__hint  { width:  80px; height: 11px; margin-bottom: 6px; }
+.stat-skeleton__num   { width:  64px; height: 30px; margin-bottom: 4px; }
+.stat-skeleton__label { width: 120px; height: 13px; }
+
+@keyframes stat-skeleton-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.55; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stat-skeleton__hint,
+  .stat-skeleton__num,
+  .stat-skeleton__label {
+    animation: none;
+  }
+}
+
+/* error inline row (§ 6.2). Hero / 다른 섹션은 영향 받지 않음. */
+.stats-section__error {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+}
+
+.stats-section__error-text { color: var(--text-2); }
+.stats-section__error-prefix { color: var(--text-4); }
+
+.stats-section__retry {
+  margin-left: auto;
+  padding: 4px 10px;
+  border: 1px solid var(--border-2);
+  border-radius: 6px;
+  background: var(--surface-2);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 12px;
+  cursor: pointer;
+}
+.stats-section__retry:hover { background: var(--surface-3); }


### PR DESCRIPTION
## Summary
Implements the Hero section (with TypedTerminal integration) and Stats section for the Landing page v2, completing PR 2 of the Landing redesign plan. Includes data fetching hooks, view model adapters, React components, and styling.

## Key Changes

### Styling (`src/styles-v2/pages/landing.css`)
- Added Hero section styles: 2-column grid layout with eyebrow badge, h1 heading, subcopy, CTA buttons, and metadata notes
- Added Stats section styles: 4-column fixed grid with stat cards and skeleton loading states
- Added error state styling for Stats section with retry button
- Includes animations (skeleton pulse) with `prefers-reduced-motion` support

### Data Layer (`src/pages-v2/Landing/hooks.ts`)
- `getFirstPage()`: Shared fetcher with module-level cache and in-flight promise reuse to prevent duplicate network requests
- `useFirstPage()`: Hook exposing raw `EventListPage` with loading/success/error states and `previous` data preservation
- `useLandingStats()`: Hook transforming `EventListPage` into `StatVM[]` array via adapter
- Implements cancelled flag pattern for unmount cleanup (avoiding AbortController issues with shared promises)

### Adapters (`src/pages-v2/Landing/adapters.ts`)
- `toStatsVM()`: Transforms first page data into 4 stat cards:
  - Active events (totalElements)
  - On-sale tickets (filtered by status)
  - Remaining seats (sum of remainingQuantity)
  - Communities (hardcoded '24+' per spec)
- `buildTerminalLines()`: Generates TypedTerminal lines with dynamic event count in line 1, fallback to "다양한" if count unavailable

### Components
- **HeroSection** (`src/pages-v2/Landing/sections/HeroSection.tsx`):
  - 2-column layout: left (static copy, CTAs, metadata) + right (TypedTerminal)
  - Integrates `useFirstPage()` to pass dynamic event count to terminal
  - Props for CTA handlers and TypedTerminal tuning parameters
  - Fallback: `onOpenPalette` defaults to `onBrowseEvents` if not provided

- **StatsSection** (`src/pages-v2/Landing/sections/StatsSection.tsx`):
  - Renders 4 stat cards in grid layout
  - State branching: loading (with skeleton), success, error (with retry button)
  - Preserves previous data during refetch to prevent UI flicker
  - Accessibility: `aria-busy`, `aria-live="polite"` for error messages, `aria-hidden` for skeletons

- **Stat** (`src/pages-v2/Landing/components/Stat.tsx`):
  - Single stat card component with hint, number, unit, and label
  - `StatSkeleton` variant for loading state with pulsing animation
  - Number formatting with locale-aware thousands separator

### Types (`src/pages-v2/Landing/types.ts`)
- `StatVM`: View model for individual stat card (hint, num, unit, label)
- `LandingFirstPageQuery`: Discriminated union for query state (loading/success/error) with optional `previous` data

### Dev Showcase (`src/pages-v2/_dev/HeroStatsShowcase.tsx`)
- Temporary dev route for validating Hero + Stats sections against spec (§12.2 verification A–D)
- Mounts real components with API integration
- Stub handlers for CTA callbacks

### App Router (`src/App.tsx`)
- Added lazy-loaded dev showcase route

## Implementation Details

- **CLS Prevention**: Stat cards have fixed `min-height: 98px` to ensure skeleton and loaded states match height
- **Data Preservation**: `previous` field in query state prevents UI flicker during refetch
- **Fallback Handling**: Terminal line count defaults to "다양한" if totalElements unavailable
- **Accessibility**: Proper ARIA attributes for loading states, error messages, and skeleton placeholders
- **Motion Preferences**: Skeleton

https://claude.ai/code/session_01V6otUYZbt1qNc9XKuWvtXB