### PR TITLE
fix(phase-2): event-detail status, qty limits, login pw toggle, cart …

### DIFF
--- a/src/api/cart.api.ts
+++ b/src/api/cart.api.ts
@@ -1,6 +1,6 @@
 import { apiClient, ApiResponse } from './client';
 import type {
-  CartItemRequest, 
+  CartItemRequest,
   CartResponse,
   CartItemQuantityRequest, CartItemQuantityResponse,
   CartItemDeleteResponse,
@@ -8,17 +8,47 @@ import type {
   AddCartItemResponse
 } from './types';
 
-export const addCartItem = (body: CartItemRequest) =>
-  apiClient.post<AddCartItemResponse>('/cart/items', body);
+// 장바구니가 변경됐음을 Layout 등 외부 구독자에 알리기 위한 이벤트 키.
+// useCartCount 가 listen 하여 즉시 refresh.
+export const CART_CHANGED_EVENT = 'cart:changed';
+
+const emitCartChanged = () => {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(CART_CHANGED_EVENT));
+  }
+};
+
+export const addCartItem = async (body: CartItemRequest) => {
+  const res = await apiClient.post<AddCartItemResponse>('/cart/items', body);
+  emitCartChanged();
+  return res;
+};
 
 export const getCart = () =>
   apiClient.get<CartResponse>('/cart');
 
-export const updateCartItemQuantity = (cartItemId: string, body: CartItemQuantityRequest) =>
-  apiClient.patch<CartItemQuantityResponse>(`/cart/items/${cartItemId}`, body);
+export const updateCartItemQuantity = async (
+  cartItemId: string,
+  body: CartItemQuantityRequest,
+) => {
+  const res = await apiClient.patch<CartItemQuantityResponse>(
+    `/cart/items/${cartItemId}`,
+    body,
+  );
+  emitCartChanged();
+  return res;
+};
 
-export const deleteCartItem = (cartItemId: string) =>
-  apiClient.delete<CartItemDeleteResponse>(`/cart/items/${cartItemId}`);
+export const deleteCartItem = async (cartItemId: string) => {
+  const res = await apiClient.delete<CartItemDeleteResponse>(
+    `/cart/items/${cartItemId}`,
+  );
+  emitCartChanged();
+  return res;
+};
 
