### PR TITLE
Implement wallet charge/withdraw UI and refactor tab management

### DIFF
--- a/src/components/Layout/TabBar.tsx
+++ b/src/components/Layout/TabBar.tsx
@@ -14,9 +14,9 @@ import type { TabDef } from './types';
  * §6-6 a11y: role="tablist" + aria-label, each tab aria-selected and
  * aria-controls="ide-editor"; close button has explicit aria-label.
  *
- * Close affordance is per-tab via `tab.closeable` so pinned base tabs (home,
- * events, cart, mypage, …) can stay un-closeable while dynamic detail tabs
- * become user-dismissible.
+ * Close affordance is per-tab via `tab.closeable`. Only the home tab is
+ * pinned; route tabs (events/cart/mypage/login/seller/admin) and dynamic
+ * detail tabs are all user-dismissible.
  */
 export interface TabBarProps {
   tabs: TabDef[];

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -20,6 +20,7 @@ import { useGlobalShortcuts } from './hooks/useGlobalShortcuts';
 import type {
   CategoryCount,
   NavigateFn,
+  RouteKey,
   SessionUser,
   TabDef,
   UpcomingEventVM,
@@ -52,22 +53,28 @@ export interface LayoutProps {
 const CATEGORY_LIST = ['컨퍼런스', '밋업', '해커톤', '스터디', '세미나', '워크샵'];
 
 /**
- * Pinned tabs (no close affordance). `detail` is intentionally *not* in this
- * list — it becomes a dynamic per-event tab that is opened on first visit
- * and dismissable by the user. Login/seller/admin remain pinned but
- * conditional on auth state.
+ * Only `home` is pinned. Everything else (events/cart/mypage/login/seller/
+ * admin and per-event detail tabs) is closeable; the user can re-open a
+ * route tab via the ActivityBar, Sidebar, or command palette. Route tabs
+ * lazily appear in `openRouteTabs` once the user navigates to them, so a
+ * fresh session shows only the home tab plus whichever route the URL
+ * landed on.
  */
-const BASE_TABS: TabDef[] = [
-  { key: 'home', label: '홈', icon: 'terminal', route: 'home' },
-  { key: 'events', label: '이벤트 목록', icon: 'folder', route: 'events' },
-  { key: 'cart', label: '장바구니', icon: 'cart', route: 'cart' },
-  { key: 'mypage', label: '마이페이지', icon: 'user', route: 'mypage' },
-];
+const HOME_TAB: TabDef = { key: 'home', label: '홈', icon: 'terminal', route: 'home' };
 
-const LOGIN_TAB: TabDef = { key: 'login', label: '로그인', icon: 'terminal', route: 'login' };
+type CloseableRouteKey = Exclude<RouteKey, 'home' | 'detail'>;
 
-const SELLER_TAB: TabDef = { key: 'seller', label: '판매자 센터', icon: 'wallet', route: 'seller' };
-const ADMIN_TAB: TabDef = { key: 'admin', label: '관리자 패널', icon: 'settings', route: 'admin' };
+const ROUTE_TAB_DEFS: Record<CloseableRouteKey, TabDef> = {
+  events: { key: 'events', label: '이벤트 목록', icon: 'folder', route: 'events', closeable: true },
+  cart: { key: 'cart', label: '장바구니', icon: 'cart', route: 'cart', closeable: true },
+  mypage: { key: 'mypage', label: '마이페이지', icon: 'user', route: 'mypage', closeable: true },
+  login: { key: 'login', label: '로그인', icon: 'terminal', route: 'login', closeable: true },
+  seller: { key: 'seller', label: '판매자 센터', icon: 'wallet', route: 'seller', closeable: true },
+  admin: { key: 'admin', label: '관리자 패널', icon: 'settings', route: 'admin', closeable: true },
+};
+
+/** Hard cap on dynamic detail tabs; oldest is evicted FIFO when exceeded. */
+const DETAIL_TAB_LIMIT = 5;
 
 const detailTabKey = (id: string) => `detail:${id}`;
 
@@ -93,6 +100,7 @@ function LayoutInner({ children }: LayoutProps) {
   const [events, setEvents] = useState<EventItem[]>([]);
   const [totalEvents, setTotalEvents] = useState(0);
   const [openDetailIds, setOpenDetailIds] = useState<string[]>([]);
+  const [openRouteTabs, setOpenRouteTabs] = useState<CloseableRouteKey[]>([]);
 
   const currentRoute = routeFromPath(location.pathname);
   const currentDetailId = detailIdFromPath(location.pathname);
@@ -145,11 +153,22 @@ function LayoutInner({ children }: LayoutProps) {
   useEffect(() => {
     if (currentDetailId) {
       lastDetailIdRef.current = currentDetailId;
-      setOpenDetailIds((prev) =>
-        prev.includes(currentDetailId) ? prev : [...prev, currentDetailId],
-      );
+      setOpenDetailIds((prev) => {
+        if (prev.includes(currentDetailId)) return prev;
+        const next = [...prev, currentDetailId];
+        // FIFO eviction: keep the most recent DETAIL_TAB_LIMIT entries.
+        return next.length > DETAIL_TAB_LIMIT
+          ? next.slice(next.length - DETAIL_TAB_LIMIT)
+          : next;
+      });
     }
   }, [currentDetailId]);
+
+  useEffect(() => {
+    if (currentRoute === 'home' || currentRoute === 'detail') return;
+    const key = currentRoute as CloseableRouteKey;
+    setOpenRouteTabs((prev) => (prev.includes(key) ? prev : [...prev, key]));
+  }, [currentRoute]);
 
   const onNavigate: NavigateFn = (key, params) => {
     const resolvedParams =
@@ -175,15 +194,22 @@ function LayoutInner({ children }: LayoutProps) {
     [openDetailIds, events],
   );
 
+  const routeTabs = useMemo<TabDef[]>(
+    () =>
+      openRouteTabs
+        .filter((key) => {
+          if (key === 'login') return !isLoggedIn;
+          if (key === 'seller') return role === 'SELLER' || role === 'ADMIN';
+          if (key === 'admin') return role === 'ADMIN';
+          return true;
+        })
+        .map((key) => ROUTE_TAB_DEFS[key]),
+    [openRouteTabs, isLoggedIn, role],
+  );
+
   const tabs = useMemo<TabDef[]>(
-    () => [
-      ...BASE_TABS,
-      ...(isLoggedIn ? [] : [LOGIN_TAB]),
-      ...(role === 'SELLER' || role === 'ADMIN' ? [SELLER_TAB] : []),
-      ...(role === 'ADMIN' ? [ADMIN_TAB] : []),
-      ...detailTabs,
-    ],
-    [isLoggedIn, role, detailTabs],
+    () => [HOME_TAB, ...routeTabs, ...detailTabs],
+    [routeTabs, detailTabs],
   );
 
   const activeTabKey =
@@ -196,25 +222,34 @@ function LayoutInner({ children }: LayoutProps) {
   };
 
   const handleTabClose = (tab: TabDef) => {
-    if (tab.route !== 'detail' || !tab.params?.id) return;
-    const closingId = tab.params.id;
-    if (activeTabKey === tab.key) {
-      // Prefer the neighbouring detail tab; otherwise fall back to the
-      // events list so the editor pane is never left without a route.
-      const idx = openDetailIds.indexOf(closingId);
-      const remaining = openDetailIds.filter((id) => id !== closingId);
-      const fallbackId =
-        remaining[idx] ?? remaining[idx - 1] ?? remaining[remaining.length - 1] ?? null;
-      if (fallbackId) {
-        navigate(pathFromRoute('detail', { id: fallbackId }));
-      } else {
-        navigate(pathFromRoute('events'));
+    if (tab.route === 'detail' && tab.params?.id) {
+      const closingId = tab.params.id;
+      if (activeTabKey === tab.key) {
+        // Prefer the neighbouring detail tab; otherwise fall back to the
+        // events list so the editor pane is never left without a route.
+        const idx = openDetailIds.indexOf(closingId);
+        const remaining = openDetailIds.filter((id) => id !== closingId);
+        const fallbackId =
+          remaining[idx] ?? remaining[idx - 1] ?? remaining[remaining.length - 1] ?? null;
+        if (fallbackId) {
+          navigate(pathFromRoute('detail', { id: fallbackId }));
+        } else {
+          navigate(pathFromRoute('events'));
+        }
       }
+      setOpenDetailIds((prev) => prev.filter((id) => id !== closingId));
+      if (lastDetailIdRef.current === closingId) {
+        lastDetailIdRef.current = null;
+      }
+      return;
     }
-    setOpenDetailIds((prev) => prev.filter((id) => id !== closingId));
-    if (lastDetailIdRef.current === closingId) {
-      lastDetailIdRef.current = null;
+
+    if (tab.route === 'home') return;
+    const closingKey = tab.route as CloseableRouteKey;
+    if (activeTabKey === tab.key) {
+      navigate(pathFromRoute('home'));
     }
+    setOpenRouteTabs((prev) => prev.filter((k) => k !== closingKey));
   };
 
   useGlobalShortcuts({

--- a/src/pages/MyPage/tabs/Tickets/components/TicketCard.tsx
+++ b/src/pages/MyPage/tabs/Tickets/components/TicketCard.tsx
@@ -12,7 +12,10 @@ interface TicketCardProps {
 
 export function TicketCard({ ticket, onRefunded }: TicketCardProps) {
   const [open, setOpen] = useState(false);
-  const canRefund = ticket.status === 'ISSUED';
+  // Match v1: surface the button for issued tickets *and* unrecognised
+  // backend statuses, then let the dialog's getRefundInfo gate the actual
+  // submit via `refundable`.
+  const canRefund = ticket.status === 'ISSUED' || ticket.status === 'UNKNOWN';
 
   return (
     <Card variant="solid" padding="none" className="ticket-card">

--- a/src/pages/MyPage/tabs/Wallet/WalletTab.tsx
+++ b/src/pages/MyPage/tabs/Wallet/WalletTab.tsx
@@ -1,14 +1,19 @@
+import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { TabErrorBox } from '../../shared/TabErrorBox';
 import { TabFetchState } from '../../shared/TabFetchState';
 import { useWalletBalance } from '../../shared/walletBalance';
 import { BalanceCard } from './components/BalanceCard';
 import { BalanceCardSkeleton } from './components/BalanceCardSkeleton';
+import { ChargePanel } from './components/ChargePanel';
 import { EmptyTransactions } from './components/EmptyTransactions';
 import { TransactionList } from './components/TransactionList';
 import { TransactionsPager } from './components/TransactionsPager';
 import { TransactionsSkeleton } from './components/TransactionsSkeleton';
+import { WithdrawPanel } from './components/WithdrawPanel';
 import { useWalletTransactions } from './hooks';
+
+type Mode = 'idle' | 'charge' | 'withdraw';
 
 export function WalletTab() {
   const balance = useWalletBalance();
@@ -16,6 +21,7 @@ export function WalletTab() {
   const rawPage = Number(sp.get('page') ?? '1');
   const page = Number.isFinite(rawPage) && rawPage >= 1 ? rawPage : 1;
   const txState = useWalletTransactions(page);
+  const [mode, setMode] = useState<Mode>('idle');
 
   const onPageChange = (next: number) => {
     setSp((prev) => {
@@ -25,6 +31,11 @@ export function WalletTab() {
       return nextSp;
     });
   };
+
+  const refreshBalance = balance.status !== 'loading' ? balance.refresh : () => {};
+  const refreshTransactions = txState.refetch;
+
+  const balanceAmount = balance.status === 'ready' ? balance.data.amount : 0;
 
   return (
     <div className="wallet-tab">
@@ -36,8 +47,23 @@ export function WalletTab() {
         <BalanceCard
           balance={balance.data.amount}
           lastUpdatedAtLabel={null}
-          onCharge={() => alert('충전 — 준비 중입니다')}
-          onWithdraw={() => alert('출금 — 준비 중입니다')}
+          onCharge={() => setMode((m) => (m === 'charge' ? 'idle' : 'charge'))}
+          onWithdraw={() => setMode((m) => (m === 'withdraw' ? 'idle' : 'withdraw'))}
+        />
+      )}
+
+      {mode === 'charge' && balance.status === 'ready' && (
+        <ChargePanel onCancel={() => setMode('idle')} />
+      )}
+      {mode === 'withdraw' && balance.status === 'ready' && (
+        <WithdrawPanel
+          balance={balanceAmount}
+          onCancel={() => setMode('idle')}
+          onSuccess={() => {
+            setMode('idle');
+            refreshBalance();
+            refreshTransactions();
+          }}
         />
       )}
 

--- a/src/pages/MyPage/tabs/Wallet/components/ChargePanel.tsx
+++ b/src/pages/MyPage/tabs/Wallet/components/ChargePanel.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import axios from 'axios';
+import { Button, Card, Input } from '@/components';
+import { startWalletCharge } from '@/api/wallet.api';
+import { requestTossCardPayment } from '@/components/PaymentModal/tossSdk';
+import { useToast } from '@/contexts/ToastContext';
+
+const QUICK_AMOUNTS = [10_000, 30_000, 50_000];
+const MIN_CHARGE = 1_000;
+
+interface ChargePanelProps {
+  onCancel: () => void;
+}
+
+export function ChargePanel({ onCancel }: ChargePanelProps) {
+  const { toast } = useToast();
+  const [amountText, setAmountText] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const parsed = Number(amountText.replace(/[^\d]/g, ''));
+  const amount = Number.isFinite(parsed) ? parsed : 0;
+  const valid = amount >= MIN_CHARGE;
+
+  const handleSubmit = async () => {
+    if (!valid) {
+      toast(`최소 ${MIN_CHARGE.toLocaleString()}원 이상 충전 가능합니다`, 'error');
+      return;
+    }
+    setSubmitting(true);
+    let chargeId: string | undefined;
+    let chargedAmount: number | undefined;
+
+    try {
+      const res = await startWalletCharge({ amount });
+      const data = res.data;
+      chargeId = data.chargeId;
+      chargedAmount = data.amount;
+    } catch (err: unknown) {
+      const message =
+        axios.isAxiosError(err) &&
+        typeof err.response?.data === 'object' &&
+        err.response?.data !== null &&
+        'message' in (err.response.data as Record<string, unknown>)
+          ? String((err.response.data as { message?: string }).message ?? '')
+          : '';
+      toast(message || '충전 요청 실패. 잠시 후 다시 시도해주세요.', 'error');
+      setSubmitting(false);
+      return;
+    }
+
+    try {
+      sessionStorage.setItem(
+        'wallet_charge_context',
+        JSON.stringify({ chargeId, amount: chargedAmount }),
+      );
+      await requestTossCardPayment({
+        paymentId: chargeId!,
+        amount: chargedAmount!,
+        orderName: '예치금 충전',
+        successUrl: `${window.location.origin}/wallet/charge/success`,
+        failUrl: `${window.location.origin}/wallet/charge/fail`,
+      });
+      // Toss redirects on success; the line below only runs on cancellation.
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : '결제창 실행에 실패했습니다.';
+      toast(message, 'error');
+      sessionStorage.removeItem('wallet_charge_context');
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Card variant="solid" padding="md" className="wallet-action-panel">
+      <div className="wallet-action-title">충전 금액</div>
+      <div className="wallet-action-quicks">
+        {QUICK_AMOUNTS.map((a) => {
+          const active = amount === a;
+          return (
+            <button
+              key={a}
+              type="button"
+              className={active ? 'wallet-quick active' : 'wallet-quick'}
+              onClick={() => setAmountText(String(a))}
+              disabled={submitting}
+            >
+              {a.toLocaleString()}원
+            </button>
+          );
+        })}
+      </div>
+      <div className="wallet-action-input">
+        <Input
+          inputMode="numeric"
+          placeholder="직접 입력 (원)"
+          value={amountText}
+          onChange={(e) => setAmountText(e.target.value.replace(/[^\d]/g, ''))}
+          disabled={submitting}
+        />
+      </div>
+      <div className="wallet-action-footer">
+        <Button variant="ghost" size="md" onClick={onCancel} disabled={submitting}>
+          취소
+        </Button>
+        <Button
+          variant="primary"
+          size="md"
+          onClick={handleSubmit}
+          loading={submitting}
+          disabled={!valid || submitting}
+        >
+          {submitting ? '처리 중...' : '충전하기'}
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/src/pages/MyPage/tabs/Wallet/components/WithdrawPanel.tsx
+++ b/src/pages/MyPage/tabs/Wallet/components/WithdrawPanel.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import axios from 'axios';
+import { Button, Card, Input } from '@/components';
+import { withdrawWallet } from '@/api/wallet.api';
+import { useToast } from '@/contexts/ToastContext';
+
+const MIN_WITHDRAW = 1_000;
+
+interface WithdrawPanelProps {
+  balance: number;
+  onCancel: () => void;
+  onSuccess: () => void;
+}
+
+export function WithdrawPanel({ balance, onCancel, onSuccess }: WithdrawPanelProps) {
+  const { toast } = useToast();
+  const [amountText, setAmountText] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const parsed = Number(amountText.replace(/[^\d]/g, ''));
+  const amount = Number.isFinite(parsed) ? parsed : 0;
+  const valid = amount >= MIN_WITHDRAW && amount <= balance;
+
+  const handleSubmit = async () => {
+    if (amount < MIN_WITHDRAW) {
+      toast(`최소 ${MIN_WITHDRAW.toLocaleString()}원 이상 출금 가능합니다`, 'error');
+      return;
+    }
+    if (amount > balance) {
+      toast('잔액이 부족합니다', 'error');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await withdrawWallet({ amount });
+      toast('출금 요청이 완료되었습니다', 'success');
+      onSuccess();
+    } catch (err: unknown) {
+      const message =
+        axios.isAxiosError(err) &&
+        typeof err.response?.data === 'object' &&
+        err.response?.data !== null &&
+        'message' in (err.response.data as Record<string, unknown>)
+          ? String((err.response.data as { message?: string }).message ?? '')
+          : '';
+      toast(message || '출금 처리에 실패했습니다', 'error');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Card variant="solid" padding="md" className="wallet-action-panel">
+      <div className="wallet-action-title">출금 금액</div>
+      <div className="wallet-action-input">
+        <Input
+          inputMode="numeric"
+          placeholder="출금 금액 (원)"
+          value={amountText}
+          onChange={(e) => setAmountText(e.target.value.replace(/[^\d]/g, ''))}
+          disabled={submitting}
+        />
+      </div>
+      <button
+        type="button"
+        className="wallet-withdraw-allbtn"
+        onClick={() => setAmountText(String(balance))}
+        disabled={submitting || balance <= 0}
+      >
+        전액 출금 ({balance.toLocaleString()}원)
+      </button>
+      <div className="wallet-action-footer">
+        <Button variant="ghost" size="md" onClick={onCancel} disabled={submitting}>
+          취소
+        </Button>
+        <Button
+          variant="primary"
+          size="md"
+          onClick={handleSubmit}
+          loading={submitting}
+          disabled={!valid || submitting}
+        >
+          {submitting ? '처리 중...' : '출금하기'}
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/src/styles/pages/mypage-wallet.css
+++ b/src/styles/pages/mypage-wallet.css
@@ -65,6 +65,75 @@
   border-radius: var(--r-md);
 }
 
+/* ── Charge / Withdraw action panels ───────────────────────────── */
+.wallet-action-panel {
+  margin-bottom: 24px;
+}
+.wallet-action-title {
+  font-family: var(--font);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
+  color: var(--text);
+  margin-bottom: 12px;
+}
+.wallet-action-quicks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+.wallet-quick {
+  padding: 6px 14px;
+  font-family: var(--font);
+  font-size: var(--fs-sm);
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-2);
+  cursor: pointer;
+}
+.wallet-quick:hover:not(:disabled) {
+  border-color: var(--brand);
+  color: var(--text);
+}
+.wallet-quick.active {
+  border-color: var(--brand);
+  background: var(--brand-light, var(--surface-2));
+  color: var(--brand);
+  font-weight: var(--fw-semibold);
+}
+.wallet-quick:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.wallet-action-input {
+  margin-bottom: 8px;
+}
+.wallet-withdraw-allbtn {
+  background: none;
+  border: none;
+  padding: 0;
+  margin-bottom: 12px;
+  font-family: var(--font);
+  font-size: var(--fs-xs);
+  color: var(--text-3);
+  cursor: pointer;
+  text-decoration: underline;
+}
+.wallet-withdraw-allbtn:hover:not(:disabled) {
+  color: var(--brand);
+}
+.wallet-withdraw-allbtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.wallet-action-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
 /* ── Transaction list shell (§12.4 row 7) ──────────────────────── */
 .tx-list-card {
   overflow: hidden;


### PR DESCRIPTION
## Summary
This PR adds wallet charge and withdraw functionality with dedicated UI panels, and refactors the tab management system to make route tabs (events/cart/mypage/login/seller/admin) dynamically closeable while keeping only the home tab pinned.

## Key Changes

### Wallet Charge & Withdraw Features
- **New `ChargePanel` component**: Allows users to charge their wallet with quick-select amounts (10K, 30K, 50K won) or custom input, integrating with Toss payment SDK
- **New `WithdrawPanel` component**: Enables wallet withdrawal with validation (minimum 1K won, max balance), includes "withdraw all" convenience button
- **Updated `WalletTab`**: Integrated charge/withdraw panels with mode state management and balance/transaction refresh on successful withdrawal
- **New styles** (`mypage-wallet.css`): Added styling for action panels, quick-select buttons, input fields, and footer buttons

### Tab Management Refactor
- **Dynamic route tabs**: Route tabs (events/cart/mypage/login/seller/admin) now appear in `openRouteTabs` state and are added lazily when users navigate to them
- **Closeable route tabs**: All route tabs except home are now user-dismissible via the close button; users can re-open them via ActivityBar, Sidebar, or command palette
- **Home tab pinned**: Only the home tab remains permanently pinned and non-closeable
- **Detail tab FIFO eviction**: Added `DETAIL_TAB_LIMIT` (5) to prevent unbounded growth of event detail tabs; oldest detail tabs are evicted when limit exceeded
- **Improved tab close logic**: Separated handling for detail tabs vs. route tabs with appropriate fallback navigation

### Minor Fixes
- **TicketCard refund logic**: Extended refund button visibility to include `UNKNOWN` ticket status alongside `ISSUED`, allowing the dialog to gate actual submission via `refundable` field

## Implementation Details
- Charge flow: `startWalletCharge()` → store context in sessionStorage → `requestTossCardPayment()` → redirect to success/fail URL
- Withdraw flow: `withdrawWallet()` → toast notification → refresh balance and transaction list on success
- Tab state is now split: `openRouteTabs` (closeable route keys) + `openDetailIds` (event detail IDs) + `HOME_TAB` (pinned)
- Route tabs are filtered based on auth state (login only for non-logged-in users, seller/admin only for appropriate roles)

https://claude.ai/code/session_01CaJ54xRTSvBZe3c74joHbY