### PR TITLE
[Admin] feat: 강제취소 사유 입력 모달 도입 (#601 후속)

### DIFF
--- a/src/api/admin.api.ts
+++ b/src/api/admin.api.ts
@@ -2,7 +2,7 @@ import { apiClient, ApiResponse } from './client';
 import type {
   AdminDashboardResponse,
   AdminEventSearchRequest, AdminEventListResponse,
-  EventCancelResponse,
+  EventCancelResponse, EventForceCancelRequest,
   UserSearchCondition, UserListResponse,
   AdminUserDetailResponse,
   UserStatusRequest, UserStatusResponse,
@@ -20,8 +20,8 @@ export const getAdminDashboard = () =>
 export const getAdminEvents = (params?: AdminEventSearchRequest) =>
   apiClient.get<ApiResponse<AdminEventListResponse>>('/admin/events', { params });
 
-export const forcecancelEvent = (eventId: string) =>
-  apiClient.patch<ApiResponse<EventCancelResponse>>(`/admin/events/${eventId}/force-cancel`);
+export const forcecancelEvent = (eventId: string, body: EventForceCancelRequest) =>
+  apiClient.patch<ApiResponse<EventCancelResponse>>(`/admin/events/${eventId}/force-cancel`, body);
 
 // ── 회원 관리 ──────────────────────────────────────────────────────────────────
 export const getAdminUsers = (params?: UserSearchCondition) =>

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -768,6 +768,10 @@ export interface EventCancelResponse {
   status: string;
 }
 
+export interface EventForceCancelRequest {
+  reason: string;
+}
+
 export interface UserSearchCondition {
   keyword?: string;
   role?: string;

--- a/src/pages/admin/AdminEvents.tsx
+++ b/src/pages/admin/AdminEvents.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom'
 import { getAdminEvents, forcecancelEvent, getSellerApplications, processSellerApplication, runSettlementProcess, getAdminSettlements, cancelSettlement, paySettlement } from '../../api/admin.api'
 import type { AdminEventItem, SellerApplicationListItem, AdminSettlementItem } from '../../api/types'
 import { useToast } from '../../contexts/ToastContext'
-import Modal from '../../components/Modal'
 
 const REASON_MAX = 500
 
@@ -533,6 +532,76 @@ export function AdminSettlements() {
           )}
         </>
       )}
+    </div>
+  )
+}
+
+function Modal({ open, onClose, title, children, width = 480, footer }: {
+  open: boolean
+  onClose: () => void
+  title?: string
+  children: React.ReactNode
+  width?: number
+  footer?: React.ReactNode
+}) {
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, zIndex: 1000,
+        background: 'rgba(0,0,0,0.4)', backdropFilter: 'blur(4px)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: 24, animation: 'fadeIn 0.15s ease',
+      }}
+      onClick={e => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div
+        style={{
+          width: '100%', maxWidth: width,
+          background: 'var(--surface)', borderRadius: 'var(--r-xl)',
+          boxShadow: '0 20px 60px rgba(0,0,0,0.2)',
+          animation: 'slideUp 0.2s ease',
+          overflow: 'hidden',
+        }}
+      >
+        {title && (
+          <div style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+            padding: '18px 24px', borderBottom: '1px solid var(--border)',
+          }}>
+            <h2 style={{ fontSize: 16, fontWeight: 600, color: 'var(--text)' }}>{title}</h2>
+            <button
+              onClick={onClose}
+              style={{
+                width: 28, height: 28, borderRadius: 'var(--r-md)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                background: 'none', border: 'none', cursor: 'pointer',
+                color: 'var(--text-4)', fontSize: 18,
+              }}
+            >✕</button>
+          </div>
+        )}
+        <div style={{ padding: '20px 24px' }}>{children}</div>
+        {footer && (
+          <div style={{
+            padding: '14px 24px', borderTop: '1px solid var(--border)',
+            display: 'flex', justifyContent: 'flex-end', gap: 8,
+            background: 'var(--surface-2)',
+          }}>{footer}</div>
+        )}
+      </div>
+      <style>{`
+        @keyframes fadeIn  { from { opacity: 0; } to { opacity: 1; } }
+        @keyframes slideUp { from { transform: translateY(16px); opacity: 0; } to { transform: none; opacity: 1; } }
+      `}</style>
     </div>
   )
 }

--- a/src/pages/admin/AdminEvents.tsx
+++ b/src/pages/admin/AdminEvents.tsx
@@ -4,6 +4,9 @@ import { useNavigate } from 'react-router-dom'
 import { getAdminEvents, forcecancelEvent, getSellerApplications, processSellerApplication, runSettlementProcess, getAdminSettlements, cancelSettlement, paySettlement } from '../../api/admin.api'
 import type { AdminEventItem, SellerApplicationListItem, AdminSettlementItem } from '../../api/types'
 import { useToast } from '../../contexts/ToastContext'
