### PR TITLE
fix(error-toast): surface server error message in toasts/popups

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -140,6 +140,21 @@ export interface ApiResponse<T> {
 }
 
 /**
+ * 서버 에러 응답의 `message` 필드를 안전하게 추출합니다.
+ * axios 에러가 아니거나 `message`가 비어 있으면 null.
+ * 호출부는 보통 `serverMsg ?? fallbackMsg` 형태로 토스트에 노출합니다.
+ */
+export function extractErrorMessage(err: unknown): string | null {
+  if (!axios.isAxiosError(err)) return null;
+  const data = err.response?.data;
+  if (typeof data === 'object' && data !== null && 'message' in data) {
+    const msg = (data as { message?: unknown }).message;
+    return typeof msg === 'string' && msg.trim().length > 0 ? msg : null;
+  }
+  return null;
+}
+
+/**
  * 백엔드 응답이 `{ code, message, data }` 래퍼이거나 raw payload일 수 있어
  * 두 케이스를 모두 안전하게 언랩합니다.
  */

--- a/src/pages/Cart/hooks.ts
+++ b/src/pages/Cart/hooks.ts
@@ -21,6 +21,7 @@ import {
 } from '@/api/cart.api';
 import {
   apiClient,
+  extractErrorMessage,
   idempotencyConfig,
   unwrapApiData,
   type ApiResponse,
@@ -124,16 +125,6 @@ const applyRemove = (prev: CartVM, cartItemId: string): CartVM => {
 
 const isStatus = (err: unknown, status: number): boolean =>
   axios.isAxiosError(err) && err.response?.status === status;
-
-const extractErrorMessage = (err: unknown): string | null => {
-  if (!axios.isAxiosError(err)) return null;
-  const data = err.response?.data;
-  if (typeof data === 'object' && data !== null && 'message' in data) {
-    const msg = (data as { message?: unknown }).message;
-    return typeof msg === 'string' && msg.trim().length > 0 ? msg : null;
-  }
-  return null;
-};
 
 const isPerUserLimitMessage = (msg: string): boolean =>
   msg.includes('1인당') ||

--- a/src/pages/Cart/index.tsx
+++ b/src/pages/Cart/index.tsx
@@ -15,6 +15,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { addCartItem } from '@/api/cart.api';
+import { extractErrorMessage } from '@/api/client';
 import { PaymentModal } from '@/components/PaymentModal';
 import { useToast } from '@/contexts/ToastContext';
 
@@ -59,8 +60,8 @@ export default function CartPage() {
         await addCartItem({ eventId, quantity: 1 });
         toast('장바구니에 담았습니다.', 'success');
         cart.refetch();
-      } catch {
-        toast('장바구니에 담지 못했습니다.', 'error');
+      } catch (err) {
+        toast(extractErrorMessage(err) ?? '장바구니에 담지 못했습니다.', 'error');
       } finally {
         const after = new Set(pendingRecRef.current);
         after.delete(eventId);

--- a/src/pages/EventDetail/components/EventHeader.tsx
+++ b/src/pages/EventDetail/components/EventHeader.tsx
@@ -4,6 +4,7 @@ import type { EventStatus } from '@/types/event';
 import type { EventDetailVM } from '../types';
 
 const STATUS_DISPLAY: Record<EventStatus, { variant: StatusVariant; label: string }> = {
+  SCHEDULED: { variant: 'ok', label: '판매 예정' },
   ON_SALE: { variant: 'ok', label: '판매중' },
   SOLD_OUT: { variant: 'sold', label: '매진' },
   SALE_ENDED: { variant: 'end', label: '판매 종료' },

--- a/src/pages/EventDetail/hooks.ts
+++ b/src/pages/EventDetail/hooks.ts
@@ -3,7 +3,12 @@ import { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { addCartItem } from '@/api/cart.api';
-import { apiClient, unwrapApiData, type ApiResponse } from '@/api/client';
+import {
+  apiClient,
+  extractErrorMessage,
+  unwrapApiData,
+  type ApiResponse,
+} from '@/api/client';
 import type { EventDetailResponse } from '@/api/types';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/contexts/ToastContext';
@@ -242,8 +247,12 @@ export function usePurchaseActions(eventId: string): UsePurchaseActionsReturn {
       try {
         await addCartItem({ eventId, quantity });
         toast('장바구니에 담았습니다', 'success');
-      } catch {
-        toast('장바구니 담기에 실패했습니다. 잠시 후 다시 시도해주세요.', 'error');
+      } catch (err) {
+        const serverMsg = extractErrorMessage(err);
+        toast(
+          serverMsg ?? '장바구니 담기에 실패했습니다. 잠시 후 다시 시도해주세요.',
+          'error',
+        );
       } finally {
         setBusy(null);
       }
@@ -262,8 +271,12 @@ export function usePurchaseActions(eventId: string): UsePurchaseActionsReturn {
       try {
         await addCartItem({ eventId, quantity });
         navigate('/cart');
-      } catch {
-        toast('오류가 발생했습니다. 잠시 후 다시 시도해주세요.', 'error');
+      } catch (err) {
+        const serverMsg = extractErrorMessage(err);
+        toast(
+          serverMsg ?? '오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+          'error',
+        );
         setBusy(null);
       }
     },

--- a/src/pages/MyPage/shared/RefundDialog.tsx
+++ b/src/pages/MyPage/shared/RefundDialog.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useId, useState } from 'react';
-import axios from 'axios';
 import { Button } from '@/components/Button';
 import {
   getRefundInfo,
   refundOrder,
   refundTicketByPg,
 } from '@/api/refunds.api';
+import { extractErrorMessage } from '@/api/client';
 import type { RefundInfoResponse } from '@/api/types';
 import { useToast } from '@/contexts/ToastContext';
 
@@ -82,14 +82,10 @@ export function RefundDialog({ open, target, onClose, onSuccess }: RefundDialogP
       onSuccess();
       onClose();
     } catch (err: unknown) {
-      const message =
-        axios.isAxiosError(err) &&
-        typeof err.response?.data === 'object' &&
-        err.response?.data !== null &&
-        'message' in (err.response.data as Record<string, unknown>)
-          ? String((err.response.data as { message?: string }).message ?? '')
-          : '';
-      toast(message || '환불 처리 중 오류가 발생했습니다.', 'error');
+      toast(
+        extractErrorMessage(err) ?? '환불 처리 중 오류가 발생했습니다.',
+        'error',
+      );
     } finally {
       setSubmitting(false);
     }

--- a/src/pages/MyPage/tabs/Settings/SettingsTab.tsx
+++ b/src/pages/MyPage/tabs/Settings/SettingsTab.tsx
@@ -15,6 +15,7 @@ import {
   updateProfile,
   withdrawUser,
 } from '@/api/auth.api';
+import { extractErrorMessage } from '@/api/client';
 import { extractTechStacks } from '@/api/techStacks';
 import type { TechStackItem } from '@/api/types';
 import { Button, Card, Chip, Input } from '@/components';
@@ -54,7 +55,12 @@ export function SettingsTab() {
   useEffect(() => {
     getTechStacks()
       .then((res) => setTechStackOptions(extractTechStacks(res.data)))
-      .catch(() => toast('기술 스택 목록을 불러오지 못했습니다.', 'error'));
+      .catch((err) =>
+        toast(
+          extractErrorMessage(err) ?? '기술 스택 목록을 불러오지 못했습니다.',
+          'error',
+        ),
+      );
   }, [toast]);
 
   const toggleStack = (id: number) => {
@@ -74,8 +80,8 @@ export function SettingsTab() {
       });
       await refresh();
       toast('프로필이 수정되었습니다.', 'success');
-    } catch {
-      toast('프로필 수정에 실패했습니다.', 'error');
+    } catch (err) {
+      toast(extractErrorMessage(err) ?? '프로필 수정에 실패했습니다.', 'error');
     } finally {
       setSavingProfile(false);
     }
@@ -100,8 +106,12 @@ export function SettingsTab() {
       });
       toast('비밀번호가 변경되었습니다.', 'success');
       setPw({ currentPassword: '', newPassword: '', confirmPassword: '' });
-    } catch {
-      toast('비밀번호 변경에 실패했습니다. 현재 비밀번호를 확인하세요.', 'error');
+    } catch (err) {
+      toast(
+        extractErrorMessage(err) ??
+          '비밀번호 변경에 실패했습니다. 현재 비밀번호를 확인하세요.',
+        'error',
+      );
     } finally {
       setSavingPw(false);
     }
@@ -114,8 +124,8 @@ export function SettingsTab() {
       toast('탈퇴되었습니다.', 'success');
       logout();
       navigate('/login');
-    } catch {
-      toast('탈퇴에 실패했습니다.', 'error');
+    } catch (err) {
+      toast(extractErrorMessage(err) ?? '탈퇴에 실패했습니다.', 'error');
     }
   };
 

--- a/src/pages/MyPage/tabs/Wallet/components/ChargePanel.tsx
+++ b/src/pages/MyPage/tabs/Wallet/components/ChargePanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import axios from 'axios';
 import { Button, Card, Input } from '@/components';
 import { startWalletCharge } from '@/api/wallet.api';
+import { extractErrorMessage } from '@/api/client';
 import { requestTossCardPayment } from '@/components/PaymentModal/tossSdk';
 import { useToast } from '@/contexts/ToastContext';
 
@@ -42,14 +42,11 @@ export function ChargePanel({ onCancel }: ChargePanelProps) {
       chargeId = data.chargeId;
       chargedAmount = data.amount;
     } catch (err: unknown) {
-      const message =
-        axios.isAxiosError(err) &&
-        typeof err.response?.data === 'object' &&
-        err.response?.data !== null &&
-        'message' in (err.response.data as Record<string, unknown>)
-          ? String((err.response.data as { message?: string }).message ?? '')
-          : '';
-      toast(message || '충전 요청 실패. 잠시 후 다시 시도해주세요.', 'error');
+      toast(
+        extractErrorMessage(err) ??
+          '충전 요청 실패. 잠시 후 다시 시도해주세요.',
+        'error',
+      );
       setSubmitting(false);
       return;
     }

--- a/src/pages/MyPage/tabs/Wallet/components/WithdrawPanel.tsx
+++ b/src/pages/MyPage/tabs/Wallet/components/WithdrawPanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import axios from 'axios';
 import { Button, Card, Input } from '@/components';
 import { withdrawWallet } from '@/api/wallet.api';
+import { extractErrorMessage } from '@/api/client';
 import { useToast } from '@/contexts/ToastContext';
 
 const MIN_WITHDRAW = 1_000;
@@ -36,14 +36,7 @@ export function WithdrawPanel({ balance, onCancel, onSuccess }: WithdrawPanelPro
       toast('출금 요청이 완료되었습니다', 'success');
       onSuccess();
     } catch (err: unknown) {
-      const message =
-        axios.isAxiosError(err) &&
-        typeof err.response?.data === 'object' &&
-        err.response?.data !== null &&
-        'message' in (err.response.data as Record<string, unknown>)
-          ? String((err.response.data as { message?: string }).message ?? '')
-          : '';
-      toast(message || '출금 처리에 실패했습니다', 'error');
+      toast(extractErrorMessage(err) ?? '출금 처리에 실패했습니다', 'error');
     } finally {
       setSubmitting(false);
     }

--- a/src/pages/Payment.tsx
+++ b/src/pages/Payment.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { readyPayment } from '../api/payments.api'
 import { getWalletBalance } from '../api/wallet.api'
-import { unwrapApiData } from '../api/client'
+import { extractErrorMessage, unwrapApiData } from '../api/client'
 import { useToast } from '../contexts/ToastContext'
 
 // `window.TossPayments` 의 타입 선언은 `src/components/PaymentModal/tossSdk.ts`
@@ -79,7 +79,7 @@ export default function Payment() {
         })
       }
     } catch (e: unknown) {
-      toast('결제 처리 중 오류가 발생했습니다', 'error')
+      toast(extractErrorMessage(e) ?? '결제 처리 중 오류가 발생했습니다', 'error')
     } finally {
       setLoading(false)
     }

