### PR TITLE
Update ticket and order API types and status handling

### DIFF
--- a/src/api/tickets.api.ts
+++ b/src/api/tickets.api.ts
@@ -5,7 +5,7 @@ import type {
 } from './types';
 
 export const getTickets = (params?: TicketListRequest) =>
-  apiClient.get<TicketListResponse>('/tickets', { params });
+  apiClient.get<ApiResponse<TicketListResponse>>('/tickets', { params });
 
 export const getTicketDetail = (ticketId: string) =>
   apiClient.get<ApiResponse<TicketDetailResponse>>(`/tickets/${ticketId}`);

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -400,9 +400,7 @@ export interface OrderItem {
   createdAt: string;
 }
 export interface OrderListResponse {
-  content: OrderItem[];
-  page: number;
-  size: number;
+  orders: OrderItem[];
   totalElements: number;
   totalPages: number;
 }
@@ -435,11 +433,12 @@ export interface TicketListRequest {
   size?: number;
 }
 export interface TicketItem {
-  ticketId: number;
+  ticketId: string;
   eventId: string;
   eventTitle: string;
-  eventDate: string;
+  eventDateTime: string;
   status: string;
+  issuedAt: string;
 }
 export interface TicketListResponse {
   tickets: TicketItem[];

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -51,14 +51,15 @@ export interface LayoutProps {
 
 const CATEGORY_LIST = ['컨퍼런스', '밋업', '해커톤', '스터디', '세미나', '워크샵'];
 
-const TABS: TabDef[] = [
+const BASE_TABS: TabDef[] = [
   { key: 'home', label: '홈', icon: 'terminal' },
   { key: 'events', label: '이벤트 목록', icon: 'folder' },
   { key: 'detail', label: '이벤트 상세', icon: 'file' },
   { key: 'cart', label: '장바구니', icon: 'cart' },
   { key: 'mypage', label: '마이페이지', icon: 'user' },
-  { key: 'login', label: '로그인', icon: 'terminal' },
 ];
+
+const LOGIN_TAB: TabDef = { key: 'login', label: '로그인', icon: 'terminal' };
 
 const SELLER_TAB: TabDef = { key: 'seller', label: '판매자 센터', icon: 'wallet' };
 const ADMIN_TAB: TabDef = { key: 'admin', label: '관리자 패널', icon: 'settings' };
@@ -182,7 +183,8 @@ function LayoutInner({ children }: LayoutProps) {
         />
         <TabBar
           tabs={[
-            ...TABS,
+            ...BASE_TABS,
+            ...(isLoggedIn ? [] : [LOGIN_TAB]),
             ...(role === 'SELLER' || role === 'ADMIN' ? [SELLER_TAB] : []),
             ...(role === 'ADMIN' ? [ADMIN_TAB] : []),
           ]}

--- a/src/pages/MyPage/tabs/Orders/hooks.ts
+++ b/src/pages/MyPage/tabs/Orders/hooks.ts
@@ -33,7 +33,7 @@ export function useOrders(page: number): UseOrdersReturn {
       .then((res) => {
         if (cancelled) return;
         const list = unwrapApiData(res.data);
-        const rows = list.content.map(toOrderRowVM);
+        const rows = list.orders.map(toOrderRowVM);
         setState({
           status: 'ready',
           data: {

--- a/src/pages/MyPage/tabs/Tickets/adapters.ts
+++ b/src/pages/MyPage/tabs/Tickets/adapters.ts
@@ -6,9 +6,10 @@ import type { TicketStatus, TicketVM } from './types';
 type StatusEntry = { variant: TicketVM['statusVariant']; label: string };
 
 export const TICKET_STATUS_MAP: Record<Exclude<TicketStatus, 'UNKNOWN'>, StatusEntry> = {
-  VALID: { variant: 'ok', label: '사용 가능' },
+  ISSUED: { variant: 'ok', label: '발급 완료' },
   USED: { variant: 'end', label: '사용 완료' },
   CANCELLED: { variant: 'sold', label: '취소됨' },
+  REFUNDED: { variant: 'sold', label: '환불 완료' },
   EXPIRED: { variant: 'end', label: '만료' },
 };
 
@@ -19,7 +20,7 @@ export function toTicketVM(api: TicketItem): TicketVM {
     ticketId: String(api.ticketId),
     eventId: api.eventId,
     title: api.eventTitle,
-    dateLabel: fmtDate(api.eventDate),
+    dateLabel: fmtDate(api.eventDateTime),
     status,
     statusVariant: known?.variant ?? 'end',
     statusLabel: known?.label ?? api.status,

--- a/src/pages/MyPage/tabs/Tickets/components/TicketCard.tsx
+++ b/src/pages/MyPage/tabs/Tickets/components/TicketCard.tsx
@@ -12,7 +12,7 @@ interface TicketCardProps {
 
 export function TicketCard({ ticket, onRefunded }: TicketCardProps) {
   const [open, setOpen] = useState(false);
-  const canRefund = ticket.status === 'VALID';
+  const canRefund = ticket.status === 'ISSUED';
 
   return (
     <Card variant="solid" padding="none" className="ticket-card">

--- a/src/pages/MyPage/tabs/Tickets/hooks.ts
+++ b/src/pages/MyPage/tabs/Tickets/hooks.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { getTickets } from '@/api/tickets.api';
+import { unwrapApiData } from '@/api/client';
 import type { FetchState } from '../../shared/TabFetchState';
 import { toTicketVM } from './adapters';
 import type { TicketVM } from './types';
@@ -32,14 +33,15 @@ export function useTickets(page: number): UseTicketsReturn {
     getTickets({ page: page - 1, size: PAGE_SIZE })
       .then((res) => {
         if (cancelled) return;
-        const tickets = res.data.tickets.map(toTicketVM);
+        const list = unwrapApiData(res.data);
+        const tickets = list.tickets.map(toTicketVM);
         setState({
           status: 'ready',
           data: {
             tickets,
-            total: res.data.totalElements,
-            totalPages: res.data.totalPages,
-            validCount: tickets.filter((t) => t.status === 'VALID').length,
+            total: list.totalElements,
+            totalPages: list.totalPages,
+            validCount: tickets.filter((t) => t.status === 'ISSUED').length,
             usedCount: tickets.filter((t) => t.status === 'USED').length,
           },
         });

--- a/src/pages/MyPage/tabs/Tickets/types.ts
+++ b/src/pages/MyPage/tabs/Tickets/types.ts
@@ -1,7 +1,8 @@
 export type TicketStatus =
-  | 'VALID'
+  | 'ISSUED'
   | 'USED'
   | 'CANCELLED'
+  | 'REFUNDED'
   | 'EXPIRED'
   | 'UNKNOWN';
 


### PR DESCRIPTION
## Summary
This PR updates the API type definitions and client code to align with backend API changes, particularly around ticket status values and response structure standardization.

## Key Changes

- **Ticket Status Updates**: Changed ticket status from `VALID` to `ISSUED` and added `REFUNDED` status to support new ticket lifecycle states
- **API Response Standardization**: Updated `TicketListResponse` to use `ApiResponse` wrapper, consistent with other API endpoints
- **Type Definition Updates**:
  - Changed `TicketItem.ticketId` from `number` to `string`
  - Renamed `TicketItem.eventDate` to `eventDateTime`
  - Added `TicketItem.issuedAt` field
  - Updated `OrderListResponse` to use `orders` instead of `content` and removed `page`/`size` fields
- **API Client Updates**: Applied `unwrapApiData()` helper to ticket responses to handle the new `ApiResponse` wrapper
- **UI/UX Improvements**:
  - Updated ticket status labels (e.g., "사용 가능" → "발급 완료")
  - Added `REFUNDED` status mapping with appropriate styling
  - Updated refund eligibility check to use `ISSUED` status
  - Refactored navigation tabs to conditionally show login tab only when not logged in

## Implementation Details

- The `unwrapApiData()` helper is now consistently used across both ticket and order API calls
- Ticket status mapping in `TICKET_STATUS_MAP` now reflects the new status values with appropriate UI variants and labels
- Navigation tab structure was refactored to separate base tabs from conditional tabs (login, seller, admin) for better maintainability

https://claude.ai/code/session_01Hw822fGuBSTwdNQ4xz8P3P