### PR TITLE
fix(events): 강제 취소 이벤트 표시·수정 가드 + 수정 폼 maxQuantity 보정

### DIFF
--- a/src/pages/admin/AdminEvents.tsx
+++ b/src/pages/admin/AdminEvents.tsx
@@ -9,11 +9,13 @@ import { useToast } from '../../contexts/ToastContext'
 const REASON_MAX = 500
 
 const EVENT_STATUS_MAP: Record<string, { label: string; cls: string }> = {
-  DRAFT:     { label: '판매 예정',    cls: 'badge-gray' },
-  ON_SALE:   { label: '판매중',  cls: 'badge-green' },
-  SOLD_OUT:  { label: '매진',    cls: 'badge-red' },
-  ENDED:     { label: '종료',    cls: 'badge-gray' },
-  CANCELLED: { label: '취소됨',  cls: 'badge-gray' },
+  DRAFT:           { label: '판매 예정',    cls: 'badge-gray' },
+  ON_SALE:         { label: '판매중',       cls: 'badge-green' },
+  SOLD_OUT:        { label: '매진',         cls: 'badge-red' },
+  SALE_ENDED:      { label: '종료',         cls: 'badge-gray' },
+  ENDED:           { label: '종료',         cls: 'badge-gray' },
+  CANCELLED:       { label: '판매 중지됨',  cls: 'badge-gray' },
+  FORCE_CANCELLED: { label: '강제 취소됨',  cls: 'badge-red' },
 }
 
 export function AdminEvents() {
@@ -104,6 +106,9 @@ export function AdminEvents() {
             <tbody>
               {events.map(event => {
                 const status = EVENT_STATUS_MAP[event.status] ?? { label: event.status, cls: 'badge-gray' }
+                const isForceCancelled = event.status === 'FORCE_CANCELLED'
+                // 강제 취소 건은 결제 완료 구매분 전부 환불되므로 잔여=0 으로 통일 표시.
+                const displayRemaining = isForceCancelled ? 0 : event.remainingQuantity
                 return (
                   <tr key={event.eventId}>
                     <td>
@@ -115,7 +120,7 @@ export function AdminEvents() {
                       {new Date(event.eventDateTime).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' })}
                     </td>
                     <td style={{ textAlign: 'right', fontSize: 13 }}>
-                      {event.totalQuantity} / <span style={{ color: event.remainingQuantity === 0 ? 'var(--danger)' : 'inherit' }}>{event.remainingQuantity}</span>
+                      {event.totalQuantity} / <span style={{ color: displayRemaining === 0 ? 'var(--danger)' : 'inherit' }}>{displayRemaining}</span>
                     </td>
                     <td>
                       {event.status === 'ON_SALE' && (

--- a/src/pages/seller/SellerDashboard.tsx
+++ b/src/pages/seller/SellerDashboard.tsx
@@ -215,7 +215,10 @@ export default function SellerDashboard() {
             <tbody>
               {events.map(event => {
                 const status = STATUS_MAP[event.status] ?? { label: event.status, cls: 'badge-gray' }
-                const sold = event.totalQuantity - event.remainingQuantity
+                const isForceCancelled = event.status === 'FORCE_CANCELLED'
+                // 강제 취소 건은 결제 완료 구매분 전부 환불되므로 잔여=0/판매=총수량 으로 통일 표시.
+                const sold = isForceCancelled ? event.totalQuantity : event.totalQuantity - event.remainingQuantity
+                const remaining = isForceCancelled ? 0 : event.remainingQuantity
                 return (
                   <tr key={event.eventId}>
                     <td>
@@ -233,7 +236,7 @@ export default function SellerDashboard() {
                     </td>
                     <td style={{ textAlign: 'right' }}>
                       <span style={{ fontWeight: 600 }}>{sold}</span>
-                      <span style={{ color: 'var(--text-3)' }}> / {event.remainingQuantity}</span>
+                      <span style={{ color: 'var(--text-3)' }}> / {remaining}</span>
                       <div style={{ height: 4, background: 'var(--surface-2)', borderRadius: 99, marginTop: 4, minWidth: 60 }}>
                         <div style={{
                           height: '100%', borderRadius: 99,
@@ -245,7 +248,11 @@ export default function SellerDashboard() {
                     <td>
                       <div style={{ display: 'flex', gap: 6, justifyContent: 'flex-end' }}>
                         <Link to={`/seller/events/${event.eventId}`} className="btn btn-ghost btn-sm">상세</Link>
-                        <Link to={`/seller/events/${event.eventId}/edit`} className="btn btn-secondary btn-sm">수정</Link>
+                        {isForceCancelled ? (
+                          <button className="btn btn-secondary btn-sm" disabled title="강제 취소된 이벤트는 수정할 수 없습니다">수정</button>
+                        ) : (
+                          <Link to={`/seller/events/${event.eventId}/edit`} className="btn btn-secondary btn-sm">수정</Link>
+                        )}
                         {event.status === 'ON_SALE' && (
                           <>
                             <button

--- a/src/pages/seller/SellerEventCreate.tsx
+++ b/src/pages/seller/SellerEventCreate.tsx
@@ -658,6 +658,9 @@ export function SellerEventEdit() {
         // datetime-local input 은 'YYYY-MM-DDTHH:mm' 16자만 허용 — ISO 끝의 :ss/Z/.fff 잘라냄.
         const toLocalInput = (iso?: string): string =>
           iso ? iso.slice(0, 16) : "";
+        // 백엔드 응답이 maxQuantityPerUser / maxQuantity 둘 중 어느 키로 내려와도 안전하게 채운다.
+        const detail = d as { maxQuantityPerUser?: number; maxQuantity?: number } & typeof d;
+        const maxQty = detail.maxQuantityPerUser ?? detail.maxQuantity ?? 1;
         setInitial({
           title: d.title,
           description: d.description,
@@ -665,7 +668,7 @@ export function SellerEventEdit() {
           techStacks: d.techStacks.map((t: any) => t.name),
           price: String(d.price),
           totalQuantity: String(d.totalQuantity),
-          maxQuantityPerUser: String(d.maxQuantityPerUser),
+          maxQuantityPerUser: String(maxQty),
           eventDateTime: toLocalInput(d.eventDateTime),
           saleStartAt: toLocalInput(d.saleStartAt),
           saleEndAt: toLocalInput(d.saleEndAt),

--- a/src/pages/seller/SellerEventDetail.tsx
+++ b/src/pages/seller/SellerEventDetail.tsx
@@ -55,7 +55,11 @@ export default function SellerEventDetail() {
           </div>
           <h1 style={{ fontSize: 22, fontWeight: 700 }}>{event.title}</h1>
         </div>
-        <Link to={`/seller/events/${id}/edit`} className="btn btn-secondary">수정하기</Link>
+        {event.status === 'FORCE_CANCELLED' ? (
+          <button className="btn btn-secondary" disabled title="강제 취소된 이벤트는 수정할 수 없습니다">수정하기</button>
+        ) : (
+          <Link to={`/seller/events/${id}/edit`} className="btn btn-secondary">수정하기</Link>
+        )}
       </div>
 
       {/* Stats */}


### PR DESCRIPTION
## Summary

판매자/관리자 화면에서 강제 취소(`FORCE_CANCELLED`) 이벤트가 일관되게 보이지 않고, 수정 흐름까지 열려 있어 혼선이 있었던 부분을 정리.

### 변경점

- **셀러/어드민 대시보드 표시**
  - `FORCE_CANCELLED` 이벤트는 결제 완료분 전부 환불 대상이라, 잔여 수량을 0 / 판매 수량을 총수량 으로 통일 표시.
    - 셀러: `판매/잔여` 컬럼 → `총수량 / 0`
    - 어드민: `총/잔여` 컬럼 → `총수량 / 0`
  - 어드민 status 맵에 `FORCE_CANCELLED`(강제 취소됨) 라벨 추가. 이전엔 raw 코드 그대로 노출됐음.

- **수정 버튼 비활성화** (셀러)
  - `SellerDashboard` 목록의 행별 `수정` 버튼: 강제 취소 건이면 disabled 버튼으로 대체.
  - `SellerEventDetail` 헤더의 `수정하기` 버튼: 동일하게 disabled 처리.
  - 어드민(`AdminEvents`)에는 별도 수정 버튼이 없어 추가 작업 불필요.

- **셀러 이벤트 수정 폼 — maxQuantity 미반영 수정**
  - 수정 진입 시 `1인 최대 구매` 입력칸이 비어 있던 문제. 백엔드 응답이 `maxQuantityPerUser` / `maxQuantity` 어느 키로 와도 안전하게 채우도록 fallback (`?? 1`) 추가.

## Test plan

- [ ] 셀러 대시보드: 강제 취소된 이벤트 행에 `총수량 / 0` 으로 표시되는지 확인
- [ ] 셀러 대시보드: 강제 취소 이벤트의 `수정` 버튼이 비활성화되고 툴팁이 뜨는지 확인
- [ ] 셀러 이벤트 상세: 강제 취소 이벤트의 `수정하기` 버튼이 비활성화되는지 확인
- [ ] 셀러 이벤트 수정 화면: 진입 시 `1인 최대 구매` 칸에 기존 값이 채워져 있는지 확인
- [ ] 어드민 이벤트 목록: 강제 취소 이벤트가 `강제 취소됨` 배지로 표시되고 `총수량 / 0` 으로 보이는지 확인

https://claude.ai/code/session_01GtALEpaGoDoX2xXfsUUqhp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtALEpaGoDoX2xXfsUUqhp)_