--- a/src/pages/PaymentCallback/hooks.ts
+++ b/src/pages/PaymentCallback/hooks.ts
@@ -19,6 +19,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 
 import { confirmPayment, failPayment } from '@/api/payments.api';
+import { extractErrorMessage } from '@/api/client';
 
 import type {
   ConfirmQuery,
@@ -50,13 +51,8 @@ const readPaymentContext = (): SessionPaymentContext | null => {
 const clearPaymentContext = () =>
   sessionStorage.removeItem(PAYMENT_CONTEXT_KEY);
 
-const errorMessageOf = (e: unknown): string => {
-  const fallback = '결제 승인 처리에 실패했습니다.';
-  if (typeof e !== 'object' || e === null) return fallback;
-  const data = (e as { response?: { data?: { message?: string } } }).response
-    ?.data;
-  return data?.message ?? fallback;
-};
+const errorMessageOf = (e: unknown): string =>
+  extractErrorMessage(e) ?? '결제 승인 처리에 실패했습니다.';
 
 // ── usePaymentConfirm ────────────────────────────────────────────────────────
 

--- a/src/pages/SellerApply.tsx
+++ b/src/pages/SellerApply.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { applyForSeller, getSellerApplicationStatus } from '../api/auth.api'
+import { extractErrorMessage } from '../api/client'
 import type { SellerApplicationStatusResponse } from '../api/types'
 import { useToast } from '../contexts/ToastContext'
 
@@ -37,7 +38,9 @@ export default function SellerApply() {
       toast('판매자 신청이 완료되었습니다!', 'success')
       const res = await getSellerApplicationStatus()
       setAppStatus(res.data.data)
-    } catch { toast('신청 실패. 다시 시도해주세요.', 'error') }
+    } catch (err) {
+      toast(extractErrorMessage(err) ?? '신청 실패. 다시 시도해주세요.', 'error')
+    }
     finally { setSubmitting(false) }
   }
 

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { signup, createProfile, getTechStacks, reissueToken } from '../api/auth.api'
+import { extractErrorMessage } from '../api/client'
 import { extractTechStacks } from '../api/techStacks'
 import { POSITION_LABELS, POSITION_OPTIONS } from '../constants/profile'
 import { useAuth } from '../contexts/AuthContext'
