### PR TITLE
fix(phase-1): landing/mypage/admin surface fixes

### DIFF
--- a/src/components/Layout/ActivityBar.tsx
+++ b/src/components/Layout/ActivityBar.tsx
@@ -4,9 +4,7 @@ import type { ActivityItem, NavigateFn, RouteKey } from './types';
 /**
  * Source: docs/archive/v2-cutover/layout.plan.md §3-5 + §6-6 a11y markup.
  *
- * Items list is a component-internal constant per §3-5. The settings button
- * is rendered separately after the spacer; it is intentionally not wired —
- * §3-5 leaves its click target undecided.
+ * Items list is a component-internal constant per §3-5.
  *
  * Auth gating per §4-2: cart/mypage clicks while logged-out route to login;
  * the cart badge only shows for logged-in users with at least one item.
@@ -86,9 +84,6 @@ export function ActivityBar({
         );
       })}
       <div className="act-spacer" />
-      <button type="button" className="act-btn" aria-label="설정">
-        <Icon name="settings" size={18} />
-      </button>
     </nav>
   );
 }

--- a/src/pages/Landing/hooks.ts
+++ b/src/pages/Landing/hooks.ts
@@ -446,18 +446,10 @@ export function useFeaturedEvents(): UseFeaturedEventsReturn {
         if (cancelled) return;
         setState({ status: 'success', data, fetchedAt: Date.now() });
       })
-      .catch((error) => {
+      .catch(() => {
+        // AI 추천 + 폴백 모두 실패 → 빈 리스트로 흡수 (에러 UI 노출 안 함).
         if (cancelled) return;
-        setState((prev) => ({
-          status: 'error',
-          error,
-          previous:
-        'data' in prev
-          ? prev.data
-          : 'previous' in prev
-            ? prev.previous
-            : undefined,
-        }));
+        setState({ status: 'success', data: [], fetchedAt: Date.now() });
       });
 
     return () => {

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -19,6 +19,8 @@
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { useChrome } from '@/components/Layout/LayoutChromeContext';
+
 import { Landing } from './Landing';
 import {
   useFeaturedEvents,
@@ -28,6 +30,7 @@ import {
 
 export default function LandingPage() {
   const navigate = useNavigate();
+  const { openPalette } = useChrome();
   const statsQuery = useLandingStats();
   const categoriesQuery = useLandingCategories();
   const featuredQuery = useFeaturedEvents();
@@ -39,6 +42,7 @@ export default function LandingPage() {
   return (
     <Landing
       onBrowseEvents={goEvents}
+      onOpenPalette={openPalette}
       onStart={goEvents}
       statsQuery={statsQuery}
       categoriesQuery={categoriesQuery}

--- a/src/pages/Landing/sections/HeroSection.tsx
+++ b/src/pages/Landing/sections/HeroSection.tsx
@@ -33,7 +33,7 @@ export interface HeroSectionProps {
   loop?: boolean;
 }
 
-const META_NOTES = ['// 키보드 친화적', '// 수수료 없음', '// 즉시 환불'];
+const META_NOTES = ['// 키보드 친화적', '// 즉시 환불'];
 
 export function HeroSection({
   onBrowseEvents,

--- a/src/pages/MyPage/tabs/Orders/OrdersTab.tsx
+++ b/src/pages/MyPage/tabs/Orders/OrdersTab.tsx
@@ -29,7 +29,7 @@ export function OrdersTab() {
       skeleton={<OrdersSkeleton rows={8} />}
       empty={{
         when: (data) => data.rows.length === 0,
-        render: <EmptyOrders onBrowse={() => navigate('/')} />,
+        render: <EmptyOrders onBrowse={() => navigate('/events')} />,
       }}
     >
       {(data) => (

--- a/src/pages/MyPage/tabs/Tickets/TicketsTab.tsx
+++ b/src/pages/MyPage/tabs/Tickets/TicketsTab.tsx
@@ -33,7 +33,7 @@ export function TicketsTab() {
       skeleton={<TicketsSkeleton count={6} />}
       empty={{
         when: (data) => data.tickets.length === 0,
-        render: <EmptyTickets onBrowse={() => navigate('/')} />,
+        render: <EmptyTickets onBrowse={() => navigate('/events')} />,
       }}
     >
       {(data) => (

--- a/src/pages/MyPage/tabs/Wallet/components/ChargePanel.tsx
+++ b/src/pages/MyPage/tabs/Wallet/components/ChargePanel.tsx
@@ -7,6 +7,8 @@ import { useToast } from '@/contexts/ToastContext';
 
 const QUICK_AMOUNTS = [10_000, 30_000, 50_000];
 const MIN_CHARGE = 1_000;
+const MAX_CHARGE = 50_000;
+const DAILY_LIMIT = 1_000_000;
 
 interface ChargePanelProps {
   onCancel: () => void;
@@ -19,11 +21,15 @@ export function ChargePanel({ onCancel }: ChargePanelProps) {
 
   const parsed = Number(amountText.replace(/[^\d]/g, ''));
   const amount = Number.isFinite(parsed) ? parsed : 0;
-  const valid = amount >= MIN_CHARGE;
+  const valid = amount >= MIN_CHARGE && amount <= MAX_CHARGE;
 
   const handleSubmit = async () => {
-    if (!valid) {
+    if (amount < MIN_CHARGE) {
       toast(`최소 ${MIN_CHARGE.toLocaleString()}원 이상 충전 가능합니다`, 'error');
+      return;
+    }
+    if (amount > MAX_CHARGE) {
+      toast(`1회 최대 ${MAX_CHARGE.toLocaleString()}원까지 충전 가능합니다`, 'error');
       return;
     }
     setSubmitting(true);
@@ -97,6 +103,12 @@ export function ChargePanel({ onCancel }: ChargePanelProps) {
           disabled={submitting}
         />
       </div>
+      <ul className="wallet-action-notice">
+        <li>1회 충전 금액: {MIN_CHARGE.toLocaleString()}원 ~ {MAX_CHARGE.toLocaleString()}원</li>
+        <li>일일 충전 한도: {DAILY_LIMIT.toLocaleString()}원</li>
+        <li>예치금 환불 수수료: 없음</li>
+        <li>예치금 유효기간: 무제한</li>
+      </ul>
       <div className="wallet-action-footer">
         <Button variant="ghost" size="md" onClick={onCancel} disabled={submitting}>
           취소

--- a/src/pages/admin/AdminEvents.tsx
+++ b/src/pages/admin/AdminEvents.tsx
@@ -1,7 +1,7 @@
 // ── AdminEvents ────────────────────────────────────────────────────────────────
 import { useEffect, useState, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { getAdminEvents, forcecancelEvent, getSellerApplications, processSellerApplication, runSettlementProcess, getAdminSettlements, cancelSettlement, paySettlement } from '../../api/admin.api'
+import { getAdminEvents, forcecancelEvent, getSellerApplications, processSellerApplication, getAdminSettlements, cancelSettlement, paySettlement } from '../../api/admin.api'
 import type { AdminEventItem, SellerApplicationListItem, AdminSettlementItem } from '../../api/types'
 import { useToast } from '../../contexts/ToastContext'
 
@@ -245,7 +245,6 @@ export function AdminSettlements() {
   const navigate = useNavigate()
   const [settlements, setSettlements] = useState<AdminSettlementItem[]>([])
   const [loading, setLoading] = useState(true)
-  const [running, setRunning] = useState(false)
   const [actionLoading, setActionLoading] = useState<string | null>(null)
   const [page, setPage] = useState(0)
   const [totalPages, setTotalPages] = useState(0)
@@ -294,27 +293,11 @@ export function AdminSettlements() {
     finally { setActionLoading(null) }
   }
 
-  const handleRun = async () => {
-    if (!confirm('정산 프로세스를 실행할까요? 이 작업은 되돌릴 수 없습니다.')) return
-    setRunning(true)
-    try {
-      await runSettlementProcess()
-      toast('정산 프로세스가 실행되었습니다', 'success')
-      fetchSettlements()
-    } catch { toast('실행 실패', 'error') }
-    finally { setRunning(false) }
-  }
-
   return (
     <div style={{ padding: '32px 36px' }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
-        <div>
-          <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 4 }}>정산서 관리</h1>
-          <p style={{ fontSize: 14, color: 'var(--text-3)' }}>총 {totalElements.toLocaleString()}건</p>
-        </div>
-        <button className="btn btn-primary" onClick={handleRun} disabled={running}>
-          {running ? '실행 중...' : '⚡ 정산 프로세스 실행'}
-        </button>
+      <div style={{ marginBottom: 24 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 4 }}>정산서 관리</h1>
+        <p style={{ fontSize: 14, color: 'var(--text-3)' }}>총 {totalElements.toLocaleString()}건</p>
       </div>
 
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 20 }}>

--- a/src/styles/pages/mypage-wallet.css
+++ b/src/styles/pages/mypage-wallet.css
@@ -109,6 +109,28 @@
 .wallet-action-input {
   margin-bottom: 8px;
 }
+.wallet-action-notice {
+  list-style: none;
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  background: var(--surface-2);
+  border: 1px solid var(--border-1);
+  border-radius: 6px;
+  font-size: var(--fs-xs);
+  color: var(--text-3);
+  line-height: 1.6;
+}
+.wallet-action-notice li {
+  position: relative;
+  padding-left: 12px;
+}
+.wallet-action-notice li::before {
+  content: '·';
+  position: absolute;
+  left: 4px;
+  top: 0;
+  color: var(--text-3);
+}
 .wallet-withdraw-allbtn {
   background: none;
   border: none;


### PR DESCRIPTION
- landing: drop "수수료 없음" hero meta, remove unused settings activity button, wire ⌘K palette via useChrome so the quick-search CTA opens the palette instead of falling back to /events, and absorb featured fetch failures as an empty list (stop showing the error UI when AI 추천 + fallback both fail).
- mypage: route empty-state "이벤트 둘러보기" buttons in Orders/Tickets to /events, and add a wallet charge notice block (1,000~50,000 per charge / 1,000,000 daily limit / 환불 수수료 없음 / 무제한) plus max-amount validation.
- admin: drop the manual "정산 프로세스 실행" button + handler/state/import per request to remove the auto-settlement runner.