### PR TITLE
Add refund policy display and event metrics to event pages

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -142,6 +142,9 @@ export interface EventItem {
   // 백엔드가 내려주는 경우 한정 (옵셔널). 프론트에서 판매 예정 이벤트를 숨기는 데 사용.
   saleStartAt?: string;
   saleEndAt?: string;
+  // 인기 지표 — 백엔드가 내려주면 카드에 표시. 부재 시 표시 생략.
+  viewCount?: number;
+  purchaseCount?: number;
 }
 export interface EventListResponse {
   content: EventItem[];

--- a/src/pages/EventDetail/EventDetail.tsx
+++ b/src/pages/EventDetail/EventDetail.tsx
@@ -16,6 +16,7 @@ import { InfoCard } from './components/InfoCard';
 import { NotFoundCard } from './components/NotFoundCard';
 import { PurchasePanel } from './components/PurchasePanel';
 import { RecommendedSection } from './components/RecommendedSection';
+import { RefundPolicy } from './components/RefundPolicy';
 import { useEventDetail, useRecommendedEvents } from './hooks';
 
 export interface EventDetailProps {
@@ -121,6 +122,7 @@ export function EventDetail({ eventId }: EventDetailProps) {
           <InfoCard vm={vm} />
           {vm.location && <EventMap location={vm.location} />}
           <EventDescription description={vm.description} />
+          <RefundPolicy eventDateTime={vm.eventDateTime} />
         </div>
         <PurchasePanel vm={vm} />
       </div>

--- a/src/pages/EventDetail/components/RefundPolicy.tsx
+++ b/src/pages/EventDetail/components/RefundPolicy.tsx
@@ -1,0 +1,61 @@
+import { Card } from '@/components/Card';
+
+export interface RefundPolicyProps {
+  eventDateTime: string;
+}
+
+type Stage = 'full' | 'partial' | 'none';
+
+const MS_PER_DAY = 86_400_000;
+
+function daysUntil(eventDateTime: string): number | null {
+  const t = new Date(eventDateTime).getTime();
+  if (Number.isNaN(t)) return null;
+  // 일 단위 floor — 같은 날 서로 다른 시각의 미세한 차이로 단계가 바뀌는 걸 막는다.
+  const diff = t - Date.now();
+  return Math.floor(diff / MS_PER_DAY);
+}
+
+function stageOf(days: number | null): Stage | null {
+  if (days === null) return null;
+  if (days >= 7) return 'full';
+  if (days >= 3) return 'partial';
+  return 'none';
+}
+
+const ROWS: { stage: Stage; label: string; rate: string }[] = [
+  { stage: 'full', label: '행사 7일 전까지', rate: '100% 환불' },
+  { stage: 'partial', label: '행사 3일 전까지', rate: '50% 환불' },
+  { stage: 'none', label: '행사 3일 이내', rate: '환불 불가' },
+];
+
+export function RefundPolicy({ eventDateTime }: RefundPolicyProps) {
+  const current = stageOf(daysUntil(eventDateTime));
+  return (
+    <Card padding="lg" className="ed-refund-policy">
+      <div className="ed-refund-policy__head">
+        <span className="ed-refund-policy__icon" aria-hidden="true">💸</span>
+        <h2 className="ed-refund-policy__title">환불 정책</h2>
+      </div>
+      <ul className="ed-refund-policy__list">
+        {ROWS.map((row) => (
+          <li
+            key={row.stage}
+            className={`ed-refund-policy__row${
+              current === row.stage ? ' is-current' : ''
+            }`}
+          >
+            <span className="ed-refund-policy__label">{row.label}</span>
+            <span className="ed-refund-policy__rate">{row.rate}</span>
+          </li>
+        ))}
+      </ul>
+      <p className="ed-refund-policy__note">
+        환불 기준일은 행사 시작일을 기준으로 산정되며, 결제 수단에 따라 환불
+        처리에 영업일이 추가로 소요될 수 있습니다.
+      </p>
+    </Card>
+  );
+}
+
+RefundPolicy.displayName = 'RefundPolicy';

--- a/src/pages/EventList/adapters.ts
+++ b/src/pages/EventList/adapters.ts
@@ -41,6 +41,8 @@ export const toEventVM = (api: EventItem): EventVM => {
     isLowStock: isLowStock(api.remainingQuantity),
     dateLabel,
     timeLabel,
+    viewCount: api.viewCount,
+    purchaseCount: api.purchaseCount,
   };
 };
 

--- a/src/pages/EventList/components/EventCard.tsx
+++ b/src/pages/EventList/components/EventCard.tsx
@@ -26,11 +26,19 @@ function statusChip(vm: EventVM) {
   return <StatusChip variant="end">판매 종료</StatusChip>;
 }
 
+function formatCount(n: number): string {
+  if (n >= 10_000) return `${(n / 10_000).toFixed(n >= 100_000 ? 0 : 1)}만`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}k`;
+  return n.toLocaleString();
+}
+
 export function EventCard({ event, onOpen }: EventCardProps) {
   const accentColor = accent(event.eventId);
   const sold = event.status === 'SOLD_OUT';
   const stacks = event.techStacks.slice(0, STACK_LIMIT);
   const extraStacks = event.techStacks.length - stacks.length;
+  const hasMetrics =
+    event.viewCount !== undefined || event.purchaseCount !== undefined;
 
   return (
     <article
@@ -65,6 +73,28 @@ export function EventCard({ event, onOpen }: EventCardProps) {
             </span>
           </div>
         </div>
+        {hasMetrics && (
+          <div className="el-card__metrics" aria-label="이벤트 지표">
+            {event.viewCount !== undefined && (
+              <span
+                className="el-card__metric"
+                title={`조회수 ${event.viewCount.toLocaleString()}회`}
+              >
+                <span aria-hidden="true">👁</span>
+                <span>{formatCount(event.viewCount)}</span>
+              </span>
+            )}
+            {event.purchaseCount !== undefined && (
+              <span
+                className="el-card__metric"
+                title={`구매 ${event.purchaseCount.toLocaleString()}건`}
+              >
+                <span aria-hidden="true">🎟</span>
+                <span>{formatCount(event.purchaseCount)}</span>
+              </span>
+            )}
+          </div>
+        )}
         {stacks.length > 0 && (
           <div className="el-card__stacks">
             {stacks.map((s) => (

--- a/src/pages/EventList/types.ts
+++ b/src/pages/EventList/types.ts
@@ -14,6 +14,8 @@ export interface EventVM {
   isLowStock: boolean;
   dateLabel: string;
   timeLabel: string;
+  viewCount?: number;
+  purchaseCount?: number;
 }
 
 export interface EventListFilters {

--- a/src/pages/seller/SellerDashboard.tsx
+++ b/src/pages/seller/SellerDashboard.tsx
@@ -108,10 +108,16 @@ export default function SellerDashboard() {
   }
 
   // Quick stats — 상단 박스는 항상 전체 기준.
-  const totalRevenue = allEvents.filter(e => e.status === 'ON_SALE' || e.status === 'ENDED')
+  // 매출/판매수는 실제로 티켓이 판매된 모든 상태(ON_SALE/SOLD_OUT/SALE_ENDED)를
+  // 합산해야 한다. 이전 버전은 'ENDED'(존재하지 않는 상태)와 ON_SALE 만 포함해
+  // SOLD_OUT/SALE_ENDED 매출이 통째로 누락됐다. CANCELLED 는 환불 대상이라 제외.
+  const REVENUE_STATUSES = new Set(['ON_SALE', 'SOLD_OUT', 'SALE_ENDED'])
+  const revenueEvents = allEvents.filter(e => REVENUE_STATUSES.has(e.status))
+  const totalRevenue = revenueEvents
     .reduce((acc, e) => acc + (e.totalQuantity - e.remainingQuantity) * e.price, 0)
   const onSaleCount = allEvents.filter(e => e.status === 'ON_SALE').length
-  const totalSold = allEvents.reduce((acc, e) => acc + (e.totalQuantity - e.remainingQuantity), 0)
+  const totalSold = revenueEvents
+    .reduce((acc, e) => acc + (e.totalQuantity - e.remainingQuantity), 0)
   const events = tabEvents
 
   return (

--- a/src/styles/pages/event-detail.css
+++ b/src/styles/pages/event-detail.css
@@ -141,6 +141,70 @@
   margin: 0;
 }
 
+/* RefundPolicy — 행사일 기준 환불 단계 안내 */
+.ed-refund-policy {
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+.ed-refund-policy__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.ed-refund-policy__icon {
+  font-size: 18px;
+}
+.ed-refund-policy__title {
+  font-family: var(--font);
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+.ed-refund-policy__list {
+  list-style: none;
+  margin: 0 0 12px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ed-refund-policy__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  font-family: var(--font);
+  font-size: 14px;
+}
+.ed-refund-policy__row.is-current {
+  border-color: var(--brand);
+  background: color-mix(in srgb, var(--brand) 8%, var(--surface));
+}
+.ed-refund-policy__label {
+  color: var(--text-2);
+}
+.ed-refund-policy__rate {
+  font-weight: 600;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+.ed-refund-policy__row.is-current .ed-refund-policy__rate {
+  color: var(--brand);
+}
+.ed-refund-policy__note {
+  font-family: var(--font);
+  font-size: 12.5px;
+  color: var(--text-3);
+  line-height: 1.6;
+  margin: 0;
+}
+
 /* PriceSummary (§2 PriceSummary) — 합계 한 줄. price=0 / 매진 시 component 가 null 반환 */
 .ed-price-summary {
   display: flex;

--- a/src/styles/pages/event-list.css
+++ b/src/styles/pages/event-list.css
@@ -198,6 +198,21 @@
   white-space: nowrap;
   min-width: 0;
 }
+.el-card__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 10px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-3);
+}
+.el-card__metric {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  letter-spacing: 0.02em;
+}
 .el-card__stacks {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
This PR enhances the event detail and event list pages with two new features: a refund policy component that displays stage-based refund information on event detail pages, and event metrics (view count and purchase count) displayed on event cards in the event list.

## Key Changes

- **Refund Policy Component**: Added a new `RefundPolicy` component that displays three refund stages (7+ days: 100%, 3-7 days: 50%, <3 days: none) based on days until the event. The current applicable stage is highlighted with brand color styling.

- **Event Metrics Display**: Added view count and purchase count metrics to event cards in the event list, with smart number formatting (e.g., "1.2만" for 12,000). Metrics are only displayed when data is available from the backend.

- **Data Model Updates**: Extended `EventItem` API type and `EventVM` view model to include optional `viewCount` and `purchaseCount` fields.

- **Seller Dashboard Fix**: Corrected revenue and sold ticket calculations to include all ticket-selling statuses (`ON_SALE`, `SOLD_OUT`, `SALE_ENDED`) instead of the non-existent `ENDED` status, fixing a bug where `SOLD_OUT` and `SALE_ENDED` events were excluded from totals.

## Implementation Details

- The `RefundPolicy` component calculates days until event using floor division to prevent stage changes due to minor time differences within the same day
- Event metrics use a monospace font and emoji icons (👁 for views, 🎟 for purchases) with accessible title attributes showing full counts
- Number formatting intelligently switches between "만" (10k+), "k" (1k+), and locale string formats
- Refund policy styling uses CSS custom properties for theming and includes a highlighted state for the current applicable stage

https://claude.ai/code/session_01KSqZTAzGTi5A6w5MaSHbSv