@@ -39,8 +40,12 @@ export default function Signup() {
         if (stacks.length === 0) throw new Error('NO_TECH_STACKS')
         setTechStacks(stacks)
       })
-      .catch(() => {
-        toast('기술 스택 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.', 'error')
+      .catch((err) => {
+        toast(
+          extractErrorMessage(err) ??
+            '기술 스택 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
+          'error',
+        )
       })
   }, [toast])
 
@@ -128,8 +133,8 @@ export default function Signup() {
     }).filter(Boolean),
   },
 })
-  } catch {
-    toast('프로필 저장 실패', 'error')
+  } catch (err) {
+    toast(extractErrorMessage(err) ?? '프로필 저장 실패', 'error')
   } finally {
     setLoading(false)
   }

--- a/src/pages/SocialProfileSetup.tsx
+++ b/src/pages/SocialProfileSetup.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { createProfile, getTechStacks } from '../api/auth.api'
+import { extractErrorMessage } from '../api/client'
 import { extractTechStacks } from '../api/techStacks'
 import { POSITION_LABELS, POSITION_OPTIONS } from '../constants/profile'
 import { useAuth } from '../contexts/AuthContext'
@@ -33,8 +34,12 @@ export default function SocialProfileSetup() {
         if (stacks.length === 0) throw new Error('NO_TECH_STACKS')
         setTechStacks(stacks)
       })
