### PR TITLE
Use relative fallback for GOOGLE_OAUTH_URL instead of hardcoded localhost

### DIFF
--- a/src/pages/Login/hooks.ts
+++ b/src/pages/Login/hooks.ts
@@ -6,7 +6,7 @@ import { unwrapApiData } from '@/api/client';
 import { useAuth } from '@/contexts/AuthContext';
 
 const GOOGLE_OAUTH_URL =
-  import.meta.env.VITE_GOOGLE_OAUTH_URL ?? 'http://localhost:8080/oauth2/authorization/google';
+  import.meta.env.VITE_GOOGLE_OAUTH_URL ?? '/oauth2/authorization/google';
 
 const SIGNUP_HREF = '/signup';
 

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -7,7 +7,7 @@ import { POSITION_LABELS, POSITION_OPTIONS } from '../constants/profile'
 import { useAuth } from '../contexts/AuthContext'
 import { useToast } from '../contexts/ToastContext'
 
-const GOOGLE_OAUTH_URL = import.meta.env.VITE_GOOGLE_OAUTH_URL ?? 'http://localhost:8080/oauth2/authorization/google'
+const GOOGLE_OAUTH_URL = import.meta.env.VITE_GOOGLE_OAUTH_URL ?? '/oauth2/authorization/google'
 
 interface TechStackItem {
   techStackId: number


### PR DESCRIPTION
### Motivation
- Avoid a hardcoded `http://localhost:8080` fallback for `GOOGLE_OAUTH_URL` so the app can use the same-origin proxy or deployed host when the environment variable is not set.

### Description
- Change the default fallback for `GOOGLE_OAUTH_URL` from `http://localhost:8080/oauth2/authorization/google` to `/oauth2/authorization/google` in `src/pages/Login/hooks.ts` and `src/pages/Signup.tsx`.

### Testing
- Ran existing automated frontend checks including `lint` and a local `build`/smoke validation and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34d05f2ac8330a30923130c9675aa)