### PR TITLE
Add refund request functionality for tickets and orders

### DIFF
--- a/src/components/Layout/Minimap.tsx
+++ b/src/components/Layout/Minimap.tsx
@@ -23,6 +23,8 @@ const PATTERNS: Record<RouteKey, string[]> = {
   cart:   ['kw', '', '', 'fn', '', 'str', '', 'kw', '', '', 'fn', '', '', 'str', '', 'cmt', '', 'kw', '', 'fn', '', '', '', '', '', ''],
   mypage: ['kw', 'fn', '', '', 'str', '', '', 'kw', '', '', 'fn', '', 'str', '', '', 'cmt', '', 'kw', 'fn', '', 'str', ''],
   login:  ['kw', '', '', 'fn', '', 'str', '', '', 'cmt', '', 'kw', 'fn', '', '', 'str', '', '', ''],
+  seller: ['kw', '', 'fn', '', 'str', '', 'kw', '', 'fn', '', '', 'cmt', '', 'kw', 'fn', '', 'str', '', '', '', 'cmt'],
+  admin:  ['kw', 'fn', '', 'str', '', '', 'kw', '', '', 'fn', 'str', '', 'cmt', '', 'kw', '', '', 'fn', 'str', '', ''],
 };
 
 const LINE_COUNT = 80;

--- a/src/components/Layout/StatusBar.tsx
+++ b/src/components/Layout/StatusBar.tsx
@@ -26,6 +26,8 @@ const ROUTE_LABEL: Record<RouteKey, string> = {
   cart: '장바구니',
   mypage: '마이페이지',
   login: '로그인',
+  seller: '판매자 센터',
+  admin: '관리자 패널',
 };
 
 const LANGUAGE_LABEL = '한국어';

