### PR TITLE
feat(event-list): tech stack filter chips alongside category

### DIFF
--- a/src/pages/EventList/EventList.tsx
+++ b/src/pages/EventList/EventList.tsx
@@ -14,6 +14,7 @@ import {
   type UseEventsReturn,
   useEventListFilters,
   useEvents,
+  useTechStacks,
 } from './hooks';
 
 import { EVENT_CATEGORY_LABELS } from '@/pages/_shared/category';
@@ -32,13 +33,19 @@ function getDisplayPage(query: UseEventsReturn) {
 export default function EventList() {
   const navigate = useNavigate();
   const { filters, setFilters } = useEventListFilters();
-  const stackNameToId = useMemo(() => new Map<string, number>(), []);
-  const query = useEvents(filters, stackNameToId);
+  const techStacks = useTechStacks();
+  const stackNames = useMemo(
+    () => techStacks.items.map((s) => s.name),
+    [techStacks.items],
+  );
+  const query = useEvents(filters, techStacks.byName);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   const displayPage = getDisplayPage(query);
   const hasActiveFilters =
-    filters.keyword.trim() !== '' || filters.category !== DEFAULT_CATEGORY;
+    filters.keyword.trim() !== '' ||
+    filters.category !== DEFAULT_CATEGORY ||
+    filters.stack !== '';
 
   const onResetFilters = () => {
     setFilters({ keyword: '', category: DEFAULT_CATEGORY, stack: '', page: 0 });
@@ -65,6 +72,9 @@ export default function EventList() {
           category={filters.category}
           onCategoryChange={(next) => setFilters({ category: next })}
           categories={CATEGORIES}
+          stack={filters.stack}
+          onStackChange={(next) => setFilters({ stack: next })}
+          stacks={stackNames}
           searchInputRef={searchInputRef}
         />
         <ResultHeader

--- a/src/pages/EventList/adapters.ts
+++ b/src/pages/EventList/adapters.ts
@@ -67,8 +67,8 @@ export const toEventListPage = (res: EventListResponse): EventListPage => ({
   hasNext: res.page < res.totalPages - 1,
 });
 
-/* 백엔드가 keyword + category 동시 적용을 무시하는 경우를 대비한 클라이언트
- * safety net. 활성 필터가 모두 적용된 결과만 노출하도록 items 만 좁힘 —
+/* 백엔드가 keyword + category + techStacks 동시 적용을 무시하는 경우를 대비한
+ * 클라이언트 safety net. 활성 필터가 모두 적용된 결과만 노출하도록 items 만 좁힘 —
  * totalElements / page 는 서버 값 유지. */
 export const applyClientSideFilters = (
   page: EventListPage,
@@ -77,11 +77,13 @@ export const applyClientSideFilters = (
   const hasCategory =
     filters.category !== DEFAULT_CATEGORY && filters.category !== '';
   const hasKeyword = filters.keyword.trim() !== '';
-  if (!hasCategory && !hasKeyword) return page;
+  const hasStack = filters.stack !== '';
+  if (!hasCategory && !hasKeyword && !hasStack) return page;
   const kw = filters.keyword.trim().toLowerCase();
   const items = page.items.filter((e) => {
     if (hasCategory && e.category !== filters.category) return false;
     if (hasKeyword && !e.title.toLowerCase().includes(kw)) return false;
+    if (hasStack && !e.techStacks.includes(filters.stack)) return false;
     return true;
   });
   return { ...page, items };

--- a/src/pages/EventList/components/SearchAndFilters.tsx
+++ b/src/pages/EventList/components/SearchAndFilters.tsx
@@ -9,8 +9,14 @@ export interface SearchAndFiltersProps {
   category: string;
   onCategoryChange: (next: string) => void;
   categories: readonly string[];
+  stack: string;
+  onStackChange: (next: string) => void;
+  stacks: readonly string[];
   searchInputRef?: RefObject<HTMLInputElement>;
 }
+
+const STACK_ALL = '';
+const STACK_ALL_LABEL = '전체';
 
 export function SearchAndFilters({
   keyword,
@@ -18,6 +24,9 @@ export function SearchAndFilters({
   category,
   onCategoryChange,
   categories,
+  stack,
+  onStackChange,
+  stacks,
   searchInputRef,
 }: SearchAndFiltersProps) {
   return (
@@ -56,6 +65,29 @@ export function SearchAndFilters({
           ))}
         </div>
       </div>
+
+      {stacks.length > 0 && (
+        <div className="el-filter-group">
+          <div className="el-filter-label">기술 스택</div>
+          <div className="el-filter-chips">
+            <Chip
+              active={stack === STACK_ALL}
+              onClick={() => onStackChange(STACK_ALL)}
+            >
+              {STACK_ALL_LABEL}
+            </Chip>
+            {stacks.map((s) => (
+              <Chip
+                key={s}
+                active={stack === s}
+                onClick={() => onStackChange(stack === s ? STACK_ALL : s)}
+              >
+                {s}
+              </Chip>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/EventList/hooks.ts
+++ b/src/pages/EventList/hooks.ts
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { apiClient, unwrapApiData, type ApiResponse } from '@/api/client';
-import type { EventListResponse } from '@/api/types';
+import { getTechStacks } from '@/api/auth.api';
+import { extractTechStacks } from '@/api/techStacks';
+import type { EventListResponse, TechStackItem } from '@/api/types';
 import type { EventListFilters, EventListPage, EventsQuery } from './types';
 import {
   DEFAULT_CATEGORY,
@@ -100,7 +102,14 @@ export function useEvents(
   filters: EventListFilters,
   stackNameToId: Map<string, number>,
 ): UseEventsReturn {
-  const key = serializeFilters(filters);
+  // stack 필터가 활성일 때는 stackNameToId 가 채워졌는지에 따라 fetch 결과가
+  // 달라지므로 (마스터 미로딩 시 techStacks 파라미터 없이 요청), 마스터 사이즈를
+  // 캐시 키에 포함시켜 마스터 도착 후 재페치되도록 한다.
+  const stackKeyFragment =
+    filters.stack !== ''
+      ? `|smap=${stackNameToId.size > 0 ? stackNameToId.get(filters.stack) ?? 'miss' : 'pending'}`
+      : '';
+  const key = serializeFilters(filters) + stackKeyFragment;
   const [state, setState] = useState<EventsQuery>(() => {
     const hit = cache.get(key);
     return hit
@@ -151,4 +160,61 @@ export function useEvents(
   }, [key]);
 
   return { ...state, refetch };
+}
+
+/* ── 기술 스택 마스터 ──────────────────────────────────────────────
+ * 모듈 캐시 + in-flight 공유 — 같은 페이지 내 여러 컴포넌트가 호출해도 1회만 페치.
+ * 응답 셰이프가 v1/v2 사이에 흔들렸던 이력 때문에 extractTechStacks 로 정규화. */
+let techStacksCache: TechStackItem[] | null = null;
+let techStacksInFlight: Promise<TechStackItem[]> | null = null;
+
+export interface UseTechStacksReturn {
+  items: TechStackItem[];
+  byName: Map<string, number>;
+  isLoading: boolean;
+}
+
+const fetchTechStacks = async (): Promise<TechStackItem[]> => {
+  const res = await getTechStacks();
+  return extractTechStacks(res.data);
+};
+
+export function useTechStacks(): UseTechStacksReturn {
+  const [items, setItems] = useState<TechStackItem[]>(
+    () => techStacksCache ?? [],
+  );
+  const [isLoading, setIsLoading] = useState(
+    () => techStacksCache === null,
+  );
+
+  useEffect(() => {
+    if (techStacksCache !== null) return;
+    let cancelled = false;
+    setIsLoading(true);
+    const promise =
+      techStacksInFlight ?? (techStacksInFlight = fetchTechStacks());
+    promise
+      .then((list) => {
+        techStacksCache = list;
+        techStacksInFlight = null;
+        if (cancelled) return;
+        setItems(list);
+        setIsLoading(false);
+      })
+      .catch(() => {
+        techStacksInFlight = null;
+        if (cancelled) return;
+        // 실패는 빈 배열 — 칩이 안 그려질 뿐 검색/카테고리는 정상 동작.
+        setItems([]);
+        setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const byName = new Map<string, number>(
+    items.map((s) => [s.name, s.techStackId]),
+  );
+  return { items, byName, isLoading };
 }


### PR DESCRIPTION
기존 EventList 의 stackNameToId 가 빈 Map 으로 고정돼 있어 filters.stack 이 백엔드에 절대 도달하지 못하던 버그를 해소하면서, v1 부터 존재하던 /tech-stacks 마스터를 SearchAndFilters 에 칩 그룹으로 노출.

- useTechStacks: 모듈 캐시 + in-flight 공유로 페이지 단위 1회 fetch. 응답 셰이프 변형(v1/v2 차이)은 기존 extractTechStacks 로 정규화하고 실패 시 빈 배열 — 검색/카테고리 동작에는 영향 없음.
- EventList: useTechStacks 의 byName 을 그대로 useEvents 에 전달해 toFilterRequest 가 techStacks 파라미터를 정상으로 합쳐 보내도록 함. hasActiveFilters / 리셋 동작에 stack 도 반영.
- useEvents 캐시 키: 마스터 미로딩 시(0건) 와 도착 후를 구분하기 위해 |smap=pending|miss|<id> 프래그먼트 추가. 마스터가 늦게 도착해도 자동으로 재페치되어 stack 필터가 반영된다.
- applyClientSideFilters: 백엔드가 techStacks 를 무시할 가능성을 대비한 safety net 으로 EventVM.techStacks 배열을 기준으로 한 번 더 좁힘.
- SearchAndFilters: "기술 스택" 그룹 추가. "전체" + 각 스택 칩, 같은 칩 재클릭 시 해제. stacks 가 비었으면 그룹 자체를 안 그림.