### PR TITLE
Replace online status label with logout button in sidebar

### DIFF
--- a/src/components/Layout/Sidebar/SidebarSession.tsx
+++ b/src/components/Layout/Sidebar/SidebarSession.tsx
@@ -1,4 +1,5 @@
 import type { SessionUser } from '../types';
+import { useChrome } from '../LayoutChromeContext';
 
 /**
  * Source: docs/archive/v2-cutover/layout.plan.md §3-9.
@@ -6,9 +7,8 @@ import type { SessionUser } from '../types';
  * Session row is always expanded (no toggle) — gating logged-out rendering is
  * the parent's responsibility, so user is always non-null here.
  *
- * Markup follows §6-6: section as <h2>, single-item <ul role="list"> with the
- * online dot decorative (aria-hidden) and the trailing "온라인" tag styled via
- * .side-meta.
+ * The online state is conveyed by the green .side-dot, so the trailing slot
+ * doubles as a logout affordance instead of a redundant "온라인" label.
  */
 export interface SidebarSessionProps {
   user: SessionUser;
@@ -17,14 +17,22 @@ export interface SidebarSessionProps {
 
 export function SidebarSession({ user, className }: SidebarSessionProps) {
   const groupCls = className ? `side-group ${className}` : 'side-group';
+  const { logout } = useChrome();
   return (
     <>
       <h2 className="side-header">세션</h2>
       <ul className={groupCls} role="list">
         <li className="side-item side-item--mini">
-          <span className="side-dot" aria-hidden="true" />
+          <span className="side-dot" aria-hidden="true" title="온라인" />
           <span>{user.nickname}</span>
-          <span className="side-meta">온라인</span>
+          <button
+            type="button"
+            className="side-meta side-meta--button"
+            onClick={logout}
+            aria-label={`${user.nickname} 로그아웃`}
+          >
+            로그아웃
+          </button>
         </li>
       </ul>
     </>

--- a/src/styles/components/ide-chrome.css
+++ b/src/styles/components/ide-chrome.css
@@ -286,6 +286,26 @@ button.side-header {
   color: var(--text-4);
 }
 
+/* Button variant: trailing meta slot used as an action (e.g. logout). */
+.side-meta--button {
+  background: none;
+  border: none;
+  padding: 2px 4px;
+  margin-right: -4px;
+  cursor: pointer;
+  border-radius: 3px;
+  transition: color 120ms, background 120ms;
+}
+.side-meta--button:hover,
+.side-meta--button:focus-visible {
+  color: var(--text-2);
+  background: var(--surface-2);
+}
+.side-meta--button:focus-visible {
+  outline: 1px solid var(--text-3);
+  outline-offset: 1px;
+}
+
 /* '#' prefix glyph for category rows. */
 .side-prefix {
   color: var(--text-4);


### PR DESCRIPTION
## Summary
Replaced the redundant "온라인" (online) status label in the session sidebar with a logout button, since the online state is already visually conveyed by the green status dot.

## Changes
- **SidebarSession component**: Converted the trailing meta slot from a static "온라인" label to a functional logout button
  - Added `useChrome()` hook to access the logout handler
  - Replaced `<span className="side-meta">온라인</span>` with a `<button>` element
  - Added proper accessibility attributes: `aria-label` with user nickname context
  - Added `title` attribute to the status dot for tooltip context
  
- **CSS styling**: Added new `.side-meta--button` variant for button-specific styling
  - Removes default button appearance (background, border)
  - Implements hover and focus states with color and background transitions
  - Adds focus-visible outline for keyboard navigation accessibility
  - Maintains visual consistency with the sidebar design system

## Implementation Details
- The logout button uses the existing `.side-meta` class as a base, with the new `.side-meta--button` modifier for button-specific styles
- Accessibility is maintained through semantic HTML (`<button>` element) and descriptive `aria-label`
- The status dot now has a `title` attribute to provide the "온라인" context on hover
- Smooth transitions (120ms) on color and background changes for better UX

https://claude.ai/code/session_01DGvJpL5ktz77bchsTecQ39