-      .catch(() => {
-        toast('기술 스택 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.', 'error')
+      .catch((err) => {
+        toast(
+          extractErrorMessage(err) ??
+            '기술 스택 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.',
+          'error',
+        )
       })
   }, [navigate, toast])
 
@@ -80,8 +85,11 @@ export default function SocialProfileSetup() {
           }).filter(Boolean),
         },
       })
-    } catch {
-      toast('프로필 저장에 실패했습니다. 다시 시도해주세요.', 'error')
+    } catch (err) {
+      toast(
+        extractErrorMessage(err) ?? '프로필 저장에 실패했습니다. 다시 시도해주세요.',
+        'error',
+      )
     } finally {
       setLoading(false)
     }

--- a/src/pages/WalletChargeSuccess.tsx
+++ b/src/pages/WalletChargeSuccess.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useSearchParams, useNavigate } from 'react-router-dom'
 import { confirmWalletCharge } from '../api/wallet.api'
+import { extractErrorMessage } from '../api/client'
 
 export default function WalletChargeSuccess() {
   const [searchParams] = useSearchParams()
@@ -29,9 +30,11 @@ export default function WalletChargeSuccess() {
         sessionStorage.removeItem('wallet_charge_context')
         setStatus('success')
         setTimeout(() => navigate('/mypage?tab=wallet', { replace: true }), 1500)
-      } catch (e: any) {
+      } catch (e: unknown) {
         setStatus('error')
-        const msg = e?.response?.data?.message ?? e?.message ?? '충전 승인 처리에 실패했습니다.'
+        const msg =
+          extractErrorMessage(e) ??
+          (e instanceof Error ? e.message : '충전 승인 처리에 실패했습니다.')
         setErrorMsg(msg)
         sessionStorage.removeItem('wallet_charge_context')
       }

--- a/src/pages/admin/AdminApplications.tsx
+++ b/src/pages/admin/AdminApplications.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { getSellerApplications, processSellerApplication } from '../../api/admin.api'
+import { extractErrorMessage } from '../../api/client'
 import type { SellerApplicationListResponse } from '../../api/types'
 
 export default function AdminApplications() {
@@ -9,7 +10,7 @@ export default function AdminApplications() {
   const fetchApplications = () => {
     getSellerApplications()
     .then(r => setApplications(r.data))
-    .catch(() => alert('로드 실패'))
+    .catch((err) => alert(extractErrorMessage(err) ?? '로드 실패'))
     .finally(() => setLoading(false))
   }
 
@@ -21,7 +22,7 @@ export default function AdminApplications() {
       await processSellerApplication(applicationId, decision)
       alert('처리 완료')
       fetchApplications()
-    } catch { alert('처리 실패') }
+    } catch (err) { alert(extractErrorMessage(err) ?? '처리 실패') }
   }
 
   if (loading) return <div style={{ display: 'flex', justifyContent: 'center', padding: 60 }}><div className="spinner" /></div>

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { getAdminDashboard } from '../../api/admin.api'
+import { extractErrorMessage } from '../../api/client'
 import type { AdminDashboardResponse } from '../../api/types'
 import { useToast } from '../../contexts/ToastContext'
 
@@ -12,7 +13,7 @@ export default function AdminDashboard() {
   useEffect(() => {
     getAdminDashboard()
       .then(r => setStats(r.data.data))
-      .catch(() => toast('로드 실패', 'error'))
+      .catch((err) => toast(extractErrorMessage(err) ?? '로드 실패', 'error'))
       .finally(() => setLoading(false))
   }, [])
 

--- a/src/pages/admin/AdminEvents.tsx
+++ b/src/pages/admin/AdminEvents.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { getAdminEvents, forcecancelEvent, getSellerApplications, processSellerApplication, getAdminSettlements, cancelSettlement, paySettlement } from '../../api/admin.api'
+import { extractErrorMessage } from '../../api/client'
 import type { AdminEventItem, SellerApplicationListItem, AdminSettlementItem } from '../../api/types'
 import { useToast } from '../../contexts/ToastContext'
 
@@ -26,7 +27,7 @@ export function AdminEvents() {
     try {
       const res = await getAdminEvents({ keyword: keyword || undefined, page: 0, size: 50 })
       setEvents(res.data.content)
-    } catch { toast('로드 실패', 'error') }
+    } catch (err) { toast(extractErrorMessage(err) ?? '로드 실패', 'error') }
     finally { setLoading(false) }
   }, [keyword])
 
