### PR TITLE
Redesign dark theme color palette for improved contrast and cohesion

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -490,5 +490,5 @@ tr:hover td { background: var(--surface-2); }
 
 /* Backdrop blur in dark mode */
 [data-theme="dark"] header {
-  background: rgba(15, 23, 42, 0.92) !important;
+  background: rgba(11, 17, 32, 0.92) !important;
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -153,23 +153,56 @@
    ========================================================================== */
 
 [data-theme="dark"] {
-  /* Common — from prototype/tokens.css:117-131 */
-  --bg:          #0F172A;
-  --surface:     #1E293B;
-  --surface-2:   #263047;
-  --surface-3:   #334155;
-  --text:        #F1F5F9;
-  --text-2:      #CBD5E1;
-  --text-3:      #94A3B8;
-  --text-4:      #64748B;
-  --border:      #1E293B;
-  --border-2:    #334155;
-  --brand-light: rgba(79, 70, 229, 0.20);
+  /* Brand — indigo-500/400 for better legibility on dark surfaces. */
+  --brand:        #6366F1;
+  --brand-hover:  #818CF8;
+  --brand-light:  rgba(99, 102, 241, 0.18);
+  --brand-muted:  #4F46E5;
 
-  /* IDE — Terminal accent (from prototype/ide-theme.css:39-41) */
-  --term-green:      #00FF88;
-  --term-green-dim:  #00E07A;
-  --term-green-soft: rgba(0, 255, 136, 0.14);
+  /* Surfaces — cohesive slate family with clear elevation steps. */
+  --bg:        #0B1120;
+  --surface:   #141C2E;
+  --surface-2: #1C2540;
+  --surface-3: #283353;
+
+  /* Text */
+  --text:   #E6EAF2;
+  --text-2: #B6C0D2;
+  --text-3: #8390A6;
+  --text-4: #5A6478;
+
+  /* Borders — distinct from surface so card edges are visible. */
+  --border:   #232E48;
+  --border-2: #344162;
+
+  /* Semantic — tinted backgrounds (no light-mode pastels on dark). */
+  --success:      #34D399;
+  --success-bg:   rgba(16, 185, 129, 0.14);
+  --success-text: #6EE7B7;
+
+  --warning:      #FBBF24;
+  --warning-bg:   rgba(245, 158, 11, 0.14);
+  --warning-text: #FCD34D;
+
+  --danger:       #F87171;
+  --danger-bg:    rgba(239, 68, 68, 0.14);
+  --danger-text:  #FCA5A5;
+
+  --info:         #60A5FA;
+  --info-bg:      rgba(59, 130, 246, 0.14);
+  --info-text:    #93C5FD;
+
+  /* Shadows — deeper to read on dark. */
+  --shadow-sm:         0 1px 2px 0 rgb(0 0 0 / 0.36);
+  --shadow-md:         0 4px 8px -2px rgb(0 0 0 / 0.40);
+  --shadow-lg:         0 12px 24px -6px rgb(0 0 0 / 0.44);
+  --shadow-card-hover: 0 10px 28px rgba(0, 0, 0, 0.50);
+  --shadow-modal:      0 24px 60px rgba(0, 0, 0, 0.60);
+
+  /* IDE — Terminal accent (less neon, easier on the eyes). */
+  --term-green:      #4ADE80;
+  --term-green-dim:  #22C55E;
+  --term-green-soft: rgba(74, 222, 128, 0.14);
 
   /* IDE — Syntax (VS Code Dark+ tone) */
   --syn-keyword: #C586C0;
@@ -182,15 +215,15 @@
   --syn-type:    #4EC9B0;
   --syn-tag:     #569CD6;
 
-  /* IDE — Chrome */
-  --chrome:      #252526;
-  --chrome-2:    #333333;
-  --gutter:      #1E1E1E;
-  --gutter-text: #5A6270;
-  --editor-bg:   #1E1E1E;
-  --editor-line: rgba(255, 255, 255, 0.035);
-  --sidebar-bg:  #1A1A1C;
-  --status-bg:   #007ACC;
-  --status-text: #FFFFFF;
-  --minimap-bg:  #161618;
+  /* IDE — Chrome (unified with slate body, no more gray ↔ slate clash). */
+  --chrome:      #141C2E;
+  --chrome-2:    #1F2840;
+  --gutter:      #0E1426;
+  --gutter-text: #4A5570;
+  --editor-bg:   #0B1120;
+  --editor-line: rgba(99, 102, 241, 0.06);
+  --sidebar-bg:  #0D1424;
+  --status-bg:   #312E81;
+  --status-text: #E0E7FF;
+  --minimap-bg:  #0A0F1E;
 }


### PR DESCRIPTION
## Summary
Completely redesigned the dark theme color palette to improve visual hierarchy, contrast, and overall cohesion. The new palette uses a unified slate color family instead of mixing gray and slate tones, adds semantic color tokens for success/warning/danger/info states, and adjusts IDE chrome colors to match the body theme.

## Key Changes

- **Brand colors**: Updated from light indigo with opacity to solid indigo-500/400 variants (`#6366F1`, `#818CF8`) for better legibility on dark surfaces
- **Surface palette**: Refined slate family (`#0B1120` → `#283353`) with clearer elevation steps and better contrast
- **Text colors**: Adjusted for improved readability with new values ranging from `#E6EAF2` (primary) to `#5A6478` (quaternary)
- **Borders**: Made more distinct from surfaces (`#232E48`, `#344162`) so card edges are clearly visible
- **Semantic colors**: Added complete token sets for success, warning, danger, and info states with background and text variants
- **Shadows**: Increased opacity and depth for better visibility on dark backgrounds (0.36–0.60 opacity range)
- **Terminal accent**: Softened from neon green (`#00FF88`) to `#4ADE80` for reduced eye strain
- **IDE chrome**: Unified with body theme by replacing gray tones with slate variants, eliminating gray/slate color clash
- **Status bar**: Changed from bright blue (`#007ACC`) to indigo (`#312E81`) with light text (`#E0E7FF`) for consistency
- **Header backdrop**: Updated blur color to match new background (`#0B1120`)

## Implementation Details
All changes are CSS custom properties in the `[data-theme="dark"]` selector. The redesign maintains backward compatibility while providing a more cohesive, accessible dark mode experience with better contrast ratios and visual hierarchy.

https://claude.ai/code/session_014g9c1rPQGWChivbg59bJV9