### PR TITLE
feat: Add Landing page with CTA section and IDE chrome layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,17 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="개발자 컨퍼런스·밋업 티케팅 플랫폼" />
+
+    <!-- Open Graph / Twitter (Landing.plan §9.1 / §11.2 / §12.4 PR 4)
+         og:image / og:url 는 배포 도메인 결정 후 절대경로로 교체 필요.
+         이미지 자산: public/og/landing.png 1280×640 (별 커밋). -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="DevTicket — 개발자 이벤트와 티켓, 한 곳에서" />
+    <meta property="og:description" content="컨퍼런스·밋업·해커톤·스터디까지. 관심 있는 기술 스택으로 바로 찾고, 몇 번의 클릭으로 티켓을 예매하세요." />
+    <meta property="og:image" content="/og/landing.png" />
+    <meta property="og:url" content="/" />
+    <meta name="twitter:card" content="summary_large_image" />
+
     <title>DevTicket</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ import NotFound          from './pages/NotFound'
 const OAuthCallback       = lazy(() => import('./pages/OAuthCallback'))
 const SocialProfileSetup  = lazy(() => import('./pages/SocialProfileSetup'))
 
-// lazy – v2 재구축 (router-toggle.plan, Login.plan §6, EventList.plan §10 PR 1, Cart.plan §10.1 / §10.3 PR 5)
+// lazy – v2 재구축 (router-toggle.plan, Login.plan §6, EventList.plan §10 PR 1, Cart.plan §10.1 / §10.3 PR 5, Landing.plan §12.4 PR 4)
 const LoginV2             = lazy(() => import('./pages-v2/Login'))
 const EventListV2         = lazy(() => import('./pages-v2/EventList'))
 const EventDetailV2       = lazy(() => import('./pages-v2/EventDetail'))