@@ -39,7 +40,7 @@ export function AdminEvents() {
       await forcecancelEvent(eventId)
       toast('관리자 이벤트 취소 및 환불 요청이 접수되었습니다', 'success')
       fetchEvents()
-    } catch { toast('처리 실패', 'error') }
+    } catch (err) { toast(extractErrorMessage(err) ?? '처리 실패', 'error') }
     finally { setActionLoading(null) }
   }
 
@@ -126,7 +127,7 @@ export function AdminApplications() {
     try {
       const res = await getSellerApplications()
       setApps(res.data.data.content)
-    } catch { toast('로드 실패', 'error') }
+    } catch (err) { toast(extractErrorMessage(err) ?? '로드 실패', 'error') }
     finally { setLoading(false) }
   }
 
@@ -140,7 +141,7 @@ export function AdminApplications() {
       await processSellerApplication(id, approve)
       toast(`${label} 처리되었습니다`, 'success')
       fetchApps()
-    } catch { toast('처리 실패', 'error') }
+    } catch (err) { toast(extractErrorMessage(err) ?? '처리 실패', 'error') }
     finally { setActionLoading(null) }
   }
 
@@ -258,7 +259,7 @@ export function AdminSettlements() {
       setSettlements(res.data.content)
       setTotalPages(res.data.totalPages)
       setTotalElements(res.data.totalElements)
-    } catch { toast('로드 실패', 'error') }
+    } catch (err) { toast(extractErrorMessage(err) ?? '로드 실패', 'error') }
     finally { setLoading(false) }
   }, [yearMonth, page])
 
