### PR TITLE
chore(cutover): promote v2 routes and remove VersionedRoute toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,12 +5,9 @@ import Layout from './components/Layout'
 import SellerLayout from './components/SellerLayout'
 import AdminLayout from './components/AdminLayout'
 import Loading from './components/Loading'
-import { VersionedRoute, RequireAuthV2 } from './router-v2'
+import { RequireAuthV2 } from './router-v2'
 
 // 즉시 로드 (비로그인 첫 화면)
-import EventList         from './pages/EventList'
-import EventDetail       from './pages/EventDetail'
-import Login             from './pages/Login'
 import Signup            from './pages/Signup'
 import NotFound          from './pages/NotFound'
 
@@ -29,22 +26,10 @@ const PaymentCompleteV2   = lazy(() => import('./pages-v2/PaymentCallback/Paymen
 const MyPageV2            = lazy(() => import('./pages-v2/MyPage'))
 const LandingV2           = lazy(() => import('./pages-v2/Landing'))
 
-// lazy – v2 dev showcase (Landing.plan §12.1 PR 1; cutover/PR 4 cleanup 시 제거)
-const TypedTerminalShowcase = lazy(() => import('./pages-v2/_dev/TypedTerminalShowcase'))
-// lazy – v2 dev showcase (Landing.plan §12.2 PR 2; cutover/PR 4 cleanup 시 제거)
-const HeroStatsShowcase     = lazy(() => import('./pages-v2/_dev/HeroStatsShowcase'))
-// lazy – v2 dev showcase (Landing.plan §12.3 PR 3; cutover/PR 4 cleanup 시 제거)
-const CategoriesFeaturedShowcase = lazy(() => import('./pages-v2/_dev/CategoriesFeaturedShowcase'))
-
 // lazy – 로그인 후 접근
 const SignupComplete      = lazy(() => import('./pages/SignupComplete'))
-const Cart                = lazy(() => import('./pages/Cart'))
 const Payment             = lazy(() => import('./pages/Payment'))
-const PaymentComplete     = lazy(() => import('./pages/PaymentComplete'))
-const MyPage              = lazy(() => import('./pages/MyPage'))
 const SellerApply         = lazy(() => import('./pages/SellerApply'))
-const PaymentSuccess      = lazy(() => import('./pages/PaymentSuccess'))
-const PaymentFail         = lazy(() => import('./pages/PaymentFail'))
 const WalletChargeSuccess = lazy(() => import('./pages/WalletChargeSuccess'))
 const WalletChargeFail    = lazy(() => import('./pages/WalletChargeFail'))
 
@@ -91,7 +76,7 @@ export default function App() {
     <Suspense fallback={<Loading fullscreen />}>
       <Routes>
         {/* 공개 */}
-        <Route path="/login"               element={<VersionedRoute v1={<Login />} v2={<LoginV2 />} />} />
+        <Route path="/login"               element={<LoginV2 />} />
         <Route path="/signup"              element={<Signup />} />
         <Route path="/signup/complete"     element={<SignupComplete />} />
 
@@ -99,28 +84,18 @@ export default function App() {
         <Route path="/oauth/callback"      element={<OAuthCallback />} />
         <Route path="/social/profile-setup" element={<SocialProfileSetup />} />
 
-        {/* v2 dev showcase (cutover/PR 4 cleanup 시 제거) */}
-        <Route path="/_dev/typed-terminal"               element={<TypedTerminalShowcase />} />
-        <Route path="/_dev/landing-hero-stats"           element={<HeroStatsShowcase />} />
-        <Route path="/_dev/landing-categories-featured" element={<CategoriesFeaturedShowcase />} />
-
         {/* 일반 사용자 */}
         <Route element={<Layout />}>
-          <Route path="/"                       element={<VersionedRoute v1={<EventList />} v2={<LandingV2 />} />} />
-          <Route path="/events"                 element={<VersionedRoute v1={<EventList />} v2={<EventListV2 />} />} />
-          <Route path="/events/:id"             element={<VersionedRoute v1={<EventDetail />} v2={<EventDetailV2 />} />} />
-          <Route path="/cart"                   element={<RequireAuth><VersionedRoute v1={<Cart />} v2={<CartV2 />} /></RequireAuth>} />
+          <Route path="/"                       element={<LandingV2 />} />
+          <Route path="/events"                 element={<EventListV2 />} />
+          <Route path="/events/:id"             element={<EventDetailV2 />} />
+          <Route path="/cart"                   element={<RequireAuth><CartV2 /></RequireAuth>} />
           <Route path="/payment"                element={<RequireAuth><Payment /></RequireAuth>} />
-          <Route path="/payment/complete"       element={<RequireAuth><VersionedRoute v1={<PaymentComplete />} v2={<PaymentCompleteV2 />} /></RequireAuth>} />
-          <Route path="/mypage/*"               element={
-            <VersionedRoute
-              v1={<RequireAuth><MyPage /></RequireAuth>}
-              v2={<RequireAuthV2><MyPageV2 /></RequireAuthV2>}
-            />
-          } />
+          <Route path="/payment/complete"       element={<RequireAuth><PaymentCompleteV2 /></RequireAuth>} />
+          <Route path="/mypage/*"               element={<RequireAuthV2><MyPageV2 /></RequireAuthV2>} />
           <Route path="/seller-apply"           element={<RequireAuth><SellerApply /></RequireAuth>} />
-          <Route path="/payment/success"        element={<RequireAuth><VersionedRoute v1={<PaymentSuccess />} v2={<PaymentSuccessV2 />} /></RequireAuth>} />
-          <Route path="/payment/fail"           element={<RequireAuth><VersionedRoute v1={<PaymentFail />} v2={<PaymentFailV2 />} /></RequireAuth>} />
+          <Route path="/payment/success"        element={<RequireAuth><PaymentSuccessV2 /></RequireAuth>} />
+          <Route path="/payment/fail"           element={<RequireAuth><PaymentFailV2 /></RequireAuth>} />
           <Route path="/wallet/charge/success"  element={<RequireAuth><WalletChargeSuccess /></RequireAuth>} />
           <Route path="/wallet/charge/fail"     element={<RequireAuth><WalletChargeFail /></RequireAuth>} />
         </Route>


### PR DESCRIPTION
### Motivation
- Finalize cutover by routing main user-facing paths to v2 implementations instead of the version-toggle wrapper to prepare for v2 rollout.
- Remove transient dev/showcase wiring and unused v1 route imports to reduce maintenance surface during the cutover window.

### Description
- Rewired `src/App.tsx` so primary public routes now mount v2 components directly (e.g. `/login` → `LoginV2`, `/` → `LandingV2`, `/events` → `EventListV2`, `/events/:id` → `EventDetailV2`, `/cart` → `CartV2`, `/mypage/*` → `MyPageV2`, `/payment/complete`/`/payment/success`/`/payment/fail` → v2 pages) by using the existing lazy imports.
- Removed usage of the `VersionedRoute` toggle wrapper from those routes and cleaned up now-unused eager/lazy v1 imports in `src/App.tsx`.
- Removed temporary v2 dev showcase routes under `/_dev/*` from the router to tidy the public route surface.
- Kept the existing v1 `Payment` route for `/payment` because a v2 payment page is not present in the codebase.

### Testing
- Ran the production build with `npm run build`, which failed due to an unresolved dependency `react-type-animation` imported by `src/pages-v2/Landing/components/TypedTerminal.tsx`, so the build did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f28686e88330b86aaf0905b9971e)