### PR TITLE
PR 3: Add Categories and Featured sections to Landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,8 @@ const MyPageV2            = lazy(() => import('./pages-v2/MyPage'))
 const TypedTerminalShowcase = lazy(() => import('./pages-v2/_dev/TypedTerminalShowcase'))
 // lazy – v2 dev showcase (Landing.plan §12.2 PR 2; cutover/PR 4 cleanup 시 제거)
 const HeroStatsShowcase     = lazy(() => import('./pages-v2/_dev/HeroStatsShowcase'))
+// lazy – v2 dev showcase (Landing.plan §12.3 PR 3; cutover/PR 4 cleanup 시 제거)
+const CategoriesFeaturedShowcase = lazy(() => import('./pages-v2/_dev/CategoriesFeaturedShowcase'))
 
 // lazy – 로그인 후 접근
 const SignupComplete      = lazy(() => import('./pages/SignupComplete'))
@@ -97,8 +99,9 @@ export default function App() {
         <Route path="/social/profile-setup" element={<SocialProfileSetup />} />
 
         {/* v2 dev showcase (cutover/PR 4 cleanup 시 제거) */}
-        <Route path="/_dev/typed-terminal"    element={<TypedTerminalShowcase />} />
-        <Route path="/_dev/landing-hero-stats" element={<HeroStatsShowcase />} />
+        <Route path="/_dev/typed-terminal"               element={<TypedTerminalShowcase />} />
+        <Route path="/_dev/landing-hero-stats"           element={<HeroStatsShowcase />} />
+        <Route path="/_dev/landing-categories-featured" element={<CategoriesFeaturedShowcase />} />
 
         {/* 일반 사용자 */}
         <Route element={<Layout />}>

--- a/src/pages-v2/Landing/adapters.ts
+++ b/src/pages-v2/Landing/adapters.ts
@@ -7,11 +7,28 @@
  * - `buildTerminalLines(totalCount)` — TypedTerminal 라인 합성 (§11 #1).
  *   라인 1 의 카운트만 동적, 라인 2 는 프로토타입 하드코딩 유지.
  *
- * (PR 3 진입 시 toFeaturedItemVM / toCategoryCountVM 추가)
+ * PR 3 (Categories + Featured) — Landing.plan.md §12.3.
+ *
+ * - `CATEGORY_DEFINITIONS` — 6 카테고리 마스터 (§2 Categories,
+ *   prototype/Landing.jsx L161–L167). 한국어 카테고리명 + 약자 + accent 키.
+ * - `toCategoryTileVM(def, count)` — master + 응답 totalElements → tile VM.
+ *   `count: null` 보존 (부분 실패) vs `0` (정상 0건) 구분 (§12.3 머지조건).
+ * - `toFeaturedItemVM(EventVM, rank)` — EventVM 좁힘 + rank/accent 부착.
+ * - `sortByDateAsc(list)` — Featured 폴백(`getEvents`) 시 `eventDateTime`
+ *   오름차순 정렬용 (§12.3 §11 #4).
+ * - `pickAccentByEventId(id)` — `eventId` 해시 기반 accent 회전. 프로토타입
+ *   `accent()` 의 하드코딩 매핑은 mock 전용이라 일반 ID 에는 못 쓰므로
+ *   결정적 해시 매핑으로 대체 (같은 ID → 항상 같은 accent).
  */
 
-import type { EventListPage } from '@/pages-v2/EventList/types';
-import type { StatVM, TerminalLine } from './types';
+import type { EventListPage, EventVM } from '@/pages-v2/EventList/types';
+import type {
+  AccentToken,
+  CategoryTileVM,
+  FeaturedItemVM,
+  StatVM,
+  TerminalLine,
+} from './types';
 
 /**
  * 4번 카드 ('참여 커뮤니티') v1 하드코딩 값.
@@ -55,3 +72,86 @@ export const buildTerminalLines = (
     },
   ];
 };
+
+/* ===== PR 3: Categories + Featured ===== */
+
+/**
+ * 6 카테고리 마스터 (§2 Categories, prototype/Landing.jsx L161–L167).
+ * `cat` 은 EventList 필터 키와 1:1 — 한국어 그대로 (URL 인코딩만, §8.1).
+ * `accent` 는 SPEC §0 accent 팔레트 키. 6 카테고리 전부 색이 다름.
+ */
+export interface CategoryDefinition {
+  cat: string;
+  icon: string;
+  accent: AccentToken;
+}
+
+export const CATEGORY_DEFINITIONS: readonly CategoryDefinition[] = [
+  { cat: '컨퍼런스', icon: 'CF', accent: 'indigo'  },
+  { cat: '밋업',     icon: 'MT', accent: 'sky'     },
+  { cat: '해커톤',   icon: 'HT', accent: 'emerald' },
+  { cat: '스터디',   icon: 'ST', accent: 'amber'   },
+  { cat: '세미나',   icon: 'SM', accent: 'violet'  },
+  { cat: '워크샵',   icon: 'WS', accent: 'pink'    },
+] as const;
+
+/**
+ * `count: null` 은 호출부에서 부분 실패 신호로 사용 (§12.3 D / 머지조건).
+ * 정상 0건은 `count: 0` 으로 들어오며 타일에 `0개 이벤트` 표시.
+ */
+export const toCategoryTileVM = (
+  def: CategoryDefinition,
+  count: number | null,
+): CategoryTileVM => ({
+  cat: def.cat,
+  count,
+  icon: def.icon,
+  accent: def.accent,
+});
+
+/**
+ * Featured accent 회전. 프로토타입 `accent()` 는 mock eventId(`a`/`b`/...)
+ * 전용 하드코딩 맵이라 실제 UUID/숫자 ID 에 못 쓴다.
+ * 대신 ID 의 char-sum 해시로 7개 토큰 중 하나를 결정적으로 고른다 —
+ * 같은 ID 는 항상 같은 accent (재마운트/재정렬에서도 안정).
+ */
+const ACCENT_ROTATION: readonly AccentToken[] = [
+  'indigo', 'sky', 'emerald', 'amber', 'violet', 'pink', 'red',
+] as const;
+
+export const pickAccentByEventId = (eventId: string): AccentToken => {
+  let h = 0;
+  for (let i = 0; i < eventId.length; i++) {
+    h = (h + eventId.charCodeAt(i)) | 0;
+  }
+  return ACCENT_ROTATION[Math.abs(h) % ACCENT_ROTATION.length];
+};
+
+export const toFeaturedItemVM = (
+  ev: EventVM,
+  rank: number,
+): FeaturedItemVM => ({
+  eventId: ev.eventId,
+  title: ev.title,
+  category: ev.category,
+  price: ev.price,
+  remainingQuantity: ev.remainingQuantity,
+  status: ev.status,
+  eventDateTime: ev.eventDateTime,
+  techStacks: ev.techStacks,
+  isFree: ev.isFree,
+  dateLabel: ev.dateLabel,
+  rank,
+  accent: pickAccentByEventId(ev.eventId),
+});
+
+/**
+ * Featured 폴백 시 `eventDateTime` 오름차순 정렬 (§12.3 §11 #4).
+ * 원본 배열을 변경하지 않도록 복사본 정렬.
+ */
+export const sortByDateAsc = <T extends { eventDateTime: string }>(
+  list: readonly T[],
+): T[] =>
+  [...list].sort((a, b) =>
+    a.eventDateTime < b.eventDateTime ? -1 : a.eventDateTime > b.eventDateTime ? 1 : 0,
+  );

--- a/src/pages-v2/Landing/components/CategoryTile.tsx
+++ b/src/pages-v2/Landing/components/CategoryTile.tsx
@@ -1,0 +1,67 @@
+/**
+ * Categories 섹션의 단일 타일.
+ * PR 3 (Categories + Featured) — Landing.plan.md §12.3 / §2 / §6.3.
+ *
+ * 구조:
+ *  - `<button>` (§9.6 — 프로토타입 `<button>` 시그니처 그대로).
+ *  - 34×34 약자 아이콘 박스 (`aria-hidden="true"` — 시각 글리프 전용).
+ *  - 카테고리명 + 카운트 (스크린리더는 이 두 텍스트만 읽음 — §9.6).
+ *
+ * 카운트 표시:
+ *  - `count: number` → `N개 이벤트` (0 포함 정상 0건, §6.3).
+ *  - `count: null`  → `—` (부분 실패, §12.3 머지조건 — 0 과 구분).
+ *
+ * accent:
+ *  - `accent` 토큰 키를 인라인 CSS 변수 `--tile-accent` 로 주입.
+ *  - hover/border/icon 색은 landing.css 가 `var(--tile-accent)` 로 결선.
+ *  - hover translateY/색 전환은 CSS 단에서 `prefers-reduced-motion: reduce`
+ *    가드 (landing.css) — 본 컴포넌트엔 애니메이션 없음.
+ *
+ * 클릭 핸들러는 props 로 끌어올림. 라우팅 결선은 CategoriesSection 이 담당
+ * (§8.2 — `useNavigate('/events?v=2&cat=...')`).
+ */
+
+import type { CSSProperties } from 'react';
+import type { AccentToken } from '../types';
+
+export interface CategoryTileProps {
+  cat: string;
+  /** `null` 은 부분 실패 (해당 슬롯 fetch reject). 정상 0건은 `0`. */
+  count: number | null;
+  icon: string;
+  accent: AccentToken;
+  onClick: () => void;
+  className?: string;
+}
+
+type CSSVars = CSSProperties & { ['--tile-accent']?: string };
+
+const accentVar = (token: AccentToken): string => `var(--accent-${token})`;
+
+const formatCount = (count: number | null): string =>
+  count === null ? '—' : `${count.toLocaleString('ko-KR')}개 이벤트`;
+
+export function CategoryTile({
+  cat,
+  count,
+  icon,
+  accent,
+  onClick,
+  className,
+}: CategoryTileProps) {
+  const style: CSSVars = { '--tile-accent': accentVar(accent) };
+  return (
+    <button
+      type="button"
+      className={`category-tile${className ? ` ${className}` : ''}`}
+      style={style}
+      onClick={onClick}
+    >
+      <span className="category-tile__icon" aria-hidden="true">
+        {icon}
+      </span>
+      <span className="category-tile__name">{cat}</span>
+      <span className="category-tile__count">{formatCount(count)}</span>
+    </button>
+  );
+}

--- a/src/pages-v2/Landing/components/FeaturedRow.tsx
+++ b/src/pages-v2/Landing/components/FeaturedRow.tsx
@@ -1,0 +1,98 @@
+/**
+ * Featured 섹션의 단일 행.
+ * PR 3 (Categories + Featured) — Landing.plan.md §12.3 / §2 / §9.6.
+ *
+ * 구조 (grid `36px 56px 1fr auto`):
+ *  - 1: 순번 (`vm.rank` → "01"~"05" mono).
+ *  - 2: 56-col 안의 48×48 그라디언트 박스 (`</>` 글리프, `aria-hidden`).
+ *  - 3: 카테고리 eyebrow + StatusChip + 제목 + 날짜·스택.
+ *  - 4: 가격 (무료/원 처리).
+ *
+ * §9.6 — 프로토타입의 `<div onClick>` 회피, **`<button type="button">`** 사용.
+ * 키보드 Enter/Space 자동 활성, 포커스 링 자동.
+ *
+ * accent:
+ *  - `accent` 토큰을 `--row-accent: var(--accent-{token})` 인라인 변수로 주입.
+ *  - 그라디언트/hover 색은 landing.css 가 `var(--row-accent)` + `color-mix`
+ *    로 결선 (CategoryTile 와 동일 패턴).
+ *  - hover transform/색 전환은 CSS `prefers-reduced-motion: reduce` 가드.
+ *
+ * 상태 칩 매핑 (프로토타입 L139–L141):
+ *  - `SOLD_OUT` → "매진" (sold)
+ *  - `ON_SALE` + 1~9 잔여 → "{N}석" (sold — 시각적 강조)
+ *  - 그 외 `ON_SALE` → "판매중" (ok)
+ */
+
+import type { CSSProperties } from 'react';
+import { StatusChip } from '@/components-v2';
+import type { AccentToken, FeaturedItemVM } from '../types';
+
+export interface FeaturedRowProps {
+  ev: FeaturedItemVM;
+  onClick: () => void;
+  className?: string;
+}
+
+type CSSVars = CSSProperties & { ['--row-accent']?: string };
+
+const accentVar = (token: AccentToken): string => `var(--accent-${token})`;
+
+const formatPrice = (price: number, isFree: boolean): string =>
+  isFree ? '무료' : `${price.toLocaleString('ko-KR')}원`;
+
+interface ChipState {
+  variant: 'ok' | 'sold';
+  text: string;
+}
+
+const chipFor = (ev: FeaturedItemVM): ChipState => {
+  if (ev.status === 'SOLD_OUT') return { variant: 'sold', text: '매진' };
+  if (ev.remainingQuantity > 0 && ev.remainingQuantity < 10) {
+    return { variant: 'sold', text: `${ev.remainingQuantity}석` };
+  }
+  return { variant: 'ok', text: '판매중' };
+};
+
+export function FeaturedRow({ ev, onClick, className }: FeaturedRowProps) {
+  const style: CSSVars = { '--row-accent': accentVar(ev.accent) };
+  const chip = chipFor(ev);
+  const techText = ev.techStacks.slice(0, 3).join(' · ');
+  const isFree = ev.isFree || ev.price === 0;
+
+  return (
+    <button
+      type="button"
+      className={`featured-row${className ? ` ${className}` : ''}`}
+      style={style}
+      onClick={onClick}
+    >
+      <span className="featured-row__rank">
+        {String(ev.rank).padStart(2, '0')}
+      </span>
+      <span className="featured-row__media" aria-hidden="true">
+        <span className="featured-row__media-glyph">&lt;/&gt;</span>
+      </span>
+      <span className="featured-row__main">
+        <span className="featured-row__meta-row">
+          <span className="featured-row__category">{`#${ev.category}`}</span>
+          <StatusChip variant={chip.variant}>{chip.text}</StatusChip>
+        </span>
+        <span className="featured-row__title">{ev.title}</span>
+        <span className="featured-row__meta">
+          {ev.dateLabel}
+          {techText && (
+            <>
+              {' · '}
+              {techText}
+            </>
+          )}
+        </span>
+      </span>
+      <span
+        className={`featured-row__price${isFree ? ' featured-row__price--free' : ''}`}
+      >
+        {formatPrice(ev.price, isFree)}
+      </span>
+    </button>
+  );
+}

--- a/src/pages-v2/Landing/hooks.ts
+++ b/src/pages-v2/Landing/hooks.ts
@@ -12,17 +12,49 @@
  * AbortController 로 fetch 자체를 끊으면 다른 컨슈머가 죽는다.
  * 따라서 unmount 처리는 cancelled 플래그로 결과 무시 방식 (§5.5).
  *
- * (PR 3 진입 시 useLandingCategories / useFeaturedEvents 추가 — §5.3 참조.
- *  키가 4종으로 늘면 LRU 도 함께 도입 — 현재는 1종이라 생략, §12.2 트리밍 힌트.)
+ * PR 3 (Categories + Featured) — Landing.plan.md §12.3 / §5.
+ *
+ * - useLandingCategories: 6 카테고리 마스터 × `filterEvents({ size:1 })`
+ *   `Promise.allSettled` (부분 실패 시 해당 타일만 `count: null`).
+ *   캐시 키 `landing:categories:counts`, stale 10분.
+ * - useFeaturedEvents: 1차 `getEventRecommendations` → 실패/빈 시
+ *   `getEvents({ size:10 })` 폴백 → ON_SALE 필터 + `eventDateTime` asc + 5개.
+ *   캐시 키 `landing:featured`, stale 5분.
+ * - 두 훅 모두 PR 2 의 `getFirstPage` 를 재사용하지 않음 (§12.3 — PR 2/3
+ *   병렬 빌드 보장). API 래퍼(`filterEvents`/`getEventRecommendations`/
+ *   `getEvents`) 가 signal 을 받지 않아 unmount 처리는 cancelled 플래그로
+ *   통일 (PR 2 와 같은 방식).
  */
 
 import { useCallback, useEffect, useState } from 'react';
 import { apiClient, unwrapApiData, type ApiResponse } from '@/api/client';
-import type { EventListResponse } from '@/api/types';
+import {
+  filterEvents,
+  getEvents,
+} from '@/api/events.api';
+import { getEventRecommendations } from '@/api/ai.api';
+import type {
+  EventFilterResponse,
+  EventListResponse,
+  RecommendationResponse,
+} from '@/api/types';
 import { toEventListPage } from '@/pages-v2/EventList/adapters';
-import type { EventListPage } from '@/pages-v2/EventList/types';
-import { toStatsVM } from './adapters';
-import type { LandingFirstPageQuery, StatVM } from './types';
+import type { EventListPage, EventVM } from '@/pages-v2/EventList/types';
+import {
+  CATEGORY_DEFINITIONS,
+  sortByDateAsc,
+  toCategoryTileVM,
+  toFeaturedItemVM,
+  toStatsVM,
+} from './adapters';
+import type {
+  CategoryTileVM,
+  FeaturedItemVM,
+  LandingCategoriesQuery,
+  LandingFeaturedQuery,
+  LandingFirstPageQuery,
+  StatVM,
+} from './types';
 
 const FIRST_PAGE_SIZE = 10;
 const FIRST_PAGE_KEY = `landing:events:firstpage:size=${FIRST_PAGE_SIZE}`;
@@ -149,4 +181,230 @@ export function useLandingStats(): UseLandingStatsReturn {
     previous,
     refetch: q.refetch,
   };
+}
+
+/* ===== PR 3: Categories + Featured ===== */
+
+const CATEGORIES_KEY = 'landing:categories:counts';
+const CATEGORIES_STALE_MS = 10 * 60_000;
+const categoriesCache = new Map<
+  string,
+  { data: CategoryTileVM[]; fetchedAt: number }
+>();
+let categoriesInFlight: Promise<CategoryTileVM[]> | null = null;
+
+const fetchCategoryCounts = async (): Promise<CategoryTileVM[]> => {
+  // 6 병렬 + Promise.allSettled — 한 카테고리 실패해도 나머지는 살림 (§6.3).
+  const results = await Promise.allSettled(
+    CATEGORY_DEFINITIONS.map((def) =>
+      filterEvents({ category: def.cat, page: 0, size: 1 }),
+    ),
+  );
+  return CATEGORY_DEFINITIONS.map((def, i) => {
+    const r = results[i];
+    if (r.status === 'fulfilled') {
+      const data = unwrapApiData<EventFilterResponse>(r.value.data);
+      return toCategoryTileVM(def, data.totalElements);
+    }
+    return toCategoryTileVM(def, null);
+  });
+};
+
+export const getCategoryCounts = (): Promise<CategoryTileVM[]> => {
+  const hit = categoriesCache.get(CATEGORIES_KEY);
+  if (hit && Date.now() - hit.fetchedAt < CATEGORIES_STALE_MS) {
+    return Promise.resolve(hit.data);
+  }
+  if (categoriesInFlight) return categoriesInFlight;
+  categoriesInFlight = fetchCategoryCounts()
+    .then((data) => {
+      categoriesCache.set(CATEGORIES_KEY, { data, fetchedAt: Date.now() });
+      return data;
+    })
+    .finally(() => {
+      categoriesInFlight = null;
+    });
+  return categoriesInFlight;
+};
+
+export const invalidateCategoryCounts = (): void => {
+  categoriesCache.delete(CATEGORIES_KEY);
+};
+
+export type UseLandingCategoriesReturn = LandingCategoriesQuery & {
+  refetch: () => void;
+};
+
+export function useLandingCategories(): UseLandingCategoriesReturn {
+  const [state, setState] = useState<LandingCategoriesQuery>(() => {
+    const hit = categoriesCache.get(CATEGORIES_KEY);
+    return hit
+      ? { status: 'success', data: hit.data, fetchedAt: hit.fetchedAt }
+      : { status: 'loading' };
+  });
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const hit = categoriesCache.get(CATEGORIES_KEY);
+    if (hit && Date.now() - hit.fetchedAt < CATEGORIES_STALE_MS) {
+      setState({ status: 'success', data: hit.data, fetchedAt: hit.fetchedAt });
+      return;
+    }
+    setState((prev) => ({
+      status: 'loading',
+      previous: 'data' in prev ? prev.data : prev.previous,
+    }));
+
+    let cancelled = false;
+    getCategoryCounts()
+      .then((data) => {
+        if (cancelled) return;
+        setState({ status: 'success', data, fetchedAt: Date.now() });
+      })
+      .catch((error) => {
+        // Promise.allSettled 라 정상 흐름에선 reject 가 없지만,
+        // 캐시 / fetcher 외 단계에서 throw 발생 시 안전망.
+        if (cancelled) return;
+        setState((prev) => ({
+          status: 'error',
+          error,
+          previous: 'data' in prev ? prev.data : prev.previous,
+        }));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tick]);
+
+  const refetch = useCallback(() => {
+    invalidateCategoryCounts();
+    setTick((n) => n + 1);
+  }, []);
+
+  return { ...state, refetch };
+}
+
+const FEATURED_KEY = 'landing:featured';
+const FEATURED_STALE_MS = 5 * 60_000;
+const FEATURED_FALLBACK_PAGE_SIZE = 10;
+const FEATURED_LIMIT = 5;
+const featuredCache = new Map<
+  string,
+  { data: FeaturedItemVM[]; fetchedAt: number }
+>();
+let featuredInFlight: Promise<FeaturedItemVM[]> | null = null;
+
+/**
+ * 폴백 + 추천 hydration 양쪽에서 쓰는 1차 페이지. PR 2 의 `getFirstPage`
+ * 와 별 캐시 키 — Featured 단독 빌드 보장 (§12.3).
+ */
+const fetchFeaturedFallbackEvents = async (): Promise<EventVM[]> => {
+  const res = await getEvents({ page: 0, size: FEATURED_FALLBACK_PAGE_SIZE });
+  const page = toEventListPage(unwrapApiData<EventListResponse>(res.data));
+  return sortByDateAsc(page.items.filter((e) => e.status === 'ON_SALE'));
+};
+
+const fetchFeatured = async (): Promise<FeaturedItemVM[]> => {
+  // 1차: /events/recommendations (비-auth, ai.api.ts:4).
+  let recIds: string[] = [];
+  try {
+    const res = await getEventRecommendations();
+    const data = unwrapApiData<RecommendationResponse>(
+      res.data as ApiResponse<RecommendationResponse> | RecommendationResponse,
+    );
+    recIds = data?.eventIdList ?? [];
+  } catch {
+    // 실패는 폴백으로 흡수 (§12.3 §11 #4).
+  }
+  if (recIds.length > 0) {
+    // RecommendationResponse 는 ID 만 — 행 렌더에 필요한 필드는 1차 페이지로 hydration.
+    const events = await fetchFeaturedFallbackEvents();
+    const byId = new Map(events.map((e) => [e.eventId, e] as const));
+    const hydrated = recIds
+      .map((id) => byId.get(id))
+      .filter((e): e is EventVM => Boolean(e))
+      .slice(0, FEATURED_LIMIT);
+    if (hydrated.length > 0) {
+      return hydrated.map((e, i) => toFeaturedItemVM(e, i + 1));
+    }
+  }
+  // 폴백: ON_SALE + date asc + 앞 5개.
+  const events = await fetchFeaturedFallbackEvents();
+  return events
+    .slice(0, FEATURED_LIMIT)
+    .map((e, i) => toFeaturedItemVM(e, i + 1));
+};
+
+export const getFeatured = (): Promise<FeaturedItemVM[]> => {
+  const hit = featuredCache.get(FEATURED_KEY);
+  if (hit && Date.now() - hit.fetchedAt < FEATURED_STALE_MS) {
+    return Promise.resolve(hit.data);
+  }
+  if (featuredInFlight) return featuredInFlight;
+  featuredInFlight = fetchFeatured()
+    .then((data) => {
+      featuredCache.set(FEATURED_KEY, { data, fetchedAt: Date.now() });
+      return data;
+    })
+    .finally(() => {
+      featuredInFlight = null;
+    });
+  return featuredInFlight;
+};
+
+export const invalidateFeatured = (): void => {
+  featuredCache.delete(FEATURED_KEY);
+};
+
+export type UseFeaturedEventsReturn = LandingFeaturedQuery & {
+  refetch: () => void;
+};
+
+export function useFeaturedEvents(): UseFeaturedEventsReturn {
+  const [state, setState] = useState<LandingFeaturedQuery>(() => {
+    const hit = featuredCache.get(FEATURED_KEY);
+    return hit
+      ? { status: 'success', data: hit.data, fetchedAt: hit.fetchedAt }
+      : { status: 'loading' };
+  });
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const hit = featuredCache.get(FEATURED_KEY);
+    if (hit && Date.now() - hit.fetchedAt < FEATURED_STALE_MS) {
+      setState({ status: 'success', data: hit.data, fetchedAt: hit.fetchedAt });
+      return;
+    }
+    setState((prev) => ({
+      status: 'loading',
+      previous: 'data' in prev ? prev.data : prev.previous,
+    }));
+
+    let cancelled = false;
+    getFeatured()
+      .then((data) => {
+        if (cancelled) return;
+        setState({ status: 'success', data, fetchedAt: Date.now() });
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setState((prev) => ({
+          status: 'error',
+          error,
+          previous: 'data' in prev ? prev.data : prev.previous,
+        }));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tick]);
+
+  const refetch = useCallback(() => {
+    invalidateFeatured();
+    setTick((n) => n + 1);
+  }, []);
+
+  return { ...state, refetch };
 }

--- a/src/pages-v2/Landing/sections/CategoriesSection.tsx
+++ b/src/pages-v2/Landing/sections/CategoriesSection.tsx
@@ -1,0 +1,116 @@
+/**
+ * Categories 섹션 — 6 타일 그리드 + 상태 분기.
+ * PR 3 (Categories + Featured) — Landing.plan.md §12.3 / §6.3 / §8.
+ *
+ * 상태 매트릭스 (§6.3):
+ *  - 로딩 (previous 없음): 6 × CategoryTileSkeleton.
+ *  - 로딩 (previous 보유): 이전 6 타일 그대로 노출 (refetch 깜빡임 방지).
+ *  - 정상: 6 × CategoryTile.
+ *  - 부분 에러: 타일 단계의 `count: null` → '—' (CategoryTile 내부 처리).
+ *  - 전체 에러 (success 없음 & previous 없음): 인라인 에러 박스 + 다시 시도.
+ *
+ * 라우팅 (§8.2 / §8.5):
+ *  - useNavigate 를 섹션 내부에서 사용. props 끌어올리지 않음 (불필요한 추상화 회피).
+ *  - URL: `/events?v=2&cat={한국어카테고리명}` (encodeURIComponent).
+ *
+ * 접근성:
+ *  - <section aria-busy> 로 로딩 상태 노출, 스켈레톤은 aria-hidden.
+ *  - 에러 메시지는 role="status" aria-live="polite" 로 1회 알림.
+ *  - 로딩 중 타일 클릭 핸들러는 미결선 (스켈레톤만 렌더).
+ *  - hover 모션은 landing.css 의 @media (prefers-reduced-motion: reduce) 가드.
+ */
+
+import { useNavigate } from 'react-router-dom';
+import { SectionHead } from '@/components-v2';
+import { CategoryTile } from '../components/CategoryTile';
+import type { UseLandingCategoriesReturn } from '../hooks';
+
+export interface CategoriesSectionProps {
+  query: UseLandingCategoriesReturn;
+}
+
+export function CategoriesSection({ query }: CategoriesSectionProps) {
+  const navigate = useNavigate();
+  const previous =
+    'previous' in query && query.previous ? query.previous : undefined;
+  const data = query.status === 'success' ? query.data : previous;
+  const isError = query.status === 'error' && !data;
+  const isLoading = query.status === 'loading' && !data;
+
+  const handleSelect = (cat: string): void => {
+    navigate(`/events?v=2&cat=${encodeURIComponent(cat)}`);
+  };
+
+  return (
+    <section
+      className="categories-section"
+      aria-label="카테고리별 이벤트"
+      aria-busy={query.status === 'loading' || undefined}
+    >
+      <SectionHead
+        title="카테고리별 이벤트"
+        hint="category"
+        caption="관심 있는 포맷을 선택해보세요"
+      />
+
+      {isLoading && (
+        <div className="categories-section__grid">
+          {Array.from({ length: 6 }, (_, i) => (
+            <CategoryTileSkeleton key={i} />
+          ))}
+        </div>
+      )}
+
+      {data && (
+        <div className="categories-section__grid">
+          {data.map((c) => (
+            <CategoryTile
+              key={c.cat}
+              cat={c.cat}
+              count={c.count}
+              icon={c.icon}
+              accent={c.accent}
+              onClick={() => handleSelect(c.cat)}
+            />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <div
+          className="categories-section__error"
+          role="status"
+          aria-live="polite"
+        >
+          <span className="categories-section__error-text">
+            <span className="categories-section__error-prefix">
+              // categories unavailable
+            </span>{' '}
+            카테고리를 불러올 수 없습니다
+          </span>
+          <button
+            type="button"
+            className="categories-section__retry"
+            onClick={query.refetch}
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+/**
+ * 스켈레톤. CategoryTile 과 같은 외곽 박스 / 그리드 정렬을 유지하기 위해
+ * 동일 구조 + aria-hidden. 색은 landing.css 의 --surface-3.
+ */
+function CategoryTileSkeleton() {
+  return (
+    <div className="category-tile category-tile--skeleton" aria-hidden="true">
+      <div className="category-tile-skeleton__icon" />
+      <div className="category-tile-skeleton__name" />
+      <div className="category-tile-skeleton__count" />
+    </div>
+  );
+}

--- a/src/pages-v2/Landing/sections/FeaturedSection.tsx
+++ b/src/pages-v2/Landing/sections/FeaturedSection.tsx
@@ -1,0 +1,150 @@
+/**
+ * Featured 섹션 — 5 rows + 상태 분기.
+ * PR 3 (Categories + Featured) — Landing.plan.md §12.3 / §6.4.
+ *
+ * 상태 매트릭스 (§6.4):
+ *  - 로딩 (previous 없음): 5 × FeaturedRowSkeleton.
+ *  - 로딩 (previous 보유): 이전 행 유지 (refetch 깜빡임 방지).
+ *  - 정상 (1~5건): 받은 만큼 행 노출 (5건 미만이어도 그대로).
+ *  - 빈 (0건): 본문을 EmptyState 로 교체 (SectionHead 유지). 섹션 숨기지 X.
+ *  - 에러 (success 없음 & previous 없음): 인라인 에러 박스 + 다시 시도.
+ *
+ * 라우팅:
+ *  - 행 클릭 → `/events/:eventId?v=2` (§12.3 검증 7)
+ *  - "전체 보기 →" → `/events?v=2`
+ *  - useNavigate 섹션 내부 사용 (CategoriesSection 과 동일, §8.5).
+ *
+ * 접근성:
+ *  - <section aria-busy> 로딩 토글, 스켈레톤은 aria-hidden.
+ *  - 에러 메시지는 role="status" aria-live="polite".
+ *  - "전체 보기" 는 button (앵커 아님 — SPA 내부 nav, EventList plan 컨벤션).
+ */
+
+import { useNavigate } from 'react-router-dom';
+import { EmptyState, SectionHead } from '@/components-v2';
+import { FeaturedRow } from '../components/FeaturedRow';
+import type { UseFeaturedEventsReturn } from '../hooks';
+
+export interface FeaturedSectionProps {
+  query: UseFeaturedEventsReturn;
+}
+
+const SKELETON_COUNT = 5;
+
+export function FeaturedSection({ query }: FeaturedSectionProps) {
+  const navigate = useNavigate();
+  const previous =
+    'previous' in query && query.previous ? query.previous : undefined;
+  const data = query.status === 'success' ? query.data : previous;
+  const isError = query.status === 'error' && !data;
+  const isLoading = query.status === 'loading' && !data;
+  const isEmpty = query.status === 'success' && data && data.length === 0;
+
+  const handleSeeAll = (): void => {
+    navigate('/events?v=2');
+  };
+  const handleRowClick = (eventId: string): void => {
+    navigate(`/events/${eventId}?v=2`);
+  };
+
+  return (
+    <section
+      className="featured-section"
+      aria-label="이번 주 주목할 이벤트"
+      aria-busy={query.status === 'loading' || undefined}
+    >
+      <SectionHead
+        title="이번 주 주목할 이벤트"
+        hint="featured"
+        caption="마감 임박 및 신규 오픈 순"
+        action={
+          <button
+            type="button"
+            className="featured-section__see-all"
+            onClick={handleSeeAll}
+          >
+            전체 보기 →
+          </button>
+        }
+      />
+
+      {isLoading && (
+        <div className="featured-section__list">
+          {Array.from({ length: SKELETON_COUNT }, (_, i) => (
+            <FeaturedRowSkeleton key={i} />
+          ))}
+        </div>
+      )}
+
+      {data && !isEmpty && (
+        <div className="featured-section__list">
+          {data.map((ev) => (
+            <FeaturedRow
+              key={ev.eventId}
+              ev={ev}
+              onClick={() => handleRowClick(ev.eventId)}
+            />
+          ))}
+        </div>
+      )}
+
+      {isEmpty && (
+        <EmptyState
+          className="featured-section__empty"
+          title="곧 새로운 이벤트가 등록될 예정입니다"
+          message="현재 판매중인 이벤트가 없습니다"
+          action={
+            <button
+              type="button"
+              className="featured-section__empty-action"
+              onClick={handleSeeAll}
+            >
+              전체 이벤트 보기 →
+            </button>
+          }
+        />
+      )}
+
+      {isError && (
+        <div
+          className="featured-section__error"
+          role="status"
+          aria-live="polite"
+        >
+          <span className="featured-section__error-text">
+            <span className="featured-section__error-prefix">
+              // featured unavailable
+            </span>{' '}
+            추천 이벤트를 불러올 수 없습니다
+          </span>
+          <button
+            type="button"
+            className="featured-section__retry"
+            onClick={query.refetch}
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+/**
+ * 스켈레톤. FeaturedRow 와 같은 grid 구조 (`36px 56px 1fr auto`) 유지.
+ * aria-hidden — 섹션 차원의 aria-busy 가 SR 에 알림.
+ */
+function FeaturedRowSkeleton() {
+  return (
+    <div className="featured-row featured-row--skeleton" aria-hidden="true">
+      <div className="featured-row-skeleton__rank" />
+      <div className="featured-row-skeleton__media" />
+      <div className="featured-row-skeleton__main">
+        <div className="featured-row-skeleton__line featured-row-skeleton__line--meta" />
+        <div className="featured-row-skeleton__line featured-row-skeleton__line--title" />
+        <div className="featured-row-skeleton__line featured-row-skeleton__line--sub" />
+      </div>
+      <div className="featured-row-skeleton__price" />
+    </div>
+  );
+}

--- a/src/pages-v2/Landing/types.ts
+++ b/src/pages-v2/Landing/types.ts
@@ -3,10 +3,12 @@
  * PR 1 (TypedTerminal) 에서 `TerminalLine` 정의.
  * PR 2 (Hero + Stats) 에서 `StatVM`, `LandingFirstPageQuery` 추가
  * (Landing.plan.md §12.2).
- * CategoryTileVM / FeaturedItemVM 등은 PR 3 진입 시 추가.
+ * PR 3 (Categories + Featured) 에서 `CategoryTileVM`, `FeaturedItemVM`,
+ * `LandingCategoriesQuery`, `LandingFeaturedQuery` 추가
+ * (Landing.plan.md §12.3).
  */
 
-import type { EventListPage } from '@/pages-v2/EventList/types';
+import type { EventVM, EventListPage } from '@/pages-v2/EventList/types';
 
 export interface TerminalLine {
   /** 프롬프트 표시용 ('~' 등) */
@@ -45,3 +47,74 @@ export type LandingFirstPageQuery =
   | { status: 'loading'; previous?: EventListPage }
   | { status: 'success'; data: EventListPage; fetchedAt: number }
   | { status: 'error'; error: unknown; previous?: EventListPage };
+
+/**
+ * Categories 6 타일 view model (§2 Categories, §6.3).
+ * - `cat`: 한국어 카테고리명 (URL/필터 키, EventList plan §4 라인 165–166).
+ * - `count`: 6 병렬 `filterEvents` 의 totalElements. 부분 실패 시 `null`
+ *   → 타일에 `—` 표시 (카운트 0 (`0개 이벤트`) 과 구분, §12.3 D / 머지조건).
+ * - `icon`: 약자 글리프 ('CF' 등). 장식용 — `aria-hidden="true"` (§9.6).
+ * - `accent`: 카테고리 고정 accent 토큰 키 ('indigo'/'sky'/...).
+ *   CSS 변수로 주입해 hover borderColor 결선 (§2 Categories).
+ */
+export interface CategoryTileVM {
+  cat: string;
+  count: number | null;
+  icon: string;
+  accent: AccentToken;
+}
+
+/**
+ * SPEC §0 accent 팔레트 키 (회전/카테고리 매핑 공용).
+ * `red` 는 카테고리 매핑에서 사용하지 않지만 Featured accent 회전에서 쓰임.
+ */
+export type AccentToken =
+  | 'indigo'
+  | 'sky'
+  | 'emerald'
+  | 'amber'
+  | 'violet'
+  | 'pink'
+  | 'red';
+
+/**
+ * Featured 5 rows view model (§2 Featured).
+ * `EventVM` 에서 행 렌더에 필요한 필드만 좁힌 형태 +
+ * 순번(rank, 1-based) + accent (eventId 회전).
+ */
+export type FeaturedItemVM = Pick<
+  EventVM,
+  | 'eventId'
+  | 'title'
+  | 'category'
+  | 'price'
+  | 'remainingQuantity'
+  | 'status'
+  | 'eventDateTime'
+  | 'techStacks'
+  | 'isFree'
+  | 'dateLabel'
+> & {
+  rank: number;
+  accent: AccentToken;
+};
+
+/**
+ * Categories 섹션 query state (§6.3).
+ * 6 병렬 호출의 부분 실패는 `data[i].count === null` 로 표현하므로
+ * 전체 차원에서는 success / loading / error 만 노출.
+ */
+export type LandingCategoriesQuery =
+  | { status: 'loading'; previous?: CategoryTileVM[] }
+  | { status: 'success'; data: CategoryTileVM[]; fetchedAt: number }
+  | { status: 'error'; error: unknown; previous?: CategoryTileVM[] };
+
+/**
+ * Featured 섹션 query state (§6.4).
+ * 1차 `/events/recommendations` 실패/빈 → `getEvents` 폴백 → 5개 슬라이스.
+ * 폴백 단계에서도 hooks 내부에서 합성하므로 query 표면은 단순 3-state.
+ */
+export type LandingFeaturedQuery =
+  | { status: 'loading'; previous?: FeaturedItemVM[] }
+  | { status: 'success'; data: FeaturedItemVM[]; fetchedAt: number }
+  | { status: 'error'; error: unknown; previous?: FeaturedItemVM[] };

--- a/src/pages-v2/_dev/CategoriesFeaturedShowcase.tsx
+++ b/src/pages-v2/_dev/CategoriesFeaturedShowcase.tsx
@@ -1,0 +1,41 @@
+/**
+ * 임시 dev 라우트 (`/_dev/landing-categories-featured`).
+ * Landing.plan.md §12.3 검증 절차 A~E 를 라이브로 확인하기 위한 마운트 셸.
+ * 실제 API 와 결선된 <CategoriesSection> + <FeaturedSection> 단독 렌더.
+ *
+ * - 타일/행 클릭은 CategoriesSection / FeaturedSection 내부의 useNavigate
+ *   가 그대로 동작 (§12.3 검증 6/7). React Router Provider 가 App.tsx
+ *   위에 있어 dev 라우트에서도 nav OK.
+ * - "전체 보기 →" 도 useNavigate 결선 — `/events?v=2` 로 이동.
+ *
+ * cutover 또는 PR 4 cleanup 커밋에서 제거 예정.
+ */
+
+import { CategoriesSection } from '../Landing/sections/CategoriesSection';
+import { FeaturedSection } from '../Landing/sections/FeaturedSection';
+import {
+  useFeaturedEvents,
+  useLandingCategories,
+} from '../Landing/hooks';
+
+export default function CategoriesFeaturedShowcase() {
+  const categories = useLandingCategories();
+  const featured = useFeaturedEvents();
+
+  return (
+    <div style={{ maxWidth: 1100, margin: '0 auto', padding: '24px 24px 64px' }}>
+      <header style={{ marginBottom: 16 }}>
+        <h1 style={{ fontSize: 18, margin: 0 }}>
+          Landing Categories + Featured — dev showcase
+        </h1>
+        <p style={{ fontSize: 12, color: 'var(--text-3)', margin: '4px 0 0' }}>
+          Landing.plan.md §12.3 검증.{' '}
+          <code>/_dev/landing-categories-featured</code>
+        </p>
+      </header>
+
+      <CategoriesSection query={categories} />
+      <FeaturedSection query={featured} />
+    </div>
+  );
+}

--- a/src/styles-v2/pages/landing.css
+++ b/src/styles-v2/pages/landing.css
@@ -295,3 +295,377 @@
   cursor: pointer;
 }
 .stats-section__retry:hover { background: var(--surface-3); }
+
+/* ===== Categories ===== (PR 3, Landing.plan.md §12.3 / §6.3 / §8) ----------
+   `--tile-accent` 는 CategoryTile 이 인라인 변수로 주입 (token → var(--accent-*)).
+   --------------------------------------------------------------------------*/
+
+.categories-section {
+  margin-bottom: 44px;
+}
+
+.categories-section__grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 10px;
+}
+
+@media (max-width: 720px) {
+  .categories-section__grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.category-tile {
+  text-align: left;
+  padding: 16px 18px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-family: inherit;
+  color: inherit;
+  transition: transform 0.15s, border-color 0.15s, box-shadow 0.15s;
+}
+
+.category-tile:hover {
+  border-color: var(--tile-accent, var(--brand));
+  transform: translateY(-2px);
+}
+.category-tile:focus-visible {
+  outline: 2px solid var(--tile-accent, var(--brand));
+  outline-offset: 2px;
+}
+
+.category-tile__icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--tile-accent, var(--brand));
+  background: color-mix(in srgb, var(--tile-accent, var(--brand)) 12%, transparent);
+}
+
+.category-tile__name {
+  font-family: var(--font);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.category-tile__count {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-4);
+}
+
+/* skeleton variant — same outer box height (CLS 0). */
+.category-tile--skeleton {
+  cursor: default;
+  pointer-events: none;
+}
+
+.category-tile-skeleton__icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  background: var(--surface-3);
+}
+
+.category-tile-skeleton__name {
+  width: 60%;
+  height: 15px;
+  border-radius: 4px;
+  background: var(--surface-3);
+}
+
+.category-tile-skeleton__count {
+  width: 40%;
+  height: 11.5px;
+  border-radius: 4px;
+  background: var(--surface-3);
+}
+
+.category-tile-skeleton__icon,
+.category-tile-skeleton__name,
+.category-tile-skeleton__count {
+  animation: stat-skeleton-pulse 1.4s ease-in-out infinite;
+}
+
+.categories-section__error {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+}
+.categories-section__error-text   { color: var(--text-2); }
+.categories-section__error-prefix { color: var(--text-4); }
+
+.categories-section__retry {
+  margin-left: auto;
+  padding: 4px 10px;
+  border: 1px solid var(--border-2);
+  border-radius: 6px;
+  background: var(--surface-2);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 12px;
+  cursor: pointer;
+}
+.categories-section__retry:hover { background: var(--surface-3); }
+
+/* ===== Featured ===== (PR 3, Landing.plan.md §12.3 / §6.4 / §9.6) ----------
+   `--row-accent` 는 FeaturedRow 가 인라인 변수로 주입.
+   `<button>` 요소라 user-agent 의 굵은 보더/배경 리셋 필요.
+   --------------------------------------------------------------------------*/
+
+.featured-section {
+  margin-bottom: 44px;
+}
+
+.featured-section__see-all {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--font);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--brand);
+}
+.featured-section__see-all:hover { text-decoration: underline; }
+.featured-section__see-all:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.featured-section__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.featured-row {
+  display: grid;
+  grid-template-columns: 36px 56px 1fr auto;
+  gap: 14px;
+  align-items: center;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  color: inherit;
+  width: 100%;
+  transition: transform 0.12s, border-color 0.12s, background 0.12s;
+}
+.featured-row:hover {
+  border-color: var(--row-accent, var(--brand));
+  background: var(--editor-line);
+}
+.featured-row:focus-visible {
+  outline: 2px solid var(--row-accent, var(--brand));
+  outline-offset: 2px;
+}
+
+.featured-row__rank {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-4);
+}
+
+.featured-row__media {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--row-accent, var(--brand)) 20%, transparent),
+    color-mix(in srgb, var(--row-accent, var(--brand)) 45%, transparent)
+  );
+  color: var(--row-accent, var(--brand));
+}
+
+.featured-row__media-glyph {
+  font-family: var(--font-mono);
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.featured-row__main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0; /* grid + ellipsis 안전망 */
+}
+
+.featured-row__meta-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 3px;
+}
+
+.featured-row__category {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--row-accent, var(--brand));
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.featured-row__title {
+  font-family: var(--font);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.featured-row__meta {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-4);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.featured-row__price {
+  font-family: var(--font);
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text);
+  white-space: nowrap;
+}
+.featured-row__price--free { color: var(--term-green-dim); }
+
+/* skeleton variant — same grid columns / row height. */
+.featured-row--skeleton {
+  cursor: default;
+  pointer-events: none;
+}
+
+.featured-row-skeleton__rank {
+  width: 22px;
+  height: 12px;
+  border-radius: 4px;
+  background: var(--surface-3);
+}
+.featured-row-skeleton__media {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  background: var(--surface-3);
+}
+.featured-row-skeleton__main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.featured-row-skeleton__line { background: var(--surface-3); border-radius: 4px; }
+.featured-row-skeleton__line--meta  { width: 30%; height: 11px; }
+.featured-row-skeleton__line--title { width: 75%; height: 14px; }
+.featured-row-skeleton__line--sub   { width: 50%; height: 11px; }
+.featured-row-skeleton__price {
+  width: 60px;
+  height: 15px;
+  border-radius: 4px;
+  background: var(--surface-3);
+}
+
+.featured-row-skeleton__rank,
+.featured-row-skeleton__media,
+.featured-row-skeleton__line,
+.featured-row-skeleton__price {
+  animation: stat-skeleton-pulse 1.4s ease-in-out infinite;
+}
+
+.featured-section__empty {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  padding: 28px 20px;
+}
+
+.featured-section__empty-action {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--font);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--brand);
+}
+.featured-section__empty-action:hover { text-decoration: underline; }
+
+.featured-section__error {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+}
+.featured-section__error-text   { color: var(--text-2); }
+.featured-section__error-prefix { color: var(--text-4); }
+
+.featured-section__retry {
+  margin-left: auto;
+  padding: 4px 10px;
+  border: 1px solid var(--border-2);
+  border-radius: 6px;
+  background: var(--surface-2);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 12px;
+  cursor: pointer;
+}
+.featured-section__retry:hover { background: var(--surface-3); }
+
+@media (prefers-reduced-motion: reduce) {
+  .category-tile,
+  .featured-row {
+    transition: none;
+  }
+  .category-tile:hover,
+  .featured-row:hover {
+    transform: none;
+  }
+  .category-tile-skeleton__icon,
+  .category-tile-skeleton__name,
+  .category-tile-skeleton__count,
+  .featured-row-skeleton__rank,
+  .featured-row-skeleton__media,
+  .featured-row-skeleton__line,
+  .featured-row-skeleton__price {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the Categories and Featured sections for the Landing page (PR 3 of Landing.plan.md §12.3), adding two new data-fetching hooks, UI components, and comprehensive styling with skeleton loading states and error handling.

## Key Changes

### Data Fetching & State Management
- **`useLandingCategories()`** — Fetches 6 category master definitions with event counts via parallel `filterEvents()` calls using `Promise.allSettled()` for partial failure resilience. Implements 10-minute cache with stale-while-revalidate pattern.
- **`useFeaturedEvents()`** — Fetches featured events with fallback logic: attempts `/events/recommendations` first, falls back to `getEvents()` filtered by ON_SALE status and sorted by date ascending, returns top 5 items. Implements 5-minute cache.
- Both hooks use `cancelled` flag pattern for unmount cleanup (consistent with PR 2) and expose `refetch()` for manual retry.

### UI Components
- **`CategoryTile`** — Single category tile with icon, name, and event count. Supports `count: null` for partial failures (displayed as "—") vs `count: 0` for zero events. Uses inline CSS variable `--tile-accent` for accent color injection.
- **`CategoriesSection`** — 6-tile grid with loading skeletons, error state with retry button, and `useNavigate` integration to `/events?v=2&cat={category}`.
- **`FeaturedRow`** — Single featured event row with rank, media icon, category badge, status chip, title, metadata, and price. Grid layout (36px 56px 1fr auto). Uses inline CSS variable `--row-accent` for accent color.
- **`FeaturedSection`** — List of featured rows with loading skeletons, empty state, error handling, and navigation to `/events/:eventId?v=2` or `/events?v=2`.

### Styling
- **`landing.css`** — 377 lines of new styles covering:
  - `.categories-section__grid` — 6-column responsive grid (3 columns on mobile ≤720px)
  - `.category-tile` — Button-based tile with hover/focus states, transitions guarded by `prefers-reduced-motion`
  - `.featured-row` — Button-based row with gradient media background and accent-driven styling
  - Skeleton variants (`.category-tile--skeleton`, `.featured-row--skeleton`) with pulsing animation
  - Error and retry button styles matching stats section pattern
  - All accent colors use `color-mix()` for tinted backgrounds

### Adapters & Types
- **`CATEGORY_DEFINITIONS`** — 6-category master with Korean names, icon glyphs, and fixed accent tokens (indigo/sky/emerald/amber/violet/pink).
- **`toCategoryTileVM()`** — Converts category definition + count to tile view model.
- **`toFeaturedItemVM()`** — Converts EventVM + rank to featured item with accent derived from eventId hash.
- **`pickAccentByEventId()`** — Deterministic accent rotation based on eventId char-sum hash (ensures same ID always gets same accent).
- **`sortByDateAsc()`** — Sorts events by eventDateTime ascending for featured fallback.
- New types: `CategoryTileVM`, `FeaturedItemVM`, `AccentToken`, `LandingCategoriesQuery`, `LandingFeaturedQuery`.

### Dev & Routing
- **`CategoriesFeaturedShowcase`** — Temporary dev route (`/_dev/landing-categories-featured`) for live validation of sections with real API integration.
- Added route in `App.tsx` for dev showcase.

## Implementation Details

- **Partial Failure Handling** — Categories uses `Promise.allSettled()` so one failed fetch doesn't block others; failed tiles show "—" instead of count.
- **Fallback Strategy** — Featured attempts AI recommendations first; if empty/failed, falls back to ON_SALE events sorted by date.
- **Accent Injection** — Both sections use inline CSS variables (`--tile

https://claude.ai/code/session_01VZGcvjbYG88RfhNbKX9vGF