@@ -277,7 +278,7 @@ export function AdminSettlements() {
       await cancelSettlement(settlementId)
       toast('정산서가 취소되었습니다', 'success')
       fetchSettlements()
-    } catch { toast('취소 처리 실패', 'error') }
+    } catch (err) { toast(extractErrorMessage(err) ?? '취소 처리 실패', 'error') }
     finally { setActionLoading(null) }
   }
 
@@ -289,7 +290,7 @@ export function AdminSettlements() {
       await paySettlement(settlementId)
       toast('정산금 지급이 완료되었습니다', 'success')
       fetchSettlements()
-    } catch { toast('지급 처리 실패', 'error') }
+    } catch (err) { toast(extractErrorMessage(err) ?? '지급 처리 실패', 'error') }
     finally { setActionLoading(null) }
   }
 

--- a/src/pages/admin/AdminSettlementDetail.tsx
+++ b/src/pages/admin/AdminSettlementDetail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { getAdminSettlementDetail } from '../../api/admin.api'
+import { extractErrorMessage } from '../../api/client'
 import type { AdminSettlementDetailResponse } from '../../api/types'
 import { useToast } from '../../contexts/ToastContext'
 
@@ -30,7 +31,7 @@ export default function AdminSettlementDetail() {
     setLoading(true)
     getAdminSettlementDetail(settlementId)
       .then(res => setDetail(res.data))
-      .catch(() => toast('로드 실패', 'error'))
+      .catch((err) => toast(extractErrorMessage(err) ?? '로드 실패', 'error'))
       .finally(() => setLoading(false))
   }, [settlementId])
 

--- a/src/pages/admin/AdminTechStacks.tsx
+++ b/src/pages/admin/AdminTechStacks.tsx
@@ -6,6 +6,7 @@ import {
   reindexAdminTechStacks,
   updateAdminTechStack,
 } from '../../api/admin.api'
+import { extractErrorMessage } from '../../api/client'
 import type { AdminTechStackItem } from '../../api/types'
 import { useToast } from '../../contexts/ToastContext'
 
