### PR TITLE
fix(event-detail): render thumbnail image; relabel order refund as 전체 환불

### DIFF
--- a/src/pages/EventDetail/EventDetail.tsx
+++ b/src/pages/EventDetail/EventDetail.tsx
@@ -116,7 +116,7 @@ export function EventDetail({ eventId }: EventDetailProps) {
     <PageShell title={vm.title}>
       <div className="ed-grid">
         <div className="ed-main">
-          <HeroBanner accent={accentColor} />
+          <HeroBanner accent={accentColor} thumbnailUrl={vm.thumbnailUrl} title={vm.title} />
           <EventHeader vm={vm} accent={accentColor} />
           <InfoCard vm={vm} />
           {vm.location && <EventMap location={vm.location} />}

--- a/src/pages/EventDetail/components/HeroBanner.tsx
+++ b/src/pages/EventDetail/components/HeroBanner.tsx
@@ -1,10 +1,28 @@
+import { useState } from 'react';
 import { AccentMediaBox } from '@/components/AccentMediaBox';
 
 export interface HeroBannerProps {
   accent: string;
+  thumbnailUrl?: string;
+  title?: string;
 }
 
-export function HeroBanner({ accent }: HeroBannerProps) {
+export function HeroBanner({ accent, thumbnailUrl, title }: HeroBannerProps) {
+  const [errored, setErrored] = useState(false);
+
+  if (thumbnailUrl && !errored) {
+    return (
+      <div className="ed-hero ed-hero--image">
+        <img
+          src={thumbnailUrl}
+          alt={title ?? ''}
+          className="ed-hero__img"
+          onError={() => setErrored(true)}
+        />
+      </div>
+    );
+  }
+
   return (
     <AccentMediaBox
       accent={accent}

--- a/src/pages/MyPage/tabs/Orders/components/OrderRow.tsx
+++ b/src/pages/MyPage/tabs/Orders/components/OrderRow.tsx
@@ -50,7 +50,7 @@ export function OrderRow({ row, onRefunded }: OrderRowProps) {
         <td className="order-cell order-cell-action">
           {canRefund && (
             <Button variant="ghost" size="sm" onClick={() => setRefundOpen(true)}>
-              환불
+              전체 환불
             </Button>
           )}
           <RefundDialog

--- a/src/styles/pages/event-detail.css
+++ b/src/styles/pages/event-detail.css
@@ -44,6 +44,19 @@
 .ed-hero {
   margin-bottom: 24px;
 }
+.ed-hero--image {
+  width: 100%;
+  height: 240px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--bg-2);
+}
+.ed-hero__img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
 
 /* InfoRow (§2 InfoRow) — single row inside InfoCard. Last row drops border via :last-child. */
 .ed-info-row {


### PR DESCRIPTION
이벤트 상세 HeroBanner 가 thumbnailUrl 을 받지 않아 항상 placeholder 만 보였던 문제를 수정. 마이페이지 주문내역의 주문 단위 환불 버튼을 부분 환불과
구분되도록 "전체 환불" 로 변경.