### PR TITLE
Refactor profile incomplete error handling to support multiple error codes

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -3,15 +3,22 @@ import axios, { AxiosInstance, InternalAxiosRequestConfig, AxiosResponse, AxiosE
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080';
 
 /**
- * 백엔드가 프로필 미완성 사용자에게 반환하는 403 에러 코드.
+ * 백엔드가 프로필 미완성 사용자에게 반환하는 403 에러 코드들.
  * 백엔드 ErrorCode enum 값과 일치해야 함.
+ * - PROFILE_NOT_COMPLETED: 구버전 코드
+ * - COMMON_010: 신규 통합 코드
  */
-const PROFILE_INCOMPLETE_CODE = 'PROFILE_NOT_COMPLETED';
+const PROFILE_INCOMPLETE_CODES: ReadonlySet<string> = new Set([
+  'PROFILE_NOT_COMPLETED',
+  'COMMON_010',
+]);
 
 /** 403 응답이 "프로필 미완성" 에러인지 판별 */
-function isProfileIncomplete(error: AxiosError): boolean {
-  const data = error.response?.data as { code?: string } | undefined;
-  return data?.code === PROFILE_INCOMPLETE_CODE;
+export function isProfileIncompleteError(error: unknown): boolean {
+  if (!axios.isAxiosError(error)) return false;
+  if (error.response?.status !== 403) return false;
+  const code = (error.response.data as { code?: string } | undefined)?.code;
+  return typeof code === 'string' && PROFILE_INCOMPLETE_CODES.has(code);
 }
 
 /** 비로그인 사용자도 자유롭게 접근 가능한 공개 라우트 (RequireAuth 미적용). */
@@ -70,9 +77,9 @@ apiClient.interceptors.response.use(
   async (error: AxiosError) => {
     const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
 
-    // 403 + PROFILE_NOT_COMPLETED: 프로필 미완성 → 프로필 설정 페이지로 리다이렉트
+    // 403 + 프로필 미완성 코드: 프로필 설정 페이지로 리다이렉트
     // 다른 이유의 403(권한 부족, 비즈니스 규칙 등)은 여기서 처리하지 않음
-    if (error.response?.status === 403 && isProfileIncomplete(error)) {
+    if (isProfileIncompleteError(error)) {
       const currentPath = window.location.pathname;
       if (currentPath !== '/social/profile-setup' && currentPath !== '/oauth/callback') {
         window.location.href = '/social/profile-setup';

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useState, useCallback } from 'react'
-import axios from 'axios'
 import { getProfile } from '@/api/auth.api'
+import { isProfileIncompleteError } from '@/api/client'
 import type { GetProfileResponse } from '@/api/types'
 
 interface AuthState {
@@ -43,13 +43,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         role: user.role as AuthState['role'],
       })
     } catch (err) {
-      // PROFILE_NOT_COMPLETED(403): 토큰은 유지하되 미로그인 상태로 둠
+      // 프로필 미완성(403): 토큰은 유지하되 미로그인 상태로 둠
       // → Axios 인터셉터가 다음 API 호출 시 /social/profile-setup 으로 리다이렉트
-      if (
-        axios.isAxiosError(err) &&
-        err.response?.status === 403 &&
-        (err.response.data as { code?: string })?.code === 'PROFILE_NOT_COMPLETED'
-      ) {
+      if (isProfileIncompleteError(err)) {
         setState({ user: null, isLoggedIn: false, isLoading: false, role: null })
         return
       }

--- a/src/pages/OAuthCallback.tsx
+++ b/src/pages/OAuthCallback.tsx
@@ -1,20 +1,9 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { getProfile } from '../api/auth.api'
+import { isProfileIncompleteError } from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 import { useToast } from '../contexts/ToastContext'
-import axios, { AxiosError } from 'axios'
-
-const PROFILE_INCOMPLETE_CODE = 'PROFILE_NOT_COMPLETED'
-
-function isProfileIncomplete(err: unknown): boolean {
-  if (!axios.isAxiosError(err)) return false
-  const axiosErr = err as AxiosError<{ code?: string }>
-  return (
-    axiosErr.response?.status === 403 &&
-    axiosErr.response.data?.code === PROFILE_INCOMPLETE_CODE
-  )
-}
 
 const ERROR_MESSAGES: Record<string, string> = {
   SOCIAL_EMAIL_CONFLICT: '이미 해당 이메일로 가입된 로컬 계정이 있습니다. 이메일/비밀번호로 로그인해주세요.',
@@ -66,8 +55,8 @@ export default function OAuthCallback() {
         }
       })
       .catch((err) => {
-        // PROFILE_NOT_COMPLETED(403): 토큰은 유지하고 프로필 설정 페이지로
-        if (isProfileIncomplete(err)) {
+        // 프로필 미완성(403): 토큰은 유지하고 프로필 설정 페이지로
+        if (isProfileIncompleteError(err)) {
           navigate('/social/profile-setup', { replace: true })
           return
         }


### PR DESCRIPTION
## Summary
Consolidated and improved profile incomplete error detection logic across the codebase to support both legacy and new error codes from the backend.

## Key Changes
- **Centralized error detection**: Extracted `isProfileIncompleteError()` function in `src/api/client.ts` and exported it for reuse across the application
- **Multi-code support**: Updated error code matching to handle both `PROFILE_NOT_COMPLETED` (legacy) and `COMMON_010` (new unified code) using a `ReadonlySet`
- **Enhanced validation**: Improved type safety by:
  - Adding explicit `axios.isAxiosError()` check
  - Validating HTTP status code is 403
  - Ensuring error code is a string before set lookup
- **Removed duplication**: Eliminated duplicate error detection logic from `OAuthCallback.tsx` and `AuthContext.tsx` by importing the centralized function
- **Updated comments**: Clarified comments to reflect support for multiple error codes rather than a single code

## Implementation Details
- The `isProfileIncompleteError()` function now accepts `unknown` type and performs comprehensive validation before checking error codes
- All three files (`client.ts`, `OAuthCallback.tsx`, `AuthContext.tsx`) now use the same error detection logic, ensuring consistent behavior across the application
- The change maintains backward compatibility with existing error codes while supporting the new unified error code format

https://claude.ai/code/session_01M8kzZ8bqGkBa5FxdBbf1xj