-export const clearCart = () =>
-  apiClient.delete<CartClearResponse>('/cart');
+export const clearCart = async () => {
+  const res = await apiClient.delete<CartClearResponse>('/cart');
+  emitCartChanged();
+  return res;
+};

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -166,6 +166,11 @@ export interface EventDetailResponse {
   sellerNickname: string;
   thumbnailUrl?: string;
   createdAt: string;
+  // 백엔드가 내려주는 경우 한정 (옵셔널). 판매 예정 카운트다운 / 상태 분기에 사용.
+  saleStartAt?: string;
+  saleEndAt?: string;
+  // 1인당 최대 구매 수량 — 백엔드가 내려주면 QuantityStepper / 장바구니 검증에 사용.
+  maxQuantityPerUser?: number;
 }
 
 export interface EventSearchRequest {
@@ -239,9 +244,12 @@ export interface SellerEventDetailResponse {
   remainingQuantity: number;
   maxQuantityPerUser: number;
   eventDateTime: string;
+  saleStartAt?: string;
+  saleEndAt?: string;
   location: string;
   status: string;
   thumbnailUrl?: string;
+  imageUrls?: string[];
   createdAt: string;
 }
 

--- a/src/components/Layout/hooks/useCartCount.ts
+++ b/src/components/Layout/hooks/useCartCount.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { getCart } from '@/api/cart.api';
+import { CART_CHANGED_EVENT, getCart } from '@/api/cart.api';
 import { useAuth } from '@/contexts/AuthContext';
 
 /**
@@ -49,6 +49,17 @@ export function useCartCount(): UseCartCountResult {
     } else {
       setCount(0);
     }
+  }, [isLoggedIn, refresh]);
+
+  // cart.api 가 변경 시 dispatch 하는 'cart:changed' 이벤트 구독 — 페이지 내
+  // 장바구니 mutation(추가/수량 변경/삭제/clear) 후 뱃지가 즉시 갱신.
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    const handler = () => {
+      void refresh();
+    };
+    window.addEventListener(CART_CHANGED_EVENT, handler);
+    return () => window.removeEventListener(CART_CHANGED_EVENT, handler);
   }, [isLoggedIn, refresh]);
 
   return { count, refresh, isLoading };

--- a/src/pages/Cart/hooks.ts
+++ b/src/pages/Cart/hooks.ts
@@ -125,6 +125,22 @@ const applyRemove = (prev: CartVM, cartItemId: string): CartVM => {
 const isStatus = (err: unknown, status: number): boolean =>
   axios.isAxiosError(err) && err.response?.status === status;
 
+const extractErrorMessage = (err: unknown): string | null => {
+  if (!axios.isAxiosError(err)) return null;
+  const data = err.response?.data;
+  if (typeof data === 'object' && data !== null && 'message' in data) {
+    const msg = (data as { message?: unknown }).message;
+    return typeof msg === 'string' && msg.trim().length > 0 ? msg : null;
+  }
+  return null;
+};
+
+const isPerUserLimitMessage = (msg: string): boolean =>
+  msg.includes('1인당') ||
+  msg.includes('최대') ||
+  msg.includes('초과') ||
+  msg.toLowerCase().includes('max');
+
 export interface UseCartMutationsReturn {
   pendingItemIds: Set<string>;
   setQuantityDelta: (cartItemId: string, delta: 1 | -1) => Promise<void>;
@@ -154,12 +170,18 @@ export function useCartMutations(cart: UseCartReturn): UseCartMutationsReturn {
 
   const handleError = useCallback(
     (err: unknown, fallbackMsg: string) => {
+      const serverMsg = extractErrorMessage(err);
+      // 백엔드가 "1인당 최대 ~ 장까지 ..." 같은 메시지를 내려주면 그대로 노출.
+      if (serverMsg && isPerUserLimitMessage(serverMsg)) {
+        toast(serverMsg, 'error');
+        return;
+      }
       if (isStatus(err, 409)) {
         cart.refetch();
         toast('재고 상태가 변경되었습니다. 장바구니를 다시 불러옵니다.', 'error');
         return;
       }
-      toast(fallbackMsg, 'error');
+      toast(serverMsg ?? fallbackMsg, 'error');
     },
     [cart, toast],
   );

--- a/src/pages/EventDetail/adapters.ts
+++ b/src/pages/EventDetail/adapters.ts
@@ -15,8 +15,19 @@ const toTechStackNames = (items: TechStackItem[]): string[] =>
 const deriveCanBuy = (status: EventStatus, remaining: number): boolean =>
   status === 'ON_SALE' && remaining > 0;
 
+const isFutureIso = (iso?: string): boolean => {
+  if (!iso) return false;
+  const t = new Date(iso).getTime();
+  return Number.isFinite(t) && t > Date.now();
+};
+
 export const toEventDetailVM = (api: EventDetailResponse): EventDetailVM => {
-  const status = toStatus(api.status);
+  const rawStatus = toStatus(api.status);
+  // 상태 enum 이 ON_SALE 이어도 saleStartAt 이 미래면 판매 예정으로 표기.
+  const isScheduled =
+    rawStatus === 'SCHEDULED' ||
+    (rawStatus === 'ON_SALE' && isFutureIso(api.saleStartAt));
+  const status: EventStatus = isScheduled ? 'SCHEDULED' : rawStatus;
   const { dateLabel, timeLabel } = toDateTimeLabels(api.eventDateTime);
   return {
     eventId: api.eventId,
@@ -35,8 +46,12 @@ export const toEventDetailVM = (api: EventDetailResponse): EventDetailVM => {
     timeLabel,
     isFree: isFree(api.price),
     isLowStock: isLowStock(api.remainingQuantity),
-    isSoldOut: api.remainingQuantity === 0,
-    canBuy: deriveCanBuy(status, api.remainingQuantity),
+    isSoldOut: api.remainingQuantity === 0 && !isScheduled,
+    canBuy: !isScheduled && deriveCanBuy(rawStatus, api.remainingQuantity),
+    isScheduled,
+    saleStartAt: api.saleStartAt,
+    saleEndAt: api.saleEndAt,
+    maxQuantityPerUser: api.maxQuantityPerUser,
     thumbnailUrl: api.thumbnailUrl,
   };
 };

--- a/src/pages/EventDetail/components/InfoCard.tsx
+++ b/src/pages/EventDetail/components/InfoCard.tsx
@@ -7,13 +7,17 @@ export interface InfoCardProps {
   vm: EventDetailVM;
 }
 
-export function InfoCard({ vm }: InfoCardProps) {
-  const seatValue = vm.isSoldOut ? (
-    <span className="ed-seat-sold">매진되었습니다</span>
-  ) : (
-    `${vm.remainingQuantity.toLocaleString()}석`
-  );
+const seatLabel = (vm: InfoCardProps['vm']) => {
+  if (vm.isScheduled) return <span className="ed-seat-sold">판매 예정</span>;
+  if (vm.status === 'CANCELLED')
+    return <span className="ed-seat-sold">취소되었습니다</span>;
+  if (vm.status === 'ENDED' || vm.status === 'SALE_ENDED')
+    return <span className="ed-seat-sold">판매 종료</span>;
+  if (vm.isSoldOut) return <span className="ed-seat-sold">매진되었습니다</span>;
+  return `${vm.remainingQuantity.toLocaleString()}석`;
+};
 
+export function InfoCard({ vm }: InfoCardProps) {
   return (
     <Card padding="none" className="ed-info-card">
       <InfoRow
@@ -23,7 +27,7 @@ export function InfoCard({ vm }: InfoCardProps) {
       />
       <InfoRow icon="📍" label="장소" value={vm.location} />
       <InfoRow icon="👤" label="주최" value={vm.sellerNickname} />
-      <InfoRow icon="🎫" label="잔여 좌석" value={seatValue} />
+      <InfoRow icon="🎫" label="잔여 좌석" value={seatLabel(vm)} />
     </Card>
   );
 }

--- a/src/pages/EventDetail/components/PurchasePanel.tsx
+++ b/src/pages/EventDetail/components/PurchasePanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { useToast } from '@/contexts/ToastContext';
 import { Button } from '@/components/Button';
 import { Card } from '@/components/Card';
 import { Icon } from '@/components/Icon';
@@ -8,17 +9,54 @@ import { QuantityStepper } from '@/components/QuantityStepper';
 import { usePurchaseActions } from '../hooks';
 import type { EventDetailVM } from '../types';
 import { PriceSummary } from './PriceSummary';
+import { SaleCountdown } from './SaleCountdown';
 
 export interface PurchasePanelProps {
   vm: EventDetailVM;
 }
 
+const unavailableLabel = (vm: EventDetailVM): string => {
+  if (vm.isScheduled) return '판매 예정 이벤트입니다';
+  if (vm.status === 'CANCELLED') return '취소된 이벤트입니다';
+  if (vm.status === 'ENDED') return '종료된 이벤트입니다';
+  if (vm.status === 'SALE_ENDED') return '판매가 종료된 이벤트입니다';
+  if (vm.status === 'SOLD_OUT' || vm.isSoldOut) return '매진된 이벤트입니다';
+  return '구매할 수 없는 이벤트입니다';
+};
+
 export function PurchasePanel({ vm }: PurchasePanelProps) {
+  const { toast } = useToast();
   const [qty, setQty] = useState(1);
   const { busy, addToCart, buyNow } = usePurchaseActions(vm.eventId);
 
   const showQuantity = !vm.isFree && vm.canBuy;
   const isBusy = busy !== null;
+  const showCountdown = vm.isScheduled && Boolean(vm.saleStartAt);
+  const perUserMax = vm.maxQuantityPerUser;
+  const effectiveMax =
+    perUserMax !== undefined
+      ? Math.min(vm.remainingQuantity, perUserMax)
+      : vm.remainingQuantity;
+
+  const handleQtyChange = (next: number) => {
+    if (perUserMax !== undefined && next > perUserMax) {
+      toast(
+        `1인당 최대 ${perUserMax.toLocaleString()}장까지 구매 가능합니다.`,
+        'error',
+      );
+      setQty(perUserMax);
+      return;
+    }
+    if (next > vm.remainingQuantity) {
+      toast(
+        `잔여 수량을 초과했습니다. 최대 ${vm.remainingQuantity.toLocaleString()}장까지 구매 가능합니다.`,
+        'error',
+      );
+      setQty(vm.remainingQuantity);
+      return;
+    }
+    setQty(next);
+  };
 
   return (
     <div className="ed-purchase-sticky">
@@ -29,14 +67,21 @@ export function PurchasePanel({ vm }: PurchasePanelProps) {
             {vm.isFree ? '무료' : `${vm.price.toLocaleString()}원`}
           </div>
 
+          {showCountdown && (
+            <div className="ed-countdown-wrap">
+              <div className="ed-countdown__label">판매 시작까지</div>
+              <SaleCountdown targetIso={vm.saleStartAt!} />
+            </div>
+          )}
+
           {showQuantity && (
             <div className="ed-quantity">
               <div className="ed-quantity__label">수량</div>
               <QuantityStepper
                 value={qty}
-                onChange={setQty}
+                onChange={handleQtyChange}
                 min={1}
-                max={vm.remainingQuantity}
+                max={effectiveMax}
                 size="md"
                 disabled={isBusy}
               />
@@ -69,7 +114,7 @@ export function PurchasePanel({ vm }: PurchasePanelProps) {
               </>
             ) : (
               <Button variant="ghost" size="lg" full disabled>
-                매진된 이벤트입니다
+                {unavailableLabel(vm)}
               </Button>
             )}
           </div>

--- a/src/pages/EventDetail/components/SaleCountdown.tsx
+++ b/src/pages/EventDetail/components/SaleCountdown.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+
+interface SaleCountdownProps {
+  targetIso: string;
+  onElapsed?: () => void;
+}
+
+const pad2 = (n: number) => String(n).padStart(2, '0');
+
+const computeRemaining = (target: number) => {
+  const ms = target - Date.now();
+  if (ms <= 0) return null;
+  const total = Math.floor(ms / 1000);
+  const days = Math.floor(total / 86_400);
+  const hours = Math.floor((total % 86_400) / 3_600);
+  const minutes = Math.floor((total % 3_600) / 60);
+  const seconds = total % 60;
+  return { days, hours, minutes, seconds };
+};
+
+export function SaleCountdown({ targetIso, onElapsed }: SaleCountdownProps) {
+  const target = new Date(targetIso).getTime();
+  const valid = Number.isFinite(target);
+  const [remaining, setRemaining] = useState(() =>
+    valid ? computeRemaining(target) : null,
+  );
+
+  useEffect(() => {
+    if (!valid) return;
+    const tick = () => {
+      const next = computeRemaining(target);
+      setRemaining(next);
+      if (next === null) onElapsed?.();
+    };
+    tick();
+    const id = window.setInterval(tick, 1000);
+    return () => window.clearInterval(id);
+  }, [target, valid, onElapsed]);
+
+  if (!valid || !remaining) return null;
+  const { days, hours, minutes, seconds } = remaining;
+
+  return (
+    <div className="ed-countdown" role="timer" aria-label="판매 시작까지 남은 시간">
+      <span className="ed-countdown__cell">
+        <span className="ed-countdown__num">{days}</span>
+        <span className="ed-countdown__unit">일</span>
+      </span>
+      <span className="ed-countdown__cell">
+        <span className="ed-countdown__num">{pad2(hours)}</span>
+        <span className="ed-countdown__unit">시</span>
+      </span>
+      <span className="ed-countdown__cell">
+        <span className="ed-countdown__num">{pad2(minutes)}</span>
+        <span className="ed-countdown__unit">분</span>
+      </span>
+      <span className="ed-countdown__cell">
+        <span className="ed-countdown__num">{pad2(seconds)}</span>
+        <span className="ed-countdown__unit">초</span>
+      </span>
+    </div>
+  );
+}

--- a/src/pages/EventDetail/types.ts
+++ b/src/pages/EventDetail/types.ts
@@ -19,6 +19,10 @@ export interface EventDetailVM {
   isLowStock: boolean;
   isSoldOut: boolean;
   canBuy: boolean;
+  isScheduled: boolean;
+  saleStartAt?: string;
+  saleEndAt?: string;
+  maxQuantityPerUser?: number;
   thumbnailUrl?: string;
 }
 

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import type { FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { Card, Button, Input } from '@/components';
 import type { LoginFieldErrors, LoginFormState } from './hooks';
 
@@ -84,6 +84,8 @@ function LoginForm({
   onChangePassword,
   onSubmit,
 }: LoginFormBlockProps) {
+  // 토글은 폼 로컬 상태 — 로그인 실패로 errors.form 이 갱신돼도 영향 없음.
+  const [showPw, setShowPw] = useState(false);
   return (
     <form className="login-form" onSubmit={onSubmit} noValidate>
       {errors.form && (
@@ -103,13 +105,25 @@ function LoginForm({
       />
       <Input
         label="비밀번호"
-        type="password"
+        type={showPw ? 'text' : 'password'}
         autoComplete="current-password"
         placeholder="비밀번호 입력"
         value={password}
         onChange={e => onChangePassword(e.target.value)}
         error={errors.password}
         disabled={loading}
+        hintEnd={
+          <button
+            type="button"
+            className="login-pw-toggle"
+            onClick={() => setShowPw((v) => !v)}
+            disabled={loading}
+            aria-pressed={showPw}
+            aria-label={showPw ? '비밀번호 숨기기' : '비밀번호 보기'}
+          >
+            {showPw ? '숨기기' : '보기'}
+          </button>
+        }
       />
       <Button
         type="submit"

--- a/src/pages/_shared/eventFormat.ts
+++ b/src/pages/_shared/eventFormat.ts
@@ -1,6 +1,7 @@
 import type { EventStatus } from '@/types/event';
 
 const KNOWN_STATUSES: readonly EventStatus[] = [
+  'SCHEDULED',
   'ON_SALE',
   'SOLD_OUT',
   'SALE_ENDED',
@@ -10,10 +11,16 @@ const KNOWN_STATUSES: readonly EventStatus[] = [
 
 const pad2 = (n: number) => String(n).padStart(2, '0');
 
-export const toStatus = (raw: string): EventStatus =>
-  (KNOWN_STATUSES as readonly string[]).includes(raw)
-    ? (raw as EventStatus)
-    : 'ENDED';
+// 백엔드가 'DRAFT' / 'UPCOMING' 등으로 내려주는 케이스도 판매 예정으로 흡수.
+const SCHEDULED_ALIASES = new Set(['DRAFT', 'UPCOMING', 'NOT_OPEN', 'PRE_SALE']);
+
+export const toStatus = (raw: string): EventStatus => {
+  if ((KNOWN_STATUSES as readonly string[]).includes(raw)) {
+    return raw as EventStatus;
+  }
+  if (SCHEDULED_ALIASES.has(raw)) return 'SCHEDULED';
+  return 'ENDED';
+};
 
 export const toDateTimeLabels = (
   iso: string,

--- a/src/pages/seller/SellerEventCreate.tsx
+++ b/src/pages/seller/SellerEventCreate.tsx
@@ -654,6 +654,9 @@ export function SellerEventEdit() {
     getSellerEventDetail(id)
       .then((res) => {
         const d = res.data.data;
+        // datetime-local input 은 'YYYY-MM-DDTHH:mm' 16자만 허용 — ISO 끝의 :ss/Z/.fff 잘라냄.
+        const toLocalInput = (iso?: string): string =>
+          iso ? iso.slice(0, 16) : "";
         setInitial({
           title: d.title,
           description: d.description,
@@ -662,11 +665,11 @@ export function SellerEventEdit() {
           price: String(d.price),
           totalQuantity: String(d.totalQuantity),
           maxQuantityPerUser: String(d.maxQuantityPerUser),
-          eventDateTime: d.eventDateTime.slice(0, 16),
-          saleStartAt: "",
-          saleEndAt: "",
+          eventDateTime: toLocalInput(d.eventDateTime),
+          saleStartAt: toLocalInput(d.saleStartAt),
+          saleEndAt: toLocalInput(d.saleEndAt),
           location: d.location,
-          imageUrls: [],
+          imageUrls: d.imageUrls ?? (d.thumbnailUrl ? [d.thumbnailUrl] : []),
         });
       })
       .catch(() => toast("이벤트 로드 실패", "error"));

--- a/src/styles/pages/event-detail.css
+++ b/src/styles/pages/event-detail.css
@@ -225,6 +225,38 @@
   flex-direction: column;
   gap: 8px;
 }
+.ed-countdown-wrap {
+  margin: 12px 0 4px;
+  padding: 10px 12px;
+  background: var(--editor-line);
+  border: 1px solid var(--border-1, var(--border));
+  border-radius: 8px;
+}
+.ed-countdown__label {
+  font-size: 12px;
+  color: var(--text-3);
+  margin-bottom: 6px;
+}
+.ed-countdown {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  font-variant-numeric: tabular-nums;
+}
+.ed-countdown__cell {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 2px;
+}
+.ed-countdown__num {
+  font-size: 18px;
+  font-weight: var(--fw-semibold);
+  color: var(--text-1);
+}
+.ed-countdown__unit {
+  font-size: 12px;
+  color: var(--text-3);
+}
 .ed-notice {
   margin-top: 16px;
   padding: 12px 14px;

--- a/src/styles/pages/login.css
+++ b/src/styles/pages/login.css
@@ -143,3 +143,22 @@
   pointer-events: none;
   opacity: 0.6;
 }
+
+/* ── Password show/hide toggle ─────────────────────────────────── */
+.login-pw-toggle {
+  background: none;
+  border: none;
+  padding: 0 6px;
+  font-family: var(--font);
+  font-size: var(--fs-xs);
+  color: var(--text-3);
+  cursor: pointer;
+  text-decoration: underline;
+}
+.login-pw-toggle:hover:not(:disabled) {
+  color: var(--brand);
+}
+.login-pw-toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,1 +1,7 @@
-export type EventStatus = 'ON_SALE' | 'SOLD_OUT' | 'SALE_ENDED' | 'CANCELLED' | 'ENDED';
+export type EventStatus =
+  | 'SCHEDULED'
+  | 'ON_SALE'
+  | 'SOLD_OUT'
+  | 'SALE_ENDED'
+  | 'CANCELLED'
+  | 'ENDED';


### PR DESCRIPTION
…sync

- event-detail: split the unavailable-state copy so 미오픈/판매 종료/취소/매진을 따로 표기, recognize SCHEDULED (with DRAFT/UPCOMING aliases) and surface a live SaleCountdown when saleStartAt is in the future. Add maxQuantityPerUser to the VM and clamp QuantityStepper + toast a "1인당 최대 N장" alert when the user tries to exceed it; toast "잔여 수량 초과" when stock is the binding limit.
- cart: when PATCH /cart/items returns a per-user-limit message, surface the server message instead of the generic 409 stock-changed toast.
- login: keep the password show/hide toggle as form-local state so a login failure that re-renders errors no longer collapses it; add an underlined 보기/숨기기 button via Input hintEnd.
- seller event edit: preload saleStartAt / saleEndAt (and existing image urls) from the detail response instead of hardcoding empty strings — also slice ISO to the 16-char datetime-local format.
- cart badge sync: dispatch a 'cart:changed' window event from cart api wrappers (add/update/delete/clear) and have useCartCount listen so the activity-bar badge updates immediately after in-page mutations without waiting for login transitions.