### PR TITLE
fix(seller): 강제취소(환불 동반)·판매중지(환불 없음) UI 분리 + cancelledQuantity 반영

### DIFF
--- a/src/pages/seller/SellerEventDetail.tsx
+++ b/src/pages/seller/SellerEventDetail.tsx
@@ -36,7 +36,14 @@ export default function SellerEventDetail() {
   if (loading) return <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 100 }}><div className="spinner" /></div>
   if (!event) return null
 
-  const soldRate = summary ? Math.round((summary.soldQuantity / summary.totalQuantity) * 100) : 0
+  // 환불 완료된 수량(cancelledQuantity)을 빼서 실제 순판매 기준으로 표시.
+  // 강제 취소·부분 환불된 이벤트도 동일 계산식으로 일관되게 0 또는 net 값이 잡힌다.
+  const totalQty   = summary?.totalQuantity ?? 0
+  const cancelled  = summary?.cancelledQuantity ?? 0
+  const netSold    = Math.max(0, (summary?.soldQuantity ?? 0) - cancelled)
+  const netRemain  = Math.max(0, totalQty - netSold)
+  const netRevenue = netSold * (summary?.price ?? 0)
+  const soldRate   = totalQty > 0 ? Math.round((netSold / totalQty) * 100) : 0
 
   return (
     <div style={{ padding: '32px 36px' }}>
@@ -56,19 +63,29 @@ export default function SellerEventDetail() {
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 14, marginBottom: 28 }}>
           <div className="stat-card">
             <div className="stat-label">총 수량</div>
-            <div className="stat-value">{summary.totalQuantity}</div>
+            <div className="stat-value">{totalQty}</div>
           </div>
           <div className="stat-card">
             <div className="stat-label">판매 수량</div>
-            <div className="stat-value" style={{ color: 'var(--brand)' }}>{summary.soldQuantity}</div>
+            <div className="stat-value" style={{ color: 'var(--brand)' }}>{netSold}</div>
+            {cancelled > 0 && (
+              <div className="stat-sub" style={{ color: 'var(--danger)' }}>
+                환불 {cancelled}건 차감
+              </div>
+            )}
           </div>
           <div className="stat-card">
             <div className="stat-label">잔여 수량</div>
-            <div className="stat-value">{summary.remainingQuantity}</div>
+            <div className="stat-value">{netRemain}</div>
           </div>
           <div className="stat-card">
             <div className="stat-label">예상 매출</div>
-            {Math.floor(summary.totalSalesAmount * 0.95).toLocaleString()}원
+            <div className="stat-value">{Math.floor(netRevenue * 0.95).toLocaleString()}원</div>
+            {cancelled > 0 && (
+              <div className="stat-sub" style={{ color: 'var(--text-3)' }}>
+                수수료 5% 차감 후
+              </div>
+            )}
           </div>
         </div>
       )}
@@ -89,8 +106,8 @@ export default function SellerEventDetail() {
           </div>
           <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 6, fontSize: 12, color: 'var(--text-3)' }}>
             <span>0</span>
-            <span>{summary.soldQuantity} / {summary.totalQuantity}장 판매</span>
-            <span>{summary.totalQuantity}</span>
+            <span>{netSold} / {totalQty}장 판매{cancelled > 0 ? ` · 환불 ${cancelled}건` : ''}</span>
+            <span>{totalQty}</span>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

BE 측 `EventService.forceCancel` SELLER 분기 라우팅 수정 (Payment.cancelSellerEvent → `event.cancel()` + `sale-stopped` 로 잘못 라우팅되어 환불 fan-out 미발생) 의 FE 카운터파트.

운영 점검에서 확인된 세 가지 문제를 함께 정리:

1. 셀러 종료 액션 두 가지(강제취소·판매중지) 의도가 FE 에서 단일 버튼으로 섞여 있어 셀러가 어느 쪽인지 인지 불가 — 이름·아이콘·카피 모두 분리.
2. `SellerEventDetail` 통계가 `cancelledQuantity` 를 무시해 환불 완료 후에도 "판매 4 / 매출 3,800원" 으로 표시 — 순판매(net) 기준으로 보정.
3. 대시보드 표·매출 stats 가 두 종료 상태 의미를 못 살림 — `4 / 96` 표시가 강제 취소·판매 중지를 구분 못 했고, 매출 합산 set 도 분리 이전 가정 그대로라 판매 중지된 이벤트 매출이 누락됨.

## Changes

### 1. 셀러 액션 분리 (`a91edfa`)
| 액션 | 호출 | 이벤트 status | 환불 |
|---|---|---|---|
| **강제 취소** (Action A) | `forceCancelSellerEvent` → `POST /seller/events/{id}/cancel` | `FORCE_CANCELLED` | ✓ |
| **판매 중지** (Action B) | `updateSellerEvent({ status: 'CANCELLED' })` | `CANCELLED` | ✗ (기존 구매자 영향 없음) |

