### PR TITLE
Add dynamic detail tabs with close affordance

### DIFF
--- a/src/components/Layout/TabBar.tsx
+++ b/src/components/Layout/TabBar.tsx
@@ -1,6 +1,6 @@
 import type { KeyboardEvent } from 'react';
 import { Icon, type IconName } from '../Icon';
-import type { RouteKey, TabDef } from './types';
+import type { TabDef } from './types';
 
 /**
  * Source: docs/archive/v2-cutover/layout.plan.md §3-10.
@@ -13,24 +13,26 @@ import type { RouteKey, TabDef } from './types';
  *
  * §6-6 a11y: role="tablist" + aria-label, each tab aria-selected and
  * aria-controls="ide-editor"; close button has explicit aria-label.
+ *
+ * Close affordance is per-tab via `tab.closeable` so pinned base tabs (home,
+ * events, cart, mypage, …) can stay un-closeable while dynamic detail tabs
+ * become user-dismissible.
  */
 export interface TabBarProps {
   tabs: TabDef[];
-  activeKey: RouteKey;
-  onSelect: (key: RouteKey) => void;
-  /** Omit (or pass single tab) to hide the close affordance. */
-  onClose?: (key: RouteKey) => void;
+  activeKey: string;
+  onSelect: (tab: TabDef) => void;
+  onClose?: (tab: TabDef) => void;
   className?: string;
 }
 
 export function TabBar({ tabs, activeKey, onSelect, onClose, className }: TabBarProps) {
-  const showClose = Boolean(onClose) && tabs.length > 1;
   const containerCls = className ? `ide-tabs ${className}` : 'ide-tabs';
 
-  const handleTabKey = (e: KeyboardEvent<HTMLDivElement>, key: RouteKey) => {
+  const handleTabKey = (e: KeyboardEvent<HTMLDivElement>, tab: TabDef) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
-      onSelect(key);
+      onSelect(tab);
     }
   };
 