--- a/src/components/Layout/__preview.tsx
+++ b/src/components/Layout/__preview.tsx
@@ -34,6 +34,8 @@ const MOCK_LABEL: Record<RouteKey, string> = {
   cart: '장바구니',
   mypage: '마이페이지',
   login: '로그인',
+  seller: '판매자 센터',
+  admin: '관리자 패널',
 };
 
 function MockPane({ route }: { route: RouteKey }) {

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -60,6 +60,9 @@ const TABS: TabDef[] = [
   { key: 'login', label: '로그인', icon: 'terminal' },
 ];
 
+const SELLER_TAB: TabDef = { key: 'seller', label: '판매자 센터', icon: 'wallet' };
+const ADMIN_TAB: TabDef = { key: 'admin', label: '관리자 패널', icon: 'settings' };
+
 const SIDEBAR_FETCH_SIZE = 50;
 const UPCOMING_LIMIT = 4;
 
@@ -74,7 +77,7 @@ function formatEventPrice(price: number): string {
 function LayoutInner({ children }: LayoutProps) {
   const location = useLocation();
   const navigate = useNavigate();
-  const { isLoggedIn, user } = useAuth();
+  const { isLoggedIn, user, role } = useAuth();
   const { resolvedTheme } = useTheme();
   const { count: cartCount } = useCartCount();
   const chrome = useChrome();
@@ -177,7 +180,15 @@ function LayoutInner({ children }: LayoutProps) {
           upcoming={upcoming}
           onNavigate={onNavigate}
         />
-        <TabBar tabs={TABS} activeKey={currentRoute} onSelect={onNavigate} />
+        <TabBar
+          tabs={[
+            ...TABS,
+            ...(role === 'SELLER' || role === 'ADMIN' ? [SELLER_TAB] : []),
+            ...(role === 'ADMIN' ? [ADMIN_TAB] : []),
+          ]}
+          activeKey={currentRoute}
+          onSelect={onNavigate}
+        />
         <main className="ide-editor" id="ide-editor" tabIndex={-1}>
           {children ?? <Outlet />}
         </main>

--- a/src/components/Layout/types.ts
+++ b/src/components/Layout/types.ts
@@ -9,7 +9,9 @@ export type RouteKey =
   | 'detail'
   | 'cart'
   | 'mypage'
-  | 'login';
+  | 'login'
+  | 'seller'
+  | 'admin';
 
 export type ActivityKey = RouteKey | 'search' | 'settings';
 

--- a/src/components/Layout/utils.ts
+++ b/src/components/Layout/utils.ts
@@ -17,6 +17,8 @@ export function routeFromPath(pathname: string): RouteKey {
   }
   if (pathname === '/cart' || pathname.startsWith('/cart/')) return 'cart';
   if (pathname === '/mypage' || pathname.startsWith('/mypage/')) return 'mypage';
+  if (pathname === '/seller' || pathname.startsWith('/seller/')) return 'seller';
+  if (pathname === '/admin' || pathname.startsWith('/admin/')) return 'admin';
   if (pathname === '/login') return 'login';
   return 'home';
 }
@@ -43,6 +45,10 @@ export function pathFromRoute(key: RouteKey, params?: NavParams): string {
       return '/cart';
     case 'mypage':
       return '/mypage';
+    case 'seller':
+      return '/seller';
+    case 'admin':
+      return '/admin';
     case 'login':
       return '/login';
   }

--- a/src/pages/MyPage/shared/RefundDialog.tsx
+++ b/src/pages/MyPage/shared/RefundDialog.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useId, useState } from 'react';
+import axios from 'axios';
+import { Button } from '@/components/Button';
+import {
+  getRefundInfo,
+  refundOrder,
+  refundTicketByPg,
+} from '@/api/refunds.api';
+import type { RefundInfoResponse } from '@/api/types';
+import { useToast } from '@/contexts/ToastContext';
+
+type RefundTarget =
+  | { kind: 'ticket'; ticketId: string; eventTitle: string }
+  | { kind: 'order'; orderId: string; amountLabel: string; orderLabel: string };
+
+interface RefundDialogProps {
+  open: boolean;
+  target: RefundTarget;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const formatKrw = (n: number): string => `${n.toLocaleString()}원`;
+
+export function RefundDialog({ open, target, onClose, onSuccess }: RefundDialogProps) {
+  const titleId = useId();
+  const { toast } = useToast();
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [info, setInfo] = useState<RefundInfoResponse | null>(null);
+  const [infoStatus, setInfoStatus] = useState<'idle' | 'loading' | 'error' | 'ready'>('idle');
+
+  useEffect(() => {
+    if (!open) {
+      setReason('');
+      setInfo(null);
+      setInfoStatus('idle');
+      return;
+    }
+    if (target.kind !== 'ticket') return;
+    let cancelled = false;
+    setInfoStatus('loading');
+    getRefundInfo(target.ticketId)
+      .then((res) => {
+        if (cancelled) return;
+        setInfo(res.data.data);
+        setInfoStatus('ready');
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setInfoStatus('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, target]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const ticketRefundDisabled =
+    target.kind === 'ticket' && (infoStatus !== 'ready' || (info && !info.refundable));
+
+  const submit = async () => {
+    setSubmitting(true);
+    try {
+      const body = { reason: reason.trim() || '사용자 요청' };
+      if (target.kind === 'ticket') {
+        await refundTicketByPg(target.ticketId, body);
+      } else {
+        await refundOrder(target.orderId, body);
+      }
+      toast('환불 요청이 접수되었습니다.', 'success');
+      onSuccess();
+      onClose();
+    } catch (err: unknown) {
+      const message =
+        axios.isAxiosError(err) &&
+        typeof err.response?.data === 'object' &&
+        err.response?.data !== null &&
+        'message' in (err.response.data as Record<string, unknown>)
+          ? String((err.response.data as { message?: string }).message ?? '')
+          : '';
+      toast(message || '환불 처리 중 오류가 발생했습니다.', 'error');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="payment-modal-backdrop"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !submitting) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="payment-modal-surface"
+      >
+        <header className="payment-modal-header">
+          <h2 id={titleId} className="payment-modal-title">
+            환불 요청
+          </h2>
+          <button
+            type="button"
+            className="payment-modal-close"
+            onClick={onClose}
+            aria-label="닫기"
+            disabled={submitting}
+          >
+            ✕
+          </button>
+        </header>
+
+        <div className="payment-modal-body">
+          {target.kind === 'ticket' ? (
+            <>
+              <div className="payment-modal-total">
+                <span className="payment-modal-total__label">티켓</span>
+                <span className="payment-modal-total__value" style={{ fontSize: 14 }}>
+                  {target.eventTitle}
+                </span>
+              </div>
+              {infoStatus === 'loading' && (
+                <div className="payment-modal-walletpg__helper">환불 정보 확인 중...</div>
+              )}
+              {infoStatus === 'error' && (
+                <div className="payment-modal-warning" role="alert">
+                  환불 정보를 불러오지 못했습니다.
+                </div>
+              )}
+              {info && (
+                <>
+                  <div className="payment-modal-total">
+                    <span className="payment-modal-total__label">결제 금액</span>
+                    <span className="payment-modal-total__value">
+                      {formatKrw(info.originalAmount)}
+                    </span>
+                  </div>
+                  <div className="payment-modal-total">
+                    <span className="payment-modal-total__label">
+                      환불 예정 ({Math.round(info.refundRate * 100)}%)
+                    </span>
+                    <span className="payment-modal-total__value">
+                      {formatKrw(info.refundAmount)}
+                    </span>
+                  </div>
+                  {!info.refundable && (
+                    <div className="payment-modal-warning" role="alert">
+                      ⚠ 이 티켓은 환불할 수 없습니다.
+                    </div>
+                  )}
+                </>
+              )}
+            </>
+          ) : (
+            <>
+              <div className="payment-modal-total">
+                <span className="payment-modal-total__label">주문</span>
+                <span className="payment-modal-total__value" style={{ fontSize: 14 }}>
+                  {target.orderLabel}
+                </span>
+              </div>
+              <div className="payment-modal-total">
+                <span className="payment-modal-total__label">결제 금액</span>
+                <span className="payment-modal-total__value">{target.amountLabel}</span>
+              </div>
+              <div className="payment-modal-walletpg__helper">
+                주문 단위로 환불을 요청합니다. 환불 금액은 정책에 따라 산정됩니다.
+              </div>
+            </>
+          )}
+
+          <label className="refund-dialog-reason">
+            <span>환불 사유 (선택)</span>
+            <textarea
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="예: 일정이 맞지 않아 참석이 어렵습니다."
+              rows={3}
+              disabled={submitting}
+            />
+          </label>
+        </div>
+
+        <footer className="payment-modal-footer">
+          <Button
+            variant="ghost"
+            size="md"
+            disabled={submitting}
+            onClick={onClose}
+            className="payment-modal-footer__cancel"
+          >
+            취소
+          </Button>
+          <Button
+            variant="primary"
+            size="md"
+            loading={submitting}
+            disabled={Boolean(ticketRefundDisabled) || submitting}
+            onClick={submit}
+            className="payment-modal-footer__pay"
+          >
+            {submitting ? '처리 중...' : '환불 요청'}
+          </Button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MyPage/tabs/Orders/OrdersTab.tsx
+++ b/src/pages/MyPage/tabs/Orders/OrdersTab.tsx
@@ -12,6 +12,7 @@ export function OrdersTab() {
   const rawPage = Number(sp.get('page') ?? '1');
   const page = Number.isFinite(rawPage) && rawPage >= 1 ? rawPage : 1;
   const state = useOrders(page);
+  const refetch = state.refetch;
 
   const onPageChange = (next: number) => {
     setSp((prev) => {
@@ -33,7 +34,7 @@ export function OrdersTab() {
     >
       {(data) => (
         <>
-          <OrdersTable rows={data.rows} />
+          <OrdersTable rows={data.rows} onRefunded={refetch} />
           {data.totalPages > 1 && (
             <OrdersPager
               page={page}

--- a/src/pages/MyPage/tabs/Orders/columns.ts
+++ b/src/pages/MyPage/tabs/Orders/columns.ts
@@ -12,3 +12,5 @@ export const ORDER_COLUMNS: readonly OrderColumn[] = [
   { key: 'statusLabel', label: '상태', align: 'left' },
   { key: 'dateLabel', label: '주문일시', align: 'left' },
 ] as const;
+
+export const ORDER_ACTION_COLUMN_LABEL = '액션';

--- a/src/pages/MyPage/tabs/Orders/components/OrderRow.tsx
+++ b/src/pages/MyPage/tabs/Orders/components/OrderRow.tsx
@@ -1,11 +1,17 @@
-import { StatusChip } from '@/components';
+import { useState } from 'react';
+import { Button, StatusChip } from '@/components';
 import type { OrderRowVM } from '../types';
+import { RefundDialog } from '../../../shared/RefundDialog';
 
 interface OrderRowProps {
   row: OrderRowVM;
+  onRefunded?: () => void;
 }
 
-export function OrderRow({ row }: OrderRowProps) {
+export function OrderRow({ row, onRefunded }: OrderRowProps) {
+  const [open, setOpen] = useState(false);
+  const canRefund = row.status === 'PAID';
+
   return (
     <tr className="order-row">
       <td className="order-cell order-cell-id" title={row.orderId}>
@@ -16,6 +22,24 @@ export function OrderRow({ row }: OrderRowProps) {
         <StatusChip variant={row.statusVariant}>{row.statusLabel}</StatusChip>
       </td>
       <td className="order-cell order-cell-date">{row.dateLabel}</td>
+      <td className="order-cell order-cell-action">
+        {canRefund && (
+          <Button variant="ghost" size="sm" onClick={() => setOpen(true)}>
+            환불
+          </Button>
+        )}
+        <RefundDialog
+          open={open}
+          target={{
+            kind: 'order',
+            orderId: row.orderId,
+            amountLabel: row.amountLabel,
+            orderLabel: row.displayId,
+          }}
+          onClose={() => setOpen(false)}
+          onSuccess={() => onRefunded?.()}
+        />
+      </td>
     </tr>
   );
 }

--- a/src/pages/MyPage/tabs/Orders/components/OrdersSkeleton.tsx
+++ b/src/pages/MyPage/tabs/Orders/components/OrdersSkeleton.tsx
@@ -31,6 +31,7 @@ export function OrdersSkeleton({ rows = 8 }: OrdersSkeletonProps) {
               <td className="order-cell order-cell-date">
                 <span className="orders-skeleton-bar orders-skeleton-bar-md" />
               </td>
+              <td className="order-cell order-cell-action" />
             </tr>
           ))}
         </tbody>

--- a/src/pages/MyPage/tabs/Orders/components/OrdersTable.tsx
+++ b/src/pages/MyPage/tabs/Orders/components/OrdersTable.tsx
@@ -5,16 +5,17 @@ import { OrdersTableHeader } from './OrdersTableHeader';
 
 interface OrdersTableProps {
   rows: OrderRowVM[];
+  onRefunded?: () => void;
 }
 
-export function OrdersTable({ rows }: OrdersTableProps) {
+export function OrdersTable({ rows, onRefunded }: OrdersTableProps) {
   return (
     <Card variant="solid" padding="none" className="orders-card">
       <table className="orders-table">
         <OrdersTableHeader />
         <tbody>
           {rows.map((row) => (
-            <OrderRow key={row.orderId} row={row} />
+            <OrderRow key={row.orderId} row={row} onRefunded={onRefunded} />
           ))}
         </tbody>
       </table>

--- a/src/pages/MyPage/tabs/Orders/components/OrdersTableHeader.tsx
+++ b/src/pages/MyPage/tabs/Orders/components/OrdersTableHeader.tsx
@@ -1,4 +1,4 @@
-import { ORDER_COLUMNS } from '../columns';
+import { ORDER_ACTION_COLUMN_LABEL, ORDER_COLUMNS } from '../columns';
 
 export function OrdersTableHeader() {
   return (
@@ -14,6 +14,9 @@ export function OrdersTableHeader() {
             {col.label}
           </th>
         ))}
+        <th scope="col" className="orders-th orders-th-action" style={{ textAlign: 'right' }}>
+          {ORDER_ACTION_COLUMN_LABEL}
+        </th>
       </tr>
     </thead>
   );

--- a/src/pages/MyPage/tabs/Tickets/TicketsTab.tsx
+++ b/src/pages/MyPage/tabs/Tickets/TicketsTab.tsx
@@ -13,6 +13,7 @@ export function TicketsTab() {
   const rawPage = Number(sp.get('page') ?? '1');
   const page = Number.isFinite(rawPage) && rawPage >= 1 ? rawPage : 1;
   const state = useTickets(page);
+  const refetch = state.refetch;
 
   const onPageChange = (next: number) => {
     setSp(
@@ -42,7 +43,7 @@ export function TicketsTab() {
             validCount={data.validCount}
             usedCount={data.usedCount}
           />
-          <TicketGrid tickets={data.tickets} />
+          <TicketGrid tickets={data.tickets} onRefunded={refetch} />
           {data.totalPages > 1 && (
             <TicketsPager
               page={page}

--- a/src/pages/MyPage/tabs/Tickets/components/TicketCard.tsx
+++ b/src/pages/MyPage/tabs/Tickets/components/TicketCard.tsx
@@ -1,21 +1,42 @@
-import { Card } from '@/components';
+import { useState } from 'react';
+import { Button, Card } from '@/components';
 import type { TicketVM } from '../types';
 import { TicketStripe } from './TicketStripe';
 import { TicketInfo } from './TicketInfo';
+import { RefundDialog } from '../../../shared/RefundDialog';
 
 interface TicketCardProps {
   ticket: TicketVM;
+  onRefunded?: () => void;
 }
 
-export function TicketCard({ ticket }: TicketCardProps) {
+export function TicketCard({ ticket, onRefunded }: TicketCardProps) {
+  const [open, setOpen] = useState(false);
+  const canRefund = ticket.status === 'VALID';
+
   return (
     <Card variant="solid" padding="none" className="ticket-card">
       <TicketStripe accent={ticket.accent} />
-      <TicketInfo
-        statusVariant={ticket.statusVariant}
-        statusLabel={ticket.statusLabel}
-        title={ticket.title}
-        dateLabel={ticket.dateLabel}
+      <div className="ticket-card-body">
+        <TicketInfo
+          statusVariant={ticket.statusVariant}
+          statusLabel={ticket.statusLabel}
+          title={ticket.title}
+          dateLabel={ticket.dateLabel}
+        />
+        {canRefund && (
+          <div className="ticket-card-actions">
+            <Button variant="ghost" size="sm" onClick={() => setOpen(true)}>
+              환불 요청
+            </Button>
+          </div>
+        )}
+      </div>
+      <RefundDialog
+        open={open}
+        target={{ kind: 'ticket', ticketId: ticket.ticketId, eventTitle: ticket.title }}
+        onClose={() => setOpen(false)}
+        onSuccess={() => onRefunded?.()}
       />
     </Card>
   );

--- a/src/pages/MyPage/tabs/Tickets/components/TicketGrid.tsx
+++ b/src/pages/MyPage/tabs/Tickets/components/TicketGrid.tsx
@@ -3,13 +3,14 @@ import { TicketCard } from './TicketCard';
 
 interface TicketGridProps {
   tickets: TicketVM[];
+  onRefunded?: () => void;
 }
 
-export function TicketGrid({ tickets }: TicketGridProps) {
+export function TicketGrid({ tickets, onRefunded }: TicketGridProps) {
   return (
     <div className="ticket-grid">
       {tickets.map((ticket) => (
-        <TicketCard key={ticket.ticketId} ticket={ticket} />
+        <TicketCard key={ticket.ticketId} ticket={ticket} onRefunded={onRefunded} />
       ))}
     </div>
   );

--- a/src/styles/components/payment-modal.css
+++ b/src/styles/components/payment-modal.css
@@ -193,6 +193,35 @@
   color: var(--danger);
 }
 
+/* ── 환불 사유 입력 ──────────────────────────────────── */
+.refund-dialog-reason {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-family: var(--font);
+}
+.refund-dialog-reason > span {
+  font-size: 13px;
+  color: var(--text-2);
+  font-weight: 600;
+}
+.refund-dialog-reason textarea {
+  width: 100%;
+  font-family: var(--font);
+  font-size: 14px;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 10px 12px;
+  resize: vertical;
+  min-height: 72px;
+}
+.refund-dialog-reason textarea:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 1px;
+}
+
 /* ── 잔액 부족 경고 박스 ─────────────────────────────── */
 .payment-modal-warning {
   padding: 10px 14px;

--- a/src/styles/pages/mypage-orders.css
+++ b/src/styles/pages/mypage-orders.css
@@ -60,6 +60,11 @@
   color: var(--text-3);
   white-space: nowrap;
 }
+.order-cell-action {
+  text-align: right;
+  white-space: nowrap;
+  width: 1%;
+}
 
 /* ── Pager (§6.3.5) ────────────────────────────────────────────── */
 .orders-pager {

--- a/src/styles/pages/mypage-tickets.css
+++ b/src/styles/pages/mypage-tickets.css
@@ -53,6 +53,19 @@
   pointer-events: none;
 }
 
+/* ── Body wrapper (info + actions) ──────────────────────────────── */
+.ticket-card-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.ticket-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 16px 12px;
+}
+
 /* ── Info (§5.1.2 TicketInfo) ───────────────────────────────────── */
 .ticket-info {
   flex: 1;


### PR DESCRIPTION
## Summary
This PR adds a comprehensive refund request feature that allows users to request refunds for both tickets and orders from the MyPage section. A new `RefundDialog` component handles the refund flow with support for optional refund reasons and real-time refund eligibility checking.

## Key Changes

- **New RefundDialog Component** (`src/pages/MyPage/shared/RefundDialog.tsx`)
  - Reusable modal dialog for handling refund requests for both tickets and orders
  - Fetches refund information (original amount, refund rate, refund amount) for tickets
  - Supports optional refund reason input with textarea
  - Handles both ticket refunds (via PG) and order refunds with appropriate API calls
  - Displays refund eligibility status and prevents refunds when not allowed
  - Includes proper error handling and user feedback via toast notifications

- **Ticket Refund Integration**
  - Added "환불 요청" (Refund Request) button to `TicketCard` component
  - Button only appears for tickets with `VALID` status
  - Integrated `RefundDialog` with ticket-specific refund target
  - Added `onRefunded` callback to refresh ticket list after successful refund
  - Updated `TicketGrid` to pass through refund callback

- **Order Refund Integration**
  - Added "환불" (Refund) action button to `OrderRow` component
  - Button only appears for orders with `PAID` status
  - Integrated `RefundDialog` with order-specific refund target
  - Added new action column to orders table with proper styling
  - Updated `OrdersTable` to pass through refund callback
  - Added `ORDER_ACTION_COLUMN_LABEL` constant to columns configuration

- **Navigation Updates**
  - Added seller and admin routes to layout navigation
  - Updated `RouteKey` type to include `'seller'` and `'admin'`
  - Added conditional tab bar items for seller and admin roles
  - Updated route utilities and status bar labels

- **Styling**
  - Added `.refund-dialog-reason` styles for refund reason textarea
  - Added `.ticket-card-body` wrapper for better layout control
  - Added `.ticket-card-actions` for action button positioning
  - Added `.order-cell-action` for order table action column styling

## Implementation Details

- Refund dialog uses `useId()` for accessible ARIA labeling
- Keyboard escape key support for closing the dialog
- Loading states for fetching refund information
- Proper cleanup of async operations with cancellation flags
- Error handling with fallback messages from API responses
- Default refund reason ("사용자 요청") when user doesn't provide one
- Disabled state management during submission to prevent double-submission

https://claude.ai/code/session_01D71SQM1FGqJMXGs3y7QGPM