@@ -27,6 +27,7 @@ const PaymentSuccessV2    = lazy(() => import('./pages-v2/PaymentCallback/Paymen
 const PaymentFailV2       = lazy(() => import('./pages-v2/PaymentCallback/PaymentFailPage'))
 const PaymentCompleteV2   = lazy(() => import('./pages-v2/PaymentCallback/PaymentCompletePage'))
 const MyPageV2            = lazy(() => import('./pages-v2/MyPage'))
+const LandingV2           = lazy(() => import('./pages-v2/Landing'))
 
 // lazy – v2 dev showcase (Landing.plan §12.1 PR 1; cutover/PR 4 cleanup 시 제거)
 const TypedTerminalShowcase = lazy(() => import('./pages-v2/_dev/TypedTerminalShowcase'))
@@ -105,7 +106,8 @@ export default function App() {
 
         {/* 일반 사용자 */}
         <Route element={<Layout />}>
-          <Route path="/"                       element={<VersionedRoute v1={<EventList />} v2={<EventListV2 />} />} />
+          <Route path="/"                       element={<VersionedRoute v1={<EventList />} v2={<LandingV2 />} />} />
+          <Route path="/events"                 element={<VersionedRoute v1={<EventList />} v2={<EventListV2 />} />} />
           <Route path="/events/:id"             element={<VersionedRoute v1={<EventDetail />} v2={<EventDetailV2 />} />} />
           <Route path="/cart"                   element={<RequireAuth><VersionedRoute v1={<Cart />} v2={<CartV2 />} /></RequireAuth>} />
           <Route path="/payment"                element={<RequireAuth><Payment /></RequireAuth>} />

--- a/src/pages-v2/Landing/Landing.tsx
+++ b/src/pages-v2/Landing/Landing.tsx
@@ -1,0 +1,120 @@
+/**
+ * Landing 페이지 컨테이너 — 5 섹션 세로 조합.
+ * PR 4 (CTA + 통합 + 라우터) — Landing.plan.md §12.4 / §1 / §6.6.
+ *
+ * editor-scroll / gutter / editor-body chrome 안에 Hero → Stats →
+ * Categories → Featured → CTA 순. 자체 상태 / 데이터 페치 없음 — 모든
+ * 데이터는 컨테이너 (`index.tsx`) 가 hooks 로 채워 props 로 전달 (§1, §6.6).
+ *
+ * 단, Hero 우측 TypedTerminal 의 카운트 합성을 위해 HeroSection 이
+ * 내부적으로 `useFirstPage()` 를 직접 호출 (PR 2 결정 — 모듈 캐시 + in-flight
+ * 공유로 네트워크 1회). 그 외 Stats / Categories / Featured 는 query 패스스루.
+ *
+ * Props 튜닝:
+ * - TypedTerminal 타이밍 (typingSpeedMs / outputDelayMs / nextLineDelayMs /
+ *   restartDelayMs / loop): HeroSection 으로 forward.
+ * - gutter 줄 수 (gutterLineCount): 기본 80 (프로토타입). 화면 비율이 맞지
+ *   않으면 컨테이너에서 override.
+ * - CTA 카피 override (ctaHeadline / ctaSubcopy / ctaButtonLabel).
+ *
+ * 접근성:
+ * - gutter 는 장식 — aria-hidden="true" (chrome 컨벤션).
+ * - 각 섹션은 자체 aria-label + aria-busy 를 가짐 (PR 2/3 에서 처리).
+ * - prefers-reduced-motion: 모션은 TypedTerminal / Categories / Featured 가
+ *   각자 가드. 컨테이너 자체에 모션 없음.
+ */
+
+import { CategoriesSection } from './sections/CategoriesSection';
+import { CtaSection } from './sections/CtaSection';
+import { FeaturedSection } from './sections/FeaturedSection';
+import { HeroSection } from './sections/HeroSection';
+import { StatsSection } from './sections/StatsSection';
+import type {
+  UseFeaturedEventsReturn,
+  UseLandingCategoriesReturn,
+  UseLandingStatsReturn,
+} from './hooks';
+
+export interface LandingProps {
+  /** Hero "이벤트 둘러보기 →" 핸들러. 보통 `/events?v=2` navigate. */
+  onBrowseEvents: () => void;
+  /** Hero "빠른 검색 ⌘K" 핸들러. 미주입 시 onBrowseEvents 로 fallback (§7.2). */
+  onOpenPalette?: () => void;
+  /** CTA "시작하기 →" 핸들러. 보통 `/events?v=2` navigate. */
+  onStart: () => void;
+
+  statsQuery: UseLandingStatsReturn;
+  categoriesQuery: UseLandingCategoriesReturn;
+  featuredQuery: UseFeaturedEventsReturn;
+
+  /** TypedTerminal 라인별 cmd 타이핑 ms */
+  typingSpeedMs?: number;
+  /** cmd 완료 후 out 노출까지 ms */
+  outputDelayMs?: number;
+  /** out 완료 후 다음 라인 시작까지 ms */
+  nextLineDelayMs?: number;
+  /** 마지막 라인 후 처음으로 돌아가기까지 ms */
+  restartDelayMs?: number;
+  /** TypedTerminal 루프 여부 */
+  loop?: boolean;
+
+  /** gutter 라인 수. 기본 80 (프로토타입) */
+  gutterLineCount?: number;
+
+  /** CTA 카피 override */
+  ctaHeadline?: string;
+  ctaSubcopy?: string;
+  ctaButtonLabel?: string;
+}
+
+const DEFAULT_GUTTER_LINE_COUNT = 80;
+
+export function Landing({
+  onBrowseEvents,
+  onOpenPalette,
+  onStart,
+  statsQuery,
+  categoriesQuery,
+  featuredQuery,
+  typingSpeedMs,
+  outputDelayMs,
+  nextLineDelayMs,
+  restartDelayMs,
+  loop,
+  gutterLineCount = DEFAULT_GUTTER_LINE_COUNT,
+  ctaHeadline,
+  ctaSubcopy,
+  ctaButtonLabel,
+}: LandingProps) {
+  return (
+    <div className="editor-scroll">
+      <div className="gutter" aria-hidden="true">
+        {Array.from({ length: gutterLineCount }, (_, i) => (
+          <span key={i} className={`ln${i === 0 ? ' active' : ''}`}>
+            {i + 1}
+          </span>
+        ))}
+      </div>
+      <div className="editor-body landing-page">
+        <HeroSection
+          onBrowseEvents={onBrowseEvents}
+          onOpenPalette={onOpenPalette}
+          typingSpeedMs={typingSpeedMs}
+          outputDelayMs={outputDelayMs}
+          nextLineDelayMs={nextLineDelayMs}
+          restartDelayMs={restartDelayMs}
+          loop={loop}
+        />
+        <StatsSection query={statsQuery} />
+        <CategoriesSection query={categoriesQuery} />
+        <FeaturedSection query={featuredQuery} />
+        <CtaSection
+          onStart={onStart}
+          headline={ctaHeadline}
+          subcopy={ctaSubcopy}
+          ctaLabel={ctaButtonLabel}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/pages-v2/Landing/hooks.ts
+++ b/src/pages-v2/Landing/hooks.ts
@@ -17,9 +17,10 @@
  * - useLandingCategories: 6 카테고리 마스터 × `filterEvents({ size:1 })`
  *   `Promise.allSettled` (부분 실패 시 해당 타일만 `count: null`).
  *   캐시 키 `landing:categories:counts`, stale 10분.
- * - useFeaturedEvents: 1차 `getEventRecommendations` → 실패/빈 시
- *   `getEvents({ size:10 })` 폴백 → ON_SALE 필터 + `eventDateTime` asc + 5개.
- *   캐시 키 `landing:featured`, stale 5분.
+ * - useFeaturedEvents: 1차 `getEventRecommendations` (anon) 또는
+ *   `recommendEvents` (authed, §11 #8) → 실패/빈 시 `getEvents({ size:10 })`
+ *   폴백 → ON_SALE 필터 + `eventDateTime` asc + 5개. 캐시 키는 인증 상태별
+ *   (`landing:featured:anon` / `landing:featured:auth`), stale 5분.
  * - 두 훅 모두 PR 2 의 `getFirstPage` 를 재사용하지 않음 (§12.3 — PR 2/3
  *   병렬 빌드 보장). API 래퍼(`filterEvents`/`getEventRecommendations`/
  *   `getEvents`) 가 signal 을 받지 않아 unmount 처리는 cancelled 플래그로
@@ -31,8 +32,10 @@ import { apiClient, unwrapApiData, type ApiResponse } from '@/api/client';
 import {
   filterEvents,
   getEvents,
+  recommendEvents,
 } from '@/api/events.api';
 import { getEventRecommendations } from '@/api/ai.api';
+import { useAuth } from '@/contexts/AuthContext';
 import type {
   EventFilterResponse,
   EventListResponse,
@@ -285,7 +288,11 @@ export function useLandingCategories(): UseLandingCategoriesReturn {
   return { ...state, refetch };
 }
 
-const FEATURED_KEY = 'landing:featured';
+/* Featured 캐시는 인증 상태별로 키를 분리. 비로그인 → /events/recommendations
+ * (anon), 로그인 → /events/user/recommendations (authed). 같은 캐시에 섞이면
+ * 로그인 / 로그아웃 transition 시 잘못된 데이터 노출 가능 (§11 #8). */
+const FEATURED_KEY_ANON = 'landing:featured:anon';
+const FEATURED_KEY_AUTH = 'landing:featured:auth';
 const FEATURED_STALE_MS = 5 * 60_000;
 const FEATURED_FALLBACK_PAGE_SIZE = 10;
 const FEATURED_LIMIT = 5;
@@ -293,7 +300,7 @@ const featuredCache = new Map<
   string,
   { data: FeaturedItemVM[]; fetchedAt: number }
 >();
-let featuredInFlight: Promise<FeaturedItemVM[]> | null = null;
+const featuredInFlight = new Map<string, Promise<FeaturedItemVM[]>>();
 
 /**
  * 폴백 + 추천 hydration 양쪽에서 쓰는 1차 페이지. PR 2 의 `getFirstPage`
@@ -305,17 +312,22 @@ const fetchFeaturedFallbackEvents = async (): Promise<EventVM[]> => {
   return sortByDateAsc(page.items.filter((e) => e.status === 'ON_SALE'));
 };
 
-const fetchFeatured = async (): Promise<FeaturedItemVM[]> => {
-  // 1차: /events/recommendations (비-auth, ai.api.ts:4).
+const fetchFeatured = async (authed: boolean): Promise<FeaturedItemVM[]> => {
+  // 1차: 인증 상태에 따라 엔드포인트 분기 (§11 #8).
+  // - authed:  /events/user/recommendations (개인화, Authorization 필요)
+  // - anon:    /events/recommendations (글로벌)
+  // 둘 다 RecommendationResponse 셰이프 (eventIdList) 동일.
   let recIds: string[] = [];
   try {
-    const res = await getEventRecommendations();
+    const res = authed
+      ? await recommendEvents()
+      : await getEventRecommendations();
     const data = unwrapApiData<RecommendationResponse>(
       res.data as ApiResponse<RecommendationResponse> | RecommendationResponse,
     );
     recIds = data?.eventIdList ?? [];
   } catch {
-    // 실패는 폴백으로 흡수 (§12.3 §11 #4).
+    // 실패는 폴백으로 흡수 (§12.3 §11 #4). authed 401/403 도 동일하게 폴백.
   }
   if (recIds.length > 0) {
     // RecommendationResponse 는 ID 만 — 행 렌더에 필요한 필드는 1차 페이지로 hydration.
@@ -336,25 +348,30 @@ const fetchFeatured = async (): Promise<FeaturedItemVM[]> => {
     .map((e, i) => toFeaturedItemVM(e, i + 1));
 };
 
-export const getFeatured = (): Promise<FeaturedItemVM[]> => {
-  const hit = featuredCache.get(FEATURED_KEY);
+export const getFeatured = (authed: boolean): Promise<FeaturedItemVM[]> => {
+  const key = authed ? FEATURED_KEY_AUTH : FEATURED_KEY_ANON;
+  const hit = featuredCache.get(key);
   if (hit && Date.now() - hit.fetchedAt < FEATURED_STALE_MS) {
     return Promise.resolve(hit.data);
   }
-  if (featuredInFlight) return featuredInFlight;
-  featuredInFlight = fetchFeatured()
+  const inflight = featuredInFlight.get(key);
+  if (inflight) return inflight;
+  const promise = fetchFeatured(authed)
     .then((data) => {
-      featuredCache.set(FEATURED_KEY, { data, fetchedAt: Date.now() });
+      featuredCache.set(key, { data, fetchedAt: Date.now() });
       return data;
     })
     .finally(() => {
-      featuredInFlight = null;
+      featuredInFlight.delete(key);
     });
-  return featuredInFlight;
+  featuredInFlight.set(key, promise);
+  return promise;
 };
 
+/* 두 캐시 모두 비움 — 사용자가 "다시 시도" 를 누른 시점에 인증 상태가
+ * 어느 쪽이든 다음 fetch 가 강제되도록. */
 export const invalidateFeatured = (): void => {
-  featuredCache.delete(FEATURED_KEY);
+  featuredCache.clear();
 };
 
 export type UseFeaturedEventsReturn = LandingFeaturedQuery & {
@@ -362,8 +379,11 @@ export type UseFeaturedEventsReturn = LandingFeaturedQuery & {
 };
 
 export function useFeaturedEvents(): UseFeaturedEventsReturn {
+  const { isLoggedIn } = useAuth();
+  const cacheKey = isLoggedIn ? FEATURED_KEY_AUTH : FEATURED_KEY_ANON;
+
   const [state, setState] = useState<LandingFeaturedQuery>(() => {
-    const hit = featuredCache.get(FEATURED_KEY);
+    const hit = featuredCache.get(cacheKey);
     return hit
       ? { status: 'success', data: hit.data, fetchedAt: hit.fetchedAt }
       : { status: 'loading' };
@@ -371,7 +391,7 @@ export function useFeaturedEvents(): UseFeaturedEventsReturn {
   const [tick, setTick] = useState(0);
 
   useEffect(() => {
-    const hit = featuredCache.get(FEATURED_KEY);
+    const hit = featuredCache.get(cacheKey);
     if (hit && Date.now() - hit.fetchedAt < FEATURED_STALE_MS) {
       setState({ status: 'success', data: hit.data, fetchedAt: hit.fetchedAt });
       return;
@@ -382,7 +402,7 @@ export function useFeaturedEvents(): UseFeaturedEventsReturn {
     }));
 
     let cancelled = false;
-    getFeatured()
+    getFeatured(isLoggedIn)
       .then((data) => {
         if (cancelled) return;
         setState({ status: 'success', data, fetchedAt: Date.now() });
@@ -399,7 +419,8 @@ export function useFeaturedEvents(): UseFeaturedEventsReturn {
     return () => {
       cancelled = true;
     };
-  }, [tick]);
+    // isLoggedIn 변동 (로그인 / 로그아웃) 시 다른 캐시 키로 재진입.
+  }, [tick, isLoggedIn, cacheKey]);
 
   const refetch = useCallback(() => {
     invalidateFeatured();

--- a/src/pages-v2/Landing/index.tsx
+++ b/src/pages-v2/Landing/index.tsx
@@ -1,0 +1,48 @@
+/**
+ * Landing 페이지 라우트 진입점.
+ * PR 4 (CTA + 통합 + 라우터) — Landing.plan.md §12.4 / §1 / §7.
+ *
+ * 책임:
+ * - useNavigate 콜백 합성 (Hero / CTA → `/events?v=2`).
+ * - 3 데이터 훅 (`useLandingStats / useLandingCategories / useFeaturedEvents`)
+ *   호출 → `<Landing>` 에 props 주입.
+ * - HeroSection 의 `useFirstPage` 는 내부 호출 (모듈 캐시 + in-flight 공유로
+ *   네트워크 1회 — §5.5). 본 컨테이너는 Hero 데이터 의존이 없으므로 미주입.
+ *
+ * 미결선 (의도):
+ * - `onOpenPalette`: PR 0 (⌘K 팔레트) 머지 후 결선. 현재 미주입 →
+ *   HeroSection 이 `onBrowseEvents` 로 fallback (§7.2).
+ * - 로그인 분기 (#8): `useFeaturedEvents` 가 향후 useAuth 분기 도입 예정
+ *   (별 커밋). 본 컨테이너 변화는 hooks.ts 가 흡수하므로 zero diff.
+ */
+
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { Landing } from './Landing';
+import {
+  useFeaturedEvents,
+  useLandingCategories,
+  useLandingStats,
+} from './hooks';
+
+export default function LandingPage() {
+  const navigate = useNavigate();
+  const statsQuery = useLandingStats();
+  const categoriesQuery = useLandingCategories();
+  const featuredQuery = useFeaturedEvents();
+
+  const goEvents = useCallback(() => {
+    navigate('/events?v=2');
+  }, [navigate]);
+
+  return (
+    <Landing
+      onBrowseEvents={goEvents}
+      onStart={goEvents}
+      statsQuery={statsQuery}
+      categoriesQuery={categoriesQuery}
+      featuredQuery={featuredQuery}
+    />
+  );
+}

--- a/src/pages-v2/Landing/sections/CtaSection.tsx
+++ b/src/pages-v2/Landing/sections/CtaSection.tsx
@@ -1,0 +1,61 @@
+/**
+ * CTA 섹션 — dashed border + brand-light 그라디언트 카드.
+ * PR 4 (CTA + 통합 + 라우터) — Landing.plan.md §12.4 / §2 / §6.5.
+ *
+ * 좌측 헤드라인 / 서브카피, 우측 primary lg "시작하기 →".
+ * 정적 컴포넌트 — 로딩 / 에러 / 동적 데이터 없음 (§6.5).
+ *
+ * 카피는 컴포넌트에 하드코딩 (§2). 다국어/원격화 시 props 로 승격.
+ * 다만 헤드라인 / 서브카피는 props 로 override 가능 — A/B 테스트나
+ * 후속 캠페인 카피 교체에 대비.
+ *
+ * 접근성:
+ * - <section aria-labelledby> 로 헤드라인을 landmark 라벨로 사용.
+ * - "// get started" 는 시각적 eyebrow 일 뿐이므로 aria-hidden.
+ *   스크린리더는 h3 → 서브카피 → 버튼 순서로만 읽음.
+ * - 모션 없음. landing.css 의 @media (prefers-reduced-motion: reduce)
+ *   guard 는 다른 섹션과 일괄 정의되며 본 카드에는 transition 자체가 없음.
+ */
+
+export interface CtaSectionProps {
+  onStart: () => void;
+  /** 헤드라인 override. 기본: "지금 바로 다음 컨퍼런스를 예약하세요" */
+  headline?: string;
+  /** 서브카피 override. 기본: "회원가입은 30초면 끝나요. ..." */
+  subcopy?: string;
+  /** 버튼 라벨 override. 기본: "시작하기 →" */
+  ctaLabel?: string;
+}
+
+const DEFAULT_HEADLINE = '지금 바로 다음 컨퍼런스를 예약하세요';
+const DEFAULT_SUBCOPY =
+  '회원가입은 30초면 끝나요. 신용카드, 계좌이체, 예치금 모두 지원합니다.';
+const DEFAULT_CTA_LABEL = '시작하기';
+
+export function CtaSection({
+  onStart,
+  headline = DEFAULT_HEADLINE,
+  subcopy = DEFAULT_SUBCOPY,
+  ctaLabel = DEFAULT_CTA_LABEL,
+}: CtaSectionProps) {
+  return (
+    <section className="cta-section" aria-labelledby="cta-section__headline">
+      <div className="cta-section__copy">
+        <div className="cta-section__eyebrow" aria-hidden="true">
+          // get started
+        </div>
+        <h3 id="cta-section__headline" className="cta-section__headline">
+          {headline}
+        </h3>
+        <p className="cta-section__subcopy">{subcopy}</p>
+      </div>
+      <button
+        type="button"
+        className="btn btn-primary btn-lg cta-section__button"
+        onClick={onStart}
+      >
+        {ctaLabel} <span aria-hidden="true">→</span>
+      </button>
+    </section>
+  );
+}

--- a/src/styles-v2/pages/landing.css
+++ b/src/styles-v2/pages/landing.css
@@ -698,6 +698,51 @@
   flex-shrink: 0;
 }
 
+/* ===== IDE chrome ===== (PR 4, Landing.plan.md §12.4 / §9.5) --------------
+   Page shell — `editor-scroll` 컬럼 그리드 (gutter + body), `gutter` 라인
+   넘버, `editor-body` 본문 프레임. 프로토타입 ide-theme.css L322-347 1:1.
+   `landing-page` modifier 는 본문 max-width 1100 + 가운데 정렬.
+
+   ⚠️ Cart / EventList / EventDetail v2 에서도 같은 클래스명을 쓰지만 현재
+      styles-v2 어디에도 정의가 없음. 본 파일에서 처음 정의 — cutover PR
+      시 components/ide-chrome.css 로 이동 검토 (§12.4 결정).
+   chrome 자체에 모션 없음 → reduced-motion 가드 추가 불필요.
+   --------------------------------------------------------------------------*/
+
+.editor-scroll {
+  display: grid;
+  grid-template-columns: 52px 1fr;
+  min-height: 100%;
+}
+
+.gutter {
+  background: var(--gutter);
+  color: var(--gutter-text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-align: right;
+  padding: 14px 10px 40px 0;
+  user-select: none;
+  border-right: 1px solid transparent;
+  line-height: 1.6;
+}
+
+.gutter .ln { display: block; }
+.gutter .ln.active { color: var(--text-2); }
+
+.editor-body {
+  padding: 14px 24px 40px;
+  line-height: 1.6;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text);
+}
+
+.editor-body.landing-page {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .category-tile,
   .featured-row {

--- a/src/styles-v2/pages/landing.css
+++ b/src/styles-v2/pages/landing.css
@@ -650,6 +650,54 @@
 }
 .featured-section__retry:hover { background: var(--surface-3); }
 
+/* ===== CTA ===== (PR 4, Landing.plan.md §12.4 / §2 / §6.5) -----------------
+   dashed border + brand-light 그라디언트 카드. 좌(카피) / 우(버튼) flex.
+   카드 내부 모션 없음 — reduced-motion 가드 추가 불필요.
+   --------------------------------------------------------------------------*/
+
+.cta-section {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+  padding: 28px 32px;
+  margin-bottom: 40px;
+  border: 1px dashed var(--border-2);
+  border-radius: 12px;
+  background: linear-gradient(135deg, var(--brand-light) 0%, transparent 70%);
+}
+
+.cta-section__copy {
+  min-width: 0;
+}
+
+.cta-section__eyebrow {
+  margin-bottom: 6px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-4);
+  letter-spacing: 0.04em;
+}
+
+.cta-section__headline {
+  margin-bottom: 4px;
+  font-family: var(--font);
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.cta-section__subcopy {
+  font-family: var(--font);
+  font-size: 14px;
+  color: var(--text-3);
+}
+
+.cta-section__button {
+  flex-shrink: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .category-tile,
   .featured-row {


### PR DESCRIPTION
## Summary
Implements the complete Landing page (PR 4) with five stacked sections (Hero, Stats, Categories, Featured, CTA), IDE-style chrome layout with gutter line numbers, and authentication-aware featured events caching.

## Key Changes

### New Components
- **Landing.tsx**: Main container composing 5 sections with IDE chrome (editor-scroll, gutter, editor-body)
- **CtaSection.tsx**: Static CTA card with dashed border, brand gradient, and customizable copy/button label
- **LandingPage (index.tsx)**: Route entry point handling navigation callbacks and data hook composition

### Data Layer Updates
- **useFeaturedEvents hook**: 
  - Split cache keys by authentication state (`landing:featured:anon` vs `landing:featured:auth`)
  - Added `useAuth()` integration to branch between `/events/recommendations` (anon) and `/events/user/recommendations` (authed)
  - Changed in-flight tracking from single promise to Map for per-key deduplication
  - Invalidation now clears both cache entries to prevent stale data during auth transitions

### Styling
- **CTA section styles**: Dashed border, brand-light gradient background, flex layout (copy left, button right)
- **IDE chrome styles**: 
  - `.editor-scroll`: Grid layout with 52px gutter column
  - `.gutter`: Line numbers with mono font, right-aligned
  - `.editor-body.landing-page`: Max-width 1100px centered container
  - All chrome elements have no motion (no reduced-motion guards needed)

### Metadata & Integration
- **index.html**: Added Open Graph and Twitter Card meta tags for social sharing (og:image points to `/og/landing.png`)
- **App.tsx**: Registered LandingPage lazy import in v2 routes

## Implementation Details

- **Data fetching**: Hero's TypedTerminal reuses `useFirstPage()` internally (module cache + in-flight sharing = 1 network call); Stats/Categories/Featured use query passthrough from container
- **Accessibility**: Gutter marked `aria-hidden="true"`, CTA section uses `aria-labelledby` for landmark labeling, eyebrow text hidden from screen readers
- **Props tuning**: TypedTerminal timing (typingSpeedMs, outputDelayMs, etc.), gutter line count (default 80), and CTA copy all configurable via Landing props
- **Auth state handling**: `useFeaturedEvents` dependency array includes `isLoggedIn` and `cacheKey` to trigger re-fetch on login/logout transitions

https://claude.ai/code/session_012TsNHornpECBnhJ2WegjUM