### PR TITLE
Match v1 cart behavior, hide upcoming events, restore event map, and update categories

### DIFF
--- a/src/pages/Cart/Cart.tsx
+++ b/src/pages/Cart/Cart.tsx
@@ -32,7 +32,6 @@ export type CheckoutState = 'idle' | 'submitting' | 'error';
 export interface CartProps {
   query: CartQuery;
   onQuantityChange: (itemId: string, next: number) => void;
-  onRemove: (itemId: string) => void;
   onCheckout: () => void;
   onBrowse: () => void;
   checkoutState: CheckoutState;
@@ -66,7 +65,6 @@ function PageShell({ children }: { children: ReactNode }) {
 export function Cart({
   query,
   onQuantityChange,
-  onRemove,
   onCheckout,
   onBrowse,
   checkoutState,
@@ -128,7 +126,6 @@ export function Cart({
         <CartItemList
           items={cart.items}
           onQuantityChange={onQuantityChange}
-          onRemove={onRemove}
           pendingItemIds={pendingItemIds}
         />
         <OrderSummary

--- a/src/pages/Cart/components/CartItem.tsx
+++ b/src/pages/Cart/components/CartItem.tsx
@@ -12,9 +12,7 @@
  */
 
 import { AccentMediaBox } from '@/components/AccentMediaBox';
-import { Button } from '@/components/Button';
 import { Card } from '@/components/Card';
-import { Icon } from '@/components/Icon';
 import { QuantityStepper } from '@/components/QuantityStepper';
 import { accent } from '@/styles/accent';
 
@@ -23,14 +21,12 @@ import type { CartItemVM } from '../types';
 export interface CartItemProps {
   item: CartItemVM;
   onQuantityChange: (next: number) => void;
-  onRemove: () => void;
   pending?: boolean;
 }
 
 export function CartItem({
   item,
   onQuantityChange,
-  onRemove,
   pending = false,
 }: CartItemProps) {
   const className = ['cart-item', pending && 'is-pending']
@@ -55,16 +51,6 @@ export function CartItem({
             size="sm"
             disabled={pending}
           />
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onRemove}
-            disabled={pending}
-            iconStart={<Icon name="trash" size={12} />}
-            className="cart-item__remove"
-          >
-            삭제
-          </Button>
         </div>
       </div>
       <div className="cart-item__total">

--- a/src/pages/Cart/components/CartItemList.tsx
+++ b/src/pages/Cart/components/CartItemList.tsx
@@ -14,14 +14,12 @@ import { CartItem } from './CartItem';
 export interface CartItemListProps {
   items: CartItemVM[];
   onQuantityChange: (itemId: string, next: number) => void;
-  onRemove: (itemId: string) => void;
   pendingItemIds?: Set<string>;
 }
 
 export function CartItemList({
   items,
   onQuantityChange,
-  onRemove,
   pendingItemIds,
 }: CartItemListProps) {
   return (
@@ -31,7 +29,6 @@ export function CartItemList({
           <CartItem
             item={item}
             onQuantityChange={(next) => onQuantityChange(item.cartItemId, next)}
-            onRemove={() => onRemove(item.cartItemId)}
             pending={pendingItemIds?.has(item.cartItemId) ?? false}
           />
         </li>

--- a/src/pages/Cart/index.tsx
+++ b/src/pages/Cart/index.tsx
@@ -90,9 +90,6 @@ export default function CartPage() {
       <Cart
         query={cart}
         onQuantityChange={handleQuantityChange}
-        onRemove={(id) => {
-          void mut.removeItem(id);
-        }}
         onCheckout={() => {
           void co.submit();
         }}

--- a/src/pages/EventDetail/EventDetail.tsx
+++ b/src/pages/EventDetail/EventDetail.tsx
@@ -8,6 +8,7 @@ import { ErrorState } from './components/ErrorState';
 import { EventDescription } from './components/EventDescription';
 import { EventDetailSkeleton } from './components/EventDetailSkeleton';
 import { EventHeader } from './components/EventHeader';
+import { EventMap } from './components/EventMap';
 import { ForbiddenCard } from './components/ForbiddenCard';
 import { HeroBanner } from './components/HeroBanner';
 import { InfoCard } from './components/InfoCard';
@@ -116,6 +117,7 @@ export function EventDetail({ eventId }: EventDetailProps) {
           <HeroBanner accent={accentColor} />
           <EventHeader vm={vm} accent={accentColor} />
           <InfoCard vm={vm} />
+          <EventMap location={vm.location} />
           <EventDescription description={vm.description} />
         </div>
         <PurchasePanel vm={vm} />

--- a/src/pages/EventDetail/components/EventMap.tsx
+++ b/src/pages/EventDetail/components/EventMap.tsx
@@ -1,0 +1,26 @@
+import { Card } from '@/components/Card';
+
+export interface EventMapProps {
+  location: string;
+}
+
+export function EventMap({ location }: EventMapProps) {
+  if (!location.trim()) return null;
+
+  const src = `https://maps.google.com/maps?q=${encodeURIComponent(location)}&z=15&output=embed`;
+
+  return (
+    <section className="ed-map">
+      <h2 className="ed-map__title">위치</h2>
+      <Card variant="solid" padding="none" className="ed-map__card">
+        <iframe
+          title={`이벤트 위치 지도: ${location}`}
+          src={src}
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          className="ed-map__frame"
+        />
+      </Card>
+    </section>
+  );
+}

--- a/src/pages/EventList/EventList.tsx
+++ b/src/pages/EventList/EventList.tsx
@@ -18,12 +18,11 @@ import {
 
 const CATEGORIES = [
   '전체',
+  '소모임',
   '컨퍼런스',
-  '밋업',
   '해커톤',
   '스터디',
-  '세미나',
-  '워크샵',
+  '프로젝트',
 ] as const;
 
 const SKELETON_COUNT = 8;

--- a/src/pages/EventList/adapters.ts
+++ b/src/pages/EventList/adapters.ts
@@ -40,7 +40,7 @@ export const toEventVM = (api: EventItem): EventVM => {
 };
 
 export const toEventListPage = (res: EventListResponse): EventListPage => ({
-  items: res.content.map(toEventVM),
+  items: res.content.map(toEventVM).filter((item) => item.status === 'ON_SALE'),
   page: res.page,
   size: res.size,
   totalElements: res.totalElements,

--- a/src/styles/pages/event-detail.css
+++ b/src/styles/pages/event-detail.css
@@ -81,6 +81,25 @@
 .ed-seat-sold {
   color: var(--danger);
 }
+.ed-map {
+  margin-bottom: 24px;
+}
+.ed-map__title {
+  font-family: var(--font);
+  font-size: 17px;
+  font-weight: 600;
+  margin: 0 0 10px;
+  color: var(--text);
+}
+.ed-map__card {
+  overflow: hidden;
+}
+.ed-map__frame {
+  display: block;
+  width: 100%;
+  height: 280px;
+  border: 0;
+}
 
 /* EventDescription (§2 EventDescription) — §8-O9 단순 h2, §8-O2 plain text + pre-wrap */
 .ed-description__title {


### PR DESCRIPTION
### Motivation
- The backend contract is unchanged so the frontend should follow the existing v1 behavior for cart interactions and list rendering.  
- Remove immediate per-item delete from the cart UI to match v1 flow where bulk/other flows handled deletion.  
- Prevent events that are not yet on sale from being discoverable in the list.  
- Restore the event-detail map UI and align the category filter labels with the backend `EventCategory` descriptions.

### Description
- Removed the per-item delete UI and its prop chain by deleting the delete `Button` from `CartItem` and removing `onRemove` from `CartItemList`, `Cart` and the cart page container (`src/pages/Cart/components/CartItem.tsx`, `src/pages/Cart/components/CartItemList.tsx`, `src/pages/Cart/Cart.tsx`, `src/pages/Cart/index.tsx`).  
- Updated the event category chips to match `EventCategory` descriptions (added `소모임`, `컨퍼런스`, `해커톤`, `스터디`, `프로젝트` with `전체`) in `src/pages/EventList/EventList.tsx`.  
- Filtered event list adapter so only events with status `ON_SALE` are included in list pages by updating `toEventListPage` to `.filter(item => item.status === 'ON_SALE')` in `src/pages/EventList/adapters.ts`.  
- Restored event location map: added `EventMap` component and inserted it into the event detail page, plus CSS styles (`src/pages/EventDetail/components/EventMap.tsx`, updated `src/pages/EventDetail/EventDetail.tsx`, and `src/styles/pages/event-detail.css`).

### Testing
- Ran `npm run build`; build step failed due to an unresolved third-party dependency (`react-type-animation`) in the workspace, so the production build did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17a2e6f688330ba552e46549bda14)