@@ -25,8 +26,8 @@ export default function AdminTechStacks() {
     try {
       const res = await getAdminTechStacks()
       setTechStacks((res.data ?? []).slice().sort((a, b) => a.id - b.id))
-    } catch {
-      toast('기술 스택을 불러오지 못했습니다', 'error')
+    } catch (err) {
+      toast(extractErrorMessage(err) ?? '기술 스택을 불러오지 못했습니다', 'error')
     } finally {
       setLoading(false)
     }
@@ -47,8 +48,8 @@ export default function AdminTechStacks() {
       setNewName('')
       toast('기술 스택이 생성되었습니다', 'success')
       fetchTechStacks()
-    } catch {
-      toast('생성에 실패했습니다', 'error')
+    } catch (err) {
+      toast(extractErrorMessage(err) ?? '생성에 실패했습니다', 'error')
     } finally {
       setCreating(false)
     }
@@ -77,8 +78,8 @@ export default function AdminTechStacks() {
       toast('기술 스택이 수정되었습니다', 'success')
       cancelEdit()
       fetchTechStacks()
-    } catch {
-      toast('수정에 실패했습니다', 'error')
+    } catch (err) {
+      toast(extractErrorMessage(err) ?? '수정에 실패했습니다', 'error')
     } finally {
       setActionId(null)
     }
@@ -92,8 +93,8 @@ export default function AdminTechStacks() {
       toast('기술 스택이 삭제되었습니다', 'success')
       if (editingId === id) cancelEdit()
       fetchTechStacks()
-    } catch {
-      toast('삭제에 실패했습니다', 'error')
+    } catch (err) {
+      toast(extractErrorMessage(err) ?? '삭제에 실패했습니다', 'error')
     } finally {
       setActionId(null)
     }
@@ -107,8 +108,8 @@ export default function AdminTechStacks() {
       await reindexAdminTechStacks()
       toast('기술 스택 재색인을 요청했습니다', 'success')
       fetchTechStacks()
-    } catch {
-      toast('재색인 요청에 실패했습니다', 'error')
+    } catch (err) {
+      toast(extractErrorMessage(err) ?? '재색인 요청에 실패했습니다', 'error')
     } finally {
       setReindexing(false)
     }

--- a/src/pages/admin/AdminUsers.tsx
+++ b/src/pages/admin/AdminUsers.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from 'react'
 import { getAdminUsers, updateUserStatus, updateUserRole } from '../../api/admin.api'
+import { extractErrorMessage } from '../../api/client'
 import type { UserListItem } from '../../api/types'
 import { useToast } from '../../contexts/ToastContext'
 
@@ -28,7 +29,7 @@ export default function AdminUsers() {
     try {
       const res = await getAdminUsers({ keyword: keyword || undefined, role: roleFilter || undefined, page: 0, size: 50 })
       setUsers(res.data.content)
-    } catch { toast('로드 실패', 'error') }
+    } catch (err) { toast(extractErrorMessage(err) ?? '로드 실패', 'error') }
     finally { setLoading(false) }
   }, [keyword, roleFilter])
 
@@ -43,7 +44,7 @@ export default function AdminUsers() {
       await updateUserStatus(user.userId, { status: newStatus })
       toast(`${label} 처리되었습니다`, 'success')
       fetchUsers()
-    } catch { toast('처리 실패', 'error') }
+    } catch (err) { toast(extractErrorMessage(err) ?? '처리 실패', 'error') }
     finally { setActionLoading(null) }
   }
 
@@ -54,7 +55,7 @@ export default function AdminUsers() {
       await updateUserRole(user.userId, { role: newRole })
       toast('권한이 변경되었습니다', 'success')
       fetchUsers()
-    } catch { toast('처리 실패', 'error') }
+    } catch (err) { toast(extractErrorMessage(err) ?? '처리 실패', 'error') }
     finally { setActionLoading(null) }
   }
 

--- a/src/pages/seller/SellerDashboard.tsx
+++ b/src/pages/seller/SellerDashboard.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { getSellerEvents, stopSellerEvent } from '../../api/events.api'
 import { getSellerEventRefundsPage } from '../../api/refunds.api'
+import { extractErrorMessage } from '../../api/client'
 import type { SellerEventItem } from '../../api/types'
 import { useToast } from '../../contexts/ToastContext'
 
@@ -29,8 +30,8 @@ export default function SellerDashboard() {
     try {
       const res = await getSellerEvents({ page: 0, size: 50 })
       setAllEvents(res.data.data.content)
-    } catch {
-      toast('이벤트 통계 로드 실패', 'error')
+    } catch (err) {
+      toast(extractErrorMessage(err) ?? '이벤트 통계 로드 실패', 'error')
     }
   }, [toast])
 