- `src/api/events.api.ts` — `stopSellerEvent` → `forceCancelSellerEvent` 개명 (deprecated alias 유지). docblock 으로 의도/환불 동반 여부 명시.
- `src/api/types.ts` — `SellerEventForceCancel{Request,Response}` 로 정리. 기존 이름은 `@deprecated` 별칭으로 유지.
- `src/pages/seller/SellerDashboard.tsx`
  - `STATUS_MAP` 에 `FORCE_CANCELLED`(빨강 배지 "강제 취소됨") 추가, 기존 `CANCELLED` 라벨을 "판매 중지됨"으로 변경. 탭에도 "판매 중지" / "강제 취소" 분리.
  - `ON_SALE` 행에 두 버튼 분리: **판매 중지**(secondary) / **강제 취소**(danger). hover title 로 환불 동반 여부 안내.
  - 모달은 `actionTarget.kind` 로 카피·버튼 분기 — 강제 취소만 사유 입력 필수, 판매 중지는 사유 없이 확정.

### 2. `SellerEventDetail` stats 순판매 기준 보정 (`833230f`)
강제 취소되어 모두 환불된 이벤트에서도 stats 가 그대로 노출되던 문제.

- `netSold = soldQuantity - cancelledQuantity` 로 순판매 수량 계산.
- 잔여 = `totalQuantity - netSold` (환불분만큼 잔여로 환산).
- 매출 = `netSold × price × 0.95` (5% 수수료 차감).
- 판매율 바도 `netSold / totalQuantity` 기준.
- `cancelledQuantity > 0` 일 때 "환불 N건 차감" 부수 라벨 노출.

샘플 데이터 (`soldQuantity=4, cancelledQuantity=4, totalSalesAmount=4000`) 기준: 이전 "판매 4 / 잔여 96 / 매출 3,800원 / 판매율 4%" → 이후 "판매 0 / 잔여 100 / 매출 0원 / 판매율 0%" + "환불 4건 차감" 라벨.

### 3. 대시보드 표·매출 stats 분기 (`148cdfe`)
- **판매/잔여 셀 분기**:
  - `FORCE_CANCELLED` → `4 / 96` 취소선 + "전량 환불 처리" 빨강 라벨. 더 이상 유효 매출이 아니라는 게 한눈에 보임.
  - `CANCELLED` → 숫자는 정상 노출(기존 구매자 유효) + "신규 판매 중단 · 기존 구매 유효" 안내 라벨. 진행 바는 의미 없으니 숨김.
  - 그 외 진행 상태 → 기존과 동일.
- **상단 매출/판매수 합산 보정**: 이전엔 단일 `CANCELLED` 가 강제취소였던 시절의 주석·로직이 그대로 남아 두 상태 모두 매출 합산에서 제외되고 있었음. 분리 후엔 `CANCELLED` 는 매출에 포함하고 `FORCE_CANCELLED` 만 제외.

## Test plan
- [x] `npx vite build` — 통과
- [ ] 셀러 계정으로 ON_SALE 이벤트 행에서 **판매 중지** 버튼 → 모달 카피·확정 후 status=`CANCELLED` 배지 "판매 중지됨" 노출 확인 (환불 미발생, 기존 구매 유효)
- [ ] 셀러 계정으로 ON_SALE 이벤트 행에서 **강제 취소** 버튼 → 사유 입력 후 확정 → status=`FORCE_CANCELLED` 배지 "강제 취소됨" + 환불 토스트 확인
- [ ] 강제 취소 완료된 이벤트 상세 페이지 → 4개 stat 카드 모두 0 또는 보정값으로 표시 + "환불 N건 차감" 라벨 노출
- [ ] 대시보드 표:
  - `FORCE_CANCELLED` 행 → 판매/잔여 취소선 + "전량 환불 처리"
  - `CANCELLED` 행 → 판매/잔여 정상 + "신규 판매 중단 · 기존 구매 유효"
- [ ] 대시보드 상단 stat — 판매 중지된 이벤트 매출이 "예상 매출"·"총 판매 티켓" 에 합산되는지 확인
- [ ] 탭 — "판매 중지" / "강제 취소" 각각 필터링 동작

## 관련
- BE PR — `EventService.forceCancel` SELLER 라우팅 수정 (Payment.cancelSellerEvent → 환불 트리거 정상화)
- 이전 PR #697 — 종료 이벤트 환불 시 `cancelledQuantity` 누적 (본 PR 의 `netSold` 계산이 의미 갖도록 결합 동작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)