@@ -38,6 +40,7 @@ export function TabBar({ tabs, activeKey, onSelect, onClose, className }: TabBar
     <div className={containerCls} role="tablist" aria-label="열린 페이지">
       {tabs.map((t) => {
         const isActive = activeKey === t.key;
+        const showClose = Boolean(onClose) && t.closeable;
         return (
           <div
             key={t.key}
@@ -46,8 +49,8 @@ export function TabBar({ tabs, activeKey, onSelect, onClose, className }: TabBar
             aria-selected={isActive}
             aria-controls="ide-editor"
             tabIndex={isActive ? 0 : -1}
-            onClick={() => onSelect(t.key)}
-            onKeyDown={(e) => handleTabKey(e, t.key)}
+            onClick={() => onSelect(t)}
+            onKeyDown={(e) => handleTabKey(e, t)}
           >
             <Icon name={t.icon as IconName} size={13} />
             <span>{t.label}</span>
@@ -58,7 +61,7 @@ export function TabBar({ tabs, activeKey, onSelect, onClose, className }: TabBar
                 aria-label={`${t.label} 탭 닫기`}
                 onClick={(e) => {
                   e.stopPropagation();
-                  onClose?.(t.key);
+                  onClose?.(t);
                 }}
               >
                 <Icon name="x" size={12} />

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -51,18 +51,25 @@ export interface LayoutProps {
 
 const CATEGORY_LIST = ['컨퍼런스', '밋업', '해커톤', '스터디', '세미나', '워크샵'];
 
+/**
+ * Pinned tabs (no close affordance). `detail` is intentionally *not* in this
+ * list — it becomes a dynamic per-event tab that is opened on first visit
+ * and dismissable by the user. Login/seller/admin remain pinned but
+ * conditional on auth state.
+ */
 const BASE_TABS: TabDef[] = [
-  { key: 'home', label: '홈', icon: 'terminal' },
-  { key: 'events', label: '이벤트 목록', icon: 'folder' },
-  { key: 'detail', label: '이벤트 상세', icon: 'file' },
-  { key: 'cart', label: '장바구니', icon: 'cart' },
-  { key: 'mypage', label: '마이페이지', icon: 'user' },
+  { key: 'home', label: '홈', icon: 'terminal', route: 'home' },
+  { key: 'events', label: '이벤트 목록', icon: 'folder', route: 'events' },
+  { key: 'cart', label: '장바구니', icon: 'cart', route: 'cart' },
+  { key: 'mypage', label: '마이페이지', icon: 'user', route: 'mypage' },
 ];
 
-const LOGIN_TAB: TabDef = { key: 'login', label: '로그인', icon: 'terminal' };
+const LOGIN_TAB: TabDef = { key: 'login', label: '로그인', icon: 'terminal', route: 'login' };
 
-const SELLER_TAB: TabDef = { key: 'seller', label: '판매자 센터', icon: 'wallet' };
-const ADMIN_TAB: TabDef = { key: 'admin', label: '관리자 패널', icon: 'settings' };
+const SELLER_TAB: TabDef = { key: 'seller', label: '판매자 센터', icon: 'wallet', route: 'seller' };
+const ADMIN_TAB: TabDef = { key: 'admin', label: '관리자 패널', icon: 'settings', route: 'admin' };
+
+const detailTabKey = (id: string) => `detail:${id}`;
 
 const SIDEBAR_FETCH_SIZE = 50;
 const UPCOMING_LIMIT = 4;
@@ -85,8 +92,10 @@ function LayoutInner({ children }: LayoutProps) {
 
   const [events, setEvents] = useState<EventItem[]>([]);
   const [totalEvents, setTotalEvents] = useState(0);
+  const [openDetailIds, setOpenDetailIds] = useState<string[]>([]);
 
   const currentRoute = routeFromPath(location.pathname);
+  const currentDetailId = detailIdFromPath(location.pathname);
   const sessionUser: SessionUser | null = user
     ? { nickname: user.nickname }
     : null;
@@ -134,9 +143,13 @@ function LayoutInner({ children }: LayoutProps) {
 
   const lastDetailIdRef = useRef<string | null>(null);
   useEffect(() => {
-    const id = detailIdFromPath(location.pathname);
-    if (id) lastDetailIdRef.current = id;
-  }, [location.pathname]);
+    if (currentDetailId) {
+      lastDetailIdRef.current = currentDetailId;
+      setOpenDetailIds((prev) =>
+        prev.includes(currentDetailId) ? prev : [...prev, currentDetailId],
+      );
+    }
+  }, [currentDetailId]);
 
   const onNavigate: NavigateFn = (key, params) => {
     const resolvedParams =
@@ -144,6 +157,64 @@ function LayoutInner({ children }: LayoutProps) {
         ? { ...params, id: lastDetailIdRef.current }
         : params;
     navigate(pathFromRoute(key, resolvedParams));
+  };
+
+  const detailTabs = useMemo<TabDef[]>(
+    () =>
+      openDetailIds.map((id) => {
+        const ev = events.find((e) => String(e.eventId) === id);
+        return {
+          key: detailTabKey(id),
+          label: ev?.title ?? `이벤트 #${id}`,
+          icon: 'file',
+          route: 'detail' as const,
+          params: { id },
+          closeable: true,
+        };
+      }),
+    [openDetailIds, events],
+  );
+
+  const tabs = useMemo<TabDef[]>(
+    () => [
+      ...BASE_TABS,
+      ...(isLoggedIn ? [] : [LOGIN_TAB]),
+      ...(role === 'SELLER' || role === 'ADMIN' ? [SELLER_TAB] : []),
+      ...(role === 'ADMIN' ? [ADMIN_TAB] : []),
+      ...detailTabs,
+    ],
+    [isLoggedIn, role, detailTabs],
+  );
+
+  const activeTabKey =
+    currentRoute === 'detail' && currentDetailId
+      ? detailTabKey(currentDetailId)
+      : currentRoute;
+
+  const handleTabSelect = (tab: TabDef) => {
+    onNavigate(tab.route, tab.params);
+  };
+
+  const handleTabClose = (tab: TabDef) => {
+    if (tab.route !== 'detail' || !tab.params?.id) return;
+    const closingId = tab.params.id;
+    if (activeTabKey === tab.key) {
+      // Prefer the neighbouring detail tab; otherwise fall back to the
+      // events list so the editor pane is never left without a route.
+      const idx = openDetailIds.indexOf(closingId);
+      const remaining = openDetailIds.filter((id) => id !== closingId);
+      const fallbackId =
+        remaining[idx] ?? remaining[idx - 1] ?? remaining[remaining.length - 1] ?? null;
+      if (fallbackId) {
+        navigate(pathFromRoute('detail', { id: fallbackId }));
+      } else {
+        navigate(pathFromRoute('events'));
+      }
+    }
+    setOpenDetailIds((prev) => prev.filter((id) => id !== closingId));
+    if (lastDetailIdRef.current === closingId) {
+      lastDetailIdRef.current = null;
+    }
   };
 
   useGlobalShortcuts({
@@ -182,14 +253,10 @@ function LayoutInner({ children }: LayoutProps) {
           onNavigate={onNavigate}
         />
         <TabBar
-          tabs={[
-            ...BASE_TABS,
-            ...(isLoggedIn ? [] : [LOGIN_TAB]),
-            ...(role === 'SELLER' || role === 'ADMIN' ? [SELLER_TAB] : []),
-            ...(role === 'ADMIN' ? [ADMIN_TAB] : []),
-          ]}
-          activeKey={currentRoute}
-          onSelect={onNavigate}
+          tabs={tabs}
+          activeKey={activeTabKey}
+          onSelect={handleTabSelect}
+          onClose={handleTabClose}
         />
         <main className="ide-editor" id="ide-editor" tabIndex={-1}>
           {children ?? <Outlet />}

--- a/src/components/Layout/types.ts
+++ b/src/components/Layout/types.ts
@@ -27,10 +27,19 @@ export interface ActivityItem {
   action?: 'palette';
 }
 
+/**
+ * `key` is a string id (not strictly RouteKey) so dynamic tabs like
+ * `detail:<eventId>` can coexist with pinned route tabs. Pinned tabs use
+ * a RouteKey as their key; dynamic tabs encode their target via `route`
+ * + `params` so the tab bar doesn't need to parse the key.
+ */
 export interface TabDef {
-  key: RouteKey;
+  key: string;
   label: string;
   icon: string;
+  route: RouteKey;
+  params?: NavParams;
+  closeable?: boolean;
 }
 
 export interface PaletteItem {


### PR DESCRIPTION
## Summary
Refactored the tab system to support dynamic, closeable detail tabs while keeping base navigation tabs pinned. Each event detail page now opens as a separate tab that can be closed by the user, with intelligent fallback navigation when closing tabs.

## Key Changes
- **Dynamic detail tabs**: Event detail pages now open as individual tabs using a `detail:<eventId>` key format, tracked in `openDetailIds` state
- **Tab definition enhancement**: Extended `TabDef` interface to include `route`, `params`, and `closeable` properties, allowing tabs to encode their navigation target independently of their key
- **Pinned vs. closeable tabs**: Base tabs (home, events, cart, mypage) remain pinned without close affordance; detail tabs are user-dismissible
- **Smart tab closure**: When closing an active detail tab, the UI intelligently falls back to a neighboring detail tab or the events list to ensure a valid route is always active
- **Tab bar refactoring**: Updated `TabBar` component to accept `TabDef` objects in callbacks instead of just route keys, and to respect per-tab `closeable` property
- **Memoized tab computation**: Tabs array and active tab key are now computed with `useMemo` to optimize re-renders

## Implementation Details
- Added `detailTabKey()` helper function to generate consistent tab keys for detail pages
- Track open detail IDs in state and automatically add new IDs when navigating to a detail page
- Close button visibility is now per-tab via `tab.closeable` rather than a global setting
- Maintains `lastDetailIdRef` to track the most recently visited detail tab for potential restoration
- Tab selection and closure now pass full `TabDef` objects through callbacks for better type safety and flexibility

https://claude.ai/code/session_01K17XMt5TcwhHf3hUjUmq5H