### PR TITLE
fix(events): debounce search input and trust ES results

### DIFF
--- a/src/pages/EventList/EventList.tsx
+++ b/src/pages/EventList/EventList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { EmptyStackTrace } from './components/EmptyStackTrace';
@@ -17,7 +17,10 @@ import {
   useTechStacks,
 } from './hooks';
 
+import { useDebounce } from '@/hooks/useDebounce';
 import { EVENT_CATEGORY_LABELS } from '@/pages/_shared/category';
+
+const SEARCH_DEBOUNCE_MS = 400;
 
 const CATEGORIES = ['전체', ...EVENT_CATEGORY_LABELS] as const;
 
@@ -40,6 +43,29 @@ export default function EventList() {
   );
   const query = useEvents(filters, techStacks.byName);
   const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // 입력은 로컬에서만 즉시 반영하고, 디바운스된 값만 URL/필터로 푸시 —
+  // 매 키스트로크마다 ES 요청이 폭주하던 문제 완화.
+  const [searchInput, setSearchInput] = useState(filters.keyword);
+  const debouncedSearch = useDebounce(searchInput, SEARCH_DEBOUNCE_MS);
+  const lastPushedKeywordRef = useRef(filters.keyword);
+
+  useEffect(() => {
+    if (debouncedSearch === filters.keyword) return;
+    lastPushedKeywordRef.current = debouncedSearch;
+    setFilters({ keyword: debouncedSearch });
+    // setFilters 는 useSearchParams 기반으로 안정적이지 않을 수 있으나
+    // 필요한 트리거는 debouncedSearch 변경뿐.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch]);
+
+  // 외부에서 filters.keyword 가 바뀐 경우 (리셋, 뒤로가기 등) 입력값 동기화.
+  // 우리가 방금 푸시한 값이면 무시해 사용자의 추가 타이핑을 덮지 않도록.
+  useEffect(() => {
+    if (filters.keyword === lastPushedKeywordRef.current) return;
+    lastPushedKeywordRef.current = filters.keyword;
+    setSearchInput(filters.keyword);
+  }, [filters.keyword]);
 
   const displayPage = getDisplayPage(query);
   const hasActiveFilters =
@@ -67,8 +93,8 @@ export default function EventList() {
       <div className="editor-body el-page">
         <Hero totalCount={displayPage?.totalElements ?? 0} />
         <SearchAndFilters
-          keyword={filters.keyword}
-          onKeywordChange={(next) => setFilters({ keyword: next })}
+          keyword={searchInput}
+          onKeywordChange={setSearchInput}
           category={filters.category}
           onCategoryChange={(next) => setFilters({ category: next })}
           categories={CATEGORIES}

--- a/src/pages/EventList/adapters.ts
+++ b/src/pages/EventList/adapters.ts
@@ -67,22 +67,20 @@ export const toEventListPage = (res: EventListResponse): EventListPage => ({
   hasNext: res.page < res.totalPages - 1,
 });
 
-/* 백엔드가 keyword + category + techStacks 동시 적용을 무시하는 경우를 대비한
- * 클라이언트 safety net. 활성 필터가 모두 적용된 결과만 노출하도록 items 만 좁힘 —
- * totalElements / page 는 서버 값 유지. */
+/* keyword 검색은 ES 결과를 그대로 신뢰한다 (제목/스택 외 토큰까지 매칭하므로
+ * 클라이언트의 단순 includes 매칭으로 좁히면 정상 결과를 떨어뜨림).
+ * 카테고리/스택은 백엔드가 keyword 와 동시 적용을 무시하는 케이스를 대비한
+ * safety net 으로 유지 — totalElements / page 는 서버 값 그대로. */
 export const applyClientSideFilters = (
   page: EventListPage,
   filters: EventListFilters,
 ): EventListPage => {
   const hasCategory =
     filters.category !== DEFAULT_CATEGORY && filters.category !== '';
-  const hasKeyword = filters.keyword.trim() !== '';
   const hasStack = filters.stack !== '';
-  if (!hasCategory && !hasKeyword && !hasStack) return page;
-  const kw = filters.keyword.trim().toLowerCase();
+  if (!hasCategory && !hasStack) return page;
   const items = page.items.filter((e) => {
     if (hasCategory && e.category !== filters.category) return false;
-    if (hasKeyword && !e.title.toLowerCase().includes(kw)) return false;
     if (hasStack && !e.techStacks.includes(filters.stack)) return false;
     return true;
   });


### PR DESCRIPTION
- Debounce keyword input by 400ms before pushing to URL/filters so each keystroke no longer fires an ES request.
- Drop client-side keyword filter from applyClientSideFilters; show ES results as-is. Category/stack safety net stays.