### PR TITLE
fix(dark-mode): align tokens to VS Code Dark+ palette spec

### DIFF
--- a/src/styles/components/chip.css
+++ b/src/styles/components/chip.css
@@ -45,10 +45,10 @@
 }
 
 /* Brand-on-translucent reads poorly on dark; lighten foreground.
- * VS Code uses a sky-tinted blue for active selections. */
+ * Lavender (indigo-300) per dark palette spec. */
 [data-theme="dark"] .chip.is-active,
 [data-theme="dark"] .chip.is-active:hover {
-  color: #75BEFF;
+  color: #A5B4FC;
 }
 
 .chip-count {

--- a/src/styles/components/ide-chrome.css
+++ b/src/styles/components/ide-chrome.css
@@ -578,10 +578,10 @@ button.side-header {
 }
 
 /* ─── Dark overrides ──────────────────────────────────── */
-/* brand-light 위 텍스트 가독성 보정. VS Code 선택 강조 톤. */
+/* brand-light 위 텍스트 가독성 보정. 라벤더(indigo-200) 톤. */
 [data-theme="dark"] .palette-item:hover,
 [data-theme="dark"] .palette-item.sel {
-  color: #75BEFF;
+  color: #C7D2FE;
 }
 
 /* ─── Responsive ──────────────────────────────────────── */

--- a/src/styles/components/status-chip.css
+++ b/src/styles/components/status-chip.css
@@ -33,9 +33,17 @@
 .status-chip-free .status-chip-dot { background: var(--brand); }
 .status-chip-end  .status-chip-dot { background: var(--text-4); }
 
-/* tokens.css does not override --danger-bg/--danger-text in dark mode, so
- * sold needs its own dark envelope (mirrors prototype line 531). */
+/* Dark-only chip overrides — emerald for ok, red for sold, slate for end.
+ * Mirrors the dark palette spec (status chip section). */
+[data-theme="dark"] .status-chip-ok {
+  background: rgba(16, 185, 129, 0.15);
+  color: #4ADE80;
+}
 [data-theme="dark"] .status-chip-sold {
   background: rgba(239, 68, 68, 0.15);
   color: #F87171;
+}
+[data-theme="dark"] .status-chip-end {
+  background: rgba(148, 163, 184, 0.12);
+  color: #94A3B8;
 }

--- a/src/styles/pages/landing.css
+++ b/src/styles/pages/landing.css
@@ -89,6 +89,23 @@
   }
 }
 
+/* Dark: GitHub-Dark tones for the terminal box (separate from editor surface).
+   Spec'd as 0D1117/30363D bg+border, 161B22 header, C9D1D9 body, 8B949E out. */
+[data-theme="dark"] .typed-terminal {
+  background: #0D1117;
+  border-color: #30363D;
+}
+[data-theme="dark"] .typed-terminal-bar {
+  background: #161B22;
+  border-bottom-color: #30363D;
+}
+[data-theme="dark"] .typed-terminal-cmd {
+  color: #C9D1D9;
+}
+[data-theme="dark"] .typed-terminal-out {
+  color: #8B949E;
+}
+
 /* ----- Hero section --------------------------------------------------------
    2-col grid (carry-over from prototype/Landing.jsx L182). Right column 은
    TypedTerminal slot 만 가지므로 추가 스타일 불필요.

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -156,22 +156,21 @@
 
 [data-theme="dark"] {
   /* Common — VS Code Dark+ palette
-     Surfaces use VS Code's neutral grays (no slate/blue cast):
-       editor #1E1E1E, sidebar #252526, hover #2A2D2E, active #37373D.
-     Text follows VS Code's foreground tokens (#CCCCCC family).
-     Borders use #3C3C3C / #474747 (panel.border, contrastBorder).        */
+     Surfaces follow a 4-step depth: 1E1E1E → 252526 → 2D2D30 → 3E3E42.
+     Text follows a 4-step hierarchy: D4D4D4 → B8B8B8 → 858585 → 6A6A6A.
+     Borders 3E3E42 (default) / 505050 (emphasis).                        */
   --bg:          #1E1E1E;
   --surface:     #252526;
   --surface-2:   #2D2D30;
-  --surface-3:   #37373D;
-  --text:        #E5E5E5;
-  --text-1:      #E5E5E5;
-  --text-2:      #CCCCCC;
-  --text-3:      #9D9D9D;
-  --text-4:      #6E7681;
-  --border:      #3C3C3C;
-  --border-1:    #3C3C3C;
-  --border-2:    #474747;
+  --surface-3:   #3E3E42;
+  --text:        #D4D4D4;
+  --text-1:      #D4D4D4;
+  --text-2:      #B8B8B8;
+  --text-3:      #858585;
+  --text-4:      #6A6A6A;
+  --border:      #3E3E42;
+  --border-1:    #3E3E42;
+  --border-2:    #505050;
   --brand:       #0E7DEC;   /* VS Code activity-bar blue */
   --brand-hover: #1F8CEF;
   --brand-light: rgba(14, 125, 236, 0.18);
@@ -212,20 +211,20 @@
   --syn-number:  #B5CEA8;
   --syn-fn:      #DCDCAA;
   --syn-prop:    #9CDCFE;
-  --syn-comment: #6A9955;
-  --syn-punct:   #D4D4D4;
+  --syn-comment: #6B7280;
+  --syn-punct:   #94A3B8;
   --syn-type:    #4EC9B0;
   --syn-tag:     #569CD6;
 
   /* IDE — Chrome */
-  --chrome:      #2D2D30;   /* tab strip / title bar */
-  --chrome-2:    #252526;   /* inactive tab */
+  --chrome:      #252526;   /* tab strip / title bar (= surface) */
+  --chrome-2:    #333333;   /* hover / inactive tab */
   --gutter:      #1E1E1E;
-  --gutter-text: #858585;   /* VS Code editorLineNumber.foreground */
+  --gutter-text: #5A6270;   /* line-number color */
   --editor-bg:   #1E1E1E;
   --editor-line: rgba(255, 255, 255, 0.04);
-  --sidebar-bg:  #252526;   /* sideBar.background */
+  --sidebar-bg:  #1A1A1C;   /* sidebar / JSON card header */
   --status-bg:   #007ACC;
   --status-text: #FFFFFF;
-  --minimap-bg:  #1E1E1E;
+  --minimap-bg:  #161618;
 }


### PR DESCRIPTION
Brings text/border/chrome/syntax/sidebar/minimap tokens in line with the canonical dark palette (4-step surface depth, 4-step text hierarchy, GitHub-Dark tones for the typed terminal box). Adds dark-only ok/end status-chip envelopes and switches chip.active / palette hover to lavender per spec.