### PR TITLE
fix(EventList): show SCHEDULED events as 판매 예정

### DIFF
--- a/src/pages/EventList/components/EventCard.tsx
+++ b/src/pages/EventList/components/EventCard.tsx
@@ -13,6 +13,9 @@ function statusChip(vm: EventVM) {
   if (vm.status === 'SOLD_OUT') {
     return <StatusChip variant="sold">매진</StatusChip>;
   }
+  if (vm.status === 'SCHEDULED') {
+    return <StatusChip variant="ok">판매 예정</StatusChip>;
+  }
   if (vm.status === 'ON_SALE') {
     return vm.isFree ? (
       <StatusChip variant="free">무료</StatusChip>


### PR DESCRIPTION
EventCard's status chip fell through to 판매 종료 for any non-ON_SALE non-SOLD_OUT status, so SCHEDULED events were rendered as 판매 종료.