@@ -43,8 +44,8 @@ export default function SellerDashboard() {
         size: 50,
       })
       setTabEvents(res.data.data.content)
-    } catch {
-      toast('이벤트 로드 실패', 'error')
+    } catch (err) {
+      toast(extractErrorMessage(err) ?? '이벤트 로드 실패', 'error')
     } finally {
       setLoading(false)
     }
@@ -75,7 +76,7 @@ export default function SellerDashboard() {
       // 통계와 현재 탭 목록 모두 갱신.
       void fetchAllEvents()
       void fetchTabEvents(activeTab)
-    } catch { toast('처리 실패', 'error') }
+    } catch (err) { toast(extractErrorMessage(err) ?? '처리 실패', 'error') }
   }
 
   // Quick stats — 상단 박스는 항상 전체 기준.

--- a/src/pages/seller/SellerEventCreate.tsx
+++ b/src/pages/seller/SellerEventCreate.tsx
@@ -7,6 +7,7 @@ import {
   uploadEventImage,
 } from "../../api/events.api";
 import { getTechStacks } from "../../api/auth.api";
+import { extractErrorMessage } from "../../api/client";
 import { extractTechStacks } from "../../api/techStacks";
 import { useToast } from "../../contexts/ToastContext";
 
@@ -672,7 +673,7 @@ export function SellerEventEdit() {
           imageUrls: d.imageUrls ?? (d.thumbnailUrl ? [d.thumbnailUrl] : []),
         });
       })
-      .catch(() => toast("이벤트 로드 실패", "error"));
+      .catch((err) => toast(extractErrorMessage(err) ?? "이벤트 로드 실패", "error"));
   }, [id]);
 
   const handleSubmit = async (form: EventForm) => {

--- a/src/pages/seller/SellerEventDetail.tsx
+++ b/src/pages/seller/SellerEventDetail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { getSellerEventDetail, getSellerEventSummary, getSellerEventParticipants } from '../../api/events.api'
+import { extractErrorMessage } from '../../api/client'
 import type { SellerEventDetailResponse, SellerEventSummaryResponse, ParticipantItem } from '../../api/types'
 import { useToast } from '../../contexts/ToastContext'
 
@@ -24,7 +25,7 @@ export default function SellerEventDetail() {
       setEvent(ev.data.data)
       setSummary(sum.data.data)
       setParticipants(part.data.content)
-    }).catch(() => toast('로드 실패', 'error'))
+    }).catch((err) => toast(extractErrorMessage(err) ?? '로드 실패', 'error'))
     .finally(() => setLoading(false))
   }, [id])
 

--- a/src/pages/seller/SellerSettlement.tsx
+++ b/src/pages/seller/SellerSettlement.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useMemo } from 'react'
 import { getSellerSettlementByMonth, getSellerSettlementPreview } from '../../api/seller.api'
+import { extractErrorMessage } from '../../api/client'
 import type { SettlementMonthResponse } from '../../api/types'
 import { useToast } from '../../contexts/ToastContext'
 
@@ -70,7 +71,12 @@ export default function SellerSettlement() {
 
     req
       .then(r => setData(r.data))
-      .catch(() => toast('정산 데이터를 불러오지 못했습니다', 'error'))
+      .catch((err) =>
+        toast(
+          extractErrorMessage(err) ?? '정산 데이터를 불러오지 못했습니다',
+          'error',
+        ),
+      )
       .finally(() => setLoading(false))
   }, [selectedIdx])
 


### PR DESCRIPTION
- src/api/client.ts에 공용 extractErrorMessage 헬퍼 추가
- Cart/EventDetail/Wallet/Refund/Payment 등 7곳의 인라인 추출 중복 제거
- 일반/admin/seller 전 페이지 catch 블록에 `serverMsg ?? fallback` 패턴 적용 (Login/Signup의 회원가입 호출은 user enumeration 방지로 의도적 제외)
- EventHeader STATUS_DISPLAY 맵에 SCHEDULED 키 추가하여 추천 카드 → 이벤트 상세 진입 시 destructure 크래시 해결