+import Modal from '../../components/Modal'
+
+const REASON_MAX = 500
 
 const EVENT_STATUS_MAP: Record<string, { label: string; cls: string }> = {
   DRAFT:     { label: '초안',    cls: 'badge-gray' },
@@ -20,6 +23,9 @@ export function AdminEvents() {
   const [keyword, setKeyword] = useState('')
   const [draftKeyword, setDraftKeyword] = useState('')
   const [actionLoading, setActionLoading] = useState<string | null>(null)
+  const [cancelTarget, setCancelTarget] = useState<{ eventId: string; title: string } | null>(null)
+  const [cancelReason, setCancelReason] = useState('')
+  const [reasonError, setReasonError] = useState<string | null>(null)
 
   const fetchEvents = useCallback(async () => {
     setLoading(true)
@@ -32,12 +38,31 @@ export function AdminEvents() {
 
   useEffect(() => { fetchEvents() }, [fetchEvents])
 
-  const handleForceCancel = async (eventId: string, title: string) => {
-    if (!confirm(`"${title}" 이벤트를 관리자 권한으로 취소할까요?\n참여자 전원 환불이 자동 처리됩니다.`)) return
-    setActionLoading(eventId)
+  const openCancelModal = (eventId: string, title: string) => {
+    setCancelTarget({ eventId, title })
+    setCancelReason('')
+    setReasonError(null)
+  }
+
+  const closeCancelModal = () => {
+    if (actionLoading) return
+    setCancelTarget(null)
+    setCancelReason('')
+    setReasonError(null)
+  }
+
+  const submitCancel = async () => {
+    if (!cancelTarget) return
+    const trimmed = cancelReason.trim()
+    if (trimmed.length === 0) { setReasonError('취소 사유를 입력해 주세요.'); return }
+    if (trimmed.length > REASON_MAX) { setReasonError(`취소 사유는 ${REASON_MAX}자 이내여야 합니다.`); return }
+    setActionLoading(cancelTarget.eventId)
     try {
-      await forcecancelEvent(eventId)
+      await forcecancelEvent(cancelTarget.eventId, { reason: trimmed })
       toast('관리자 이벤트 취소 및 환불 요청이 접수되었습니다', 'success')
+      setCancelTarget(null)
+      setCancelReason('')
+      setReasonError(null)
       fetchEvents()
     } catch { toast('처리 실패', 'error') }
     finally { setActionLoading(null) }
@@ -97,7 +122,7 @@ export function AdminEvents() {
                         <button
                           className="btn btn-danger btn-sm"
                           disabled={actionLoading === event.eventId}
-                          onClick={() => handleForceCancel(event.eventId, event.title)}
+                          onClick={() => openCancelModal(event.eventId, event.title)}
                         >
                           {actionLoading === event.eventId ? '...' : '관리자 취소'}
                         </button>
@@ -110,6 +135,75 @@ export function AdminEvents() {
           </table>
         </div>
       )}
+
+      <Modal
+        open={cancelTarget !== null}
+        onClose={closeCancelModal}
+        title="이벤트 강제취소"
+        width={480}
+        footer={
+          <>
+            <button
+              className="btn btn-secondary"
+              onClick={closeCancelModal}
+              disabled={actionLoading !== null}
+            >
+              취소
+            </button>
+            <button
+              className="btn btn-danger"
+              onClick={submitCancel}
+              disabled={actionLoading !== null}
+            >
+              {actionLoading ? '처리 중...' : '강제 취소'}
+            </button>
+          </>
+        }
+      >
+        {cancelTarget && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <div style={{ fontSize: 14, color: 'var(--text-2)' }}>
+              <strong style={{ color: 'var(--text-1)' }}>{cancelTarget.title}</strong> 이벤트를 강제 취소합니다.
+              <br />
+              참여자 전원 환불이 자동 처리됩니다.
+            </div>
+
+            <textarea
+              value={cancelReason}
+              onChange={e => {
+                setCancelReason(e.target.value)
+                if (reasonError) setReasonError(null)
+              }}
+              maxLength={REASON_MAX}
+              rows={5}
+              placeholder="취소 사유를 입력해 주세요 (필수, 최대 500자)"
+              disabled={actionLoading !== null}
+              style={{
+                width: '100%',
+                padding: '10px 12px',
+                borderRadius: 'var(--r-md)',
+                border: `1px solid ${reasonError ? 'var(--danger)' : 'var(--border)'}`,
+                fontSize: 14,
+                fontFamily: 'inherit',
+                resize: 'vertical',
+                background: 'var(--surface)',
+                color: 'var(--text-1)',
+                outline: 'none',
+                boxSizing: 'border-box',
+              }}
+            />
+
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 12 }}>
+              <span style={{ color: reasonError ? 'var(--danger)' : 'var(--text-4)' }}>
+                {reasonError ?? '취소 사유는 환불 안내 및 감사 로그에 기록됩니다.'}
+              </span>
+              <span style={{ color: 'var(--text-4)', fontFamily: 'var(--font-mono)' }}>
+                {cancelReason.length} / {REASON_MAX}
+              </span>
+            </div>
+          </div>
+        )}
+      </Modal>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- 어드민 강제취소 시 사유(reason) 입력 모달 추가, 입력값을 PATCH body 로 송신
- 클라이언트 검증: 1~500자, 공백만 입력 거부
- issue #601 1차 hotfix 의 후속 작업 — admin 측 하드코딩된 reason ("관리자 강제 취소") 을 실제 운영 사유로 대체

## API 변경
- `PATCH /api/admin/events/{eventId}/force-cancel`
  - 변경 전: body 없음
  - 변경 후: `{ "reason": "<1~500자>" }`
- 응답: 기존과 동일 (204 No Content)

## 변경 파일
- `src/api/types.ts` — `EventForceCancelRequest` 타입 추가
- `src/api/admin.api.ts` — `forcecancelEvent(eventId, body)` 시그니처 변경
- `src/pages/admin/AdminEvents.tsx` — 모달 도입, 검증/송신 플로우, 처리 중 닫기 차단, 인라인 Modal helper 포함

## 커밋 구성
1. `feat(admin): 강제취소 사유 입력 모달 도입 (issue #601 후속)` — 메인 변경
2. `fix(admin): inline modal after v1 components removal on develop` — develop 의 `ce0735d` 가 v1→v2 전환으로 `src/components/Modal.tsx` 를 삭제함에 따라 동일 파일 내부 helper 로 인라인화

## UI
- 제목: "이벤트 강제취소"
- 본문: 대상 이벤트명 + "참여자 전원 환불이 자동 처리됩니다" 안내
- 입력: textarea (max 500자, 실시간 카운터)
- 안내문: "취소 사유는 환불 안내 및 감사 로그에 기록됩니다."
- 버튼: [취소] / [강제 취소] (destructive)
- 처리 중 ESC/배경 클릭/취소 버튼 모두 차단 (이중 제출 방지)

## Test plan (수동)
- [x] `npx tsc --noEmit` — 본 PR 로 인한 새 에러 0건 (기존 4건은 라인 시프트만)
- [x] `npm run build` — 통과 (2.95s)
- [ ] `npm run dev` → 어드민 로그인 → 이벤트 관리
- [ ] ON_SALE 이벤트의 "관리자 취소" 클릭 → 모달 오픈 (애니메이션 정상)
- [ ] 빈 입력으로 [강제 취소] 클릭 → 인라인 에러, **PATCH 미발송** (Network 탭 확인)
- [ ] 공백/탭/줄바꿈만 입력 → 같은 에러 (trim 검증)
- [ ] 입력 시작 → 에러 자동 사라짐
- [ ] 카운터 `X / 500` 정상 갱신, maxLength 차단 동작
- [ ] ESC / 배경 클릭으로 닫힘
- [ ] 처리 중에는 ESC/배경 클릭/취소 버튼 모두 무시
- [ ] 정상 입력 후 송신 → DevTools Network 에서 다음 확인
  - Method: `PATCH`
  - Request Body: `{"reason":"<trimmed text>"}`
- [ ] 다크/라이트 토큰(`--surface`, `--border`, `--text-4` 등) v2 환경에서 색상 깨지지 않음
- [ ] (admin PR 배포 후) dev 환경에서 200/204 + admin-svc 로그에 reason 그대로 기록 + Kafka `event.force-cancelled` 이벤트의 reason 전파 확인

## ⚠️ 머지/배포 타이밍 주의 (issue #601 본문 참조)
- admin 측 컨트롤러 시그니처 변경 PR (`@RequestBody InternalEventForceCancelRequest` 추가) 과 **동시 배포 필요**
- admin 만 먼저 배포되면: 기존 FE 가 body 없이 PATCH → `@NotBlank` 위반 → **400** 으로 운영 차단
- FE 만 먼저 배포되면: admin 이 body 무시, 기존 하드코딩 reason 그대로 사용 → 운영 차단은 없으나 사유 데이터가 가짜
- → admin PR 머지/배포 확인 후 본 PR 머지 권장

## 참고: develop 영향 분석
- develop 의 `9858314 fix(front): align v2 frontend with v1 backend spec` 검토 결과 본 PR 과 무관
  - 변경된 19개 파일 중 우리 영역과 겹치는 건 `src/api/types.ts` 1개
  - 그 변경은 `EventItem` 인터페이스에 옵셔널 필드 2개 추가뿐 (우리 PR 이 쓰는 7개 타입과 무관)
- develop 의 `ce0735d` 로 인한 `Modal.tsx` 삭제는 본 PR 의 두 번째 커밋에서 인라인화로 대응

## Refs
- 1차 hotfix / 진단 과정: issue #601 댓글
- admin 측 컨트롤러 변경 PR: (admin 측에서 별도 진행)
