### PR TITLE
fix(events): 셀러/어드민 판매현황 컬럼을 '판매량/총수량' 으로 통일

### DIFF
--- a/src/pages/admin/AdminEvents.tsx
+++ b/src/pages/admin/AdminEvents.tsx
@@ -99,7 +99,7 @@ export function AdminEvents() {
                 <th>판매자</th>
                 <th>상태</th>
                 <th>일시</th>
-                <th style={{ textAlign: 'right' }}>총/잔여</th>
+                <th style={{ textAlign: 'right' }}>판매량/총수량</th>
                 <th>관리</th>
               </tr>
             </thead>
@@ -107,8 +107,8 @@ export function AdminEvents() {
               {events.map(event => {
                 const status = EVENT_STATUS_MAP[event.status] ?? { label: event.status, cls: 'badge-gray' }
                 const isForceCancelled = event.status === 'FORCE_CANCELLED'
-                // 강제 취소 건은 결제 완료 구매분 전부 환불되므로 잔여=0 으로 통일 표시.
-                const displayRemaining = isForceCancelled ? 0 : event.remainingQuantity
+                // 강제 취소 건은 결제 완료 구매분 전부 환불되므로 판매량=0 / 총수량은 그대로 노출(초기 상태).
+                const sold = isForceCancelled ? 0 : event.totalQuantity - event.remainingQuantity
                 return (
                   <tr key={event.eventId}>
                     <td>
@@ -120,7 +120,7 @@ export function AdminEvents() {
                       {new Date(event.eventDateTime).toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' })}
                     </td>
                     <td style={{ textAlign: 'right', fontSize: 13 }}>
-                      {event.totalQuantity} / <span style={{ color: displayRemaining === 0 ? 'var(--danger)' : 'inherit' }}>{displayRemaining}</span>
+                      <span style={{ fontWeight: 600 }}>{sold}</span> / <span style={{ color: 'var(--text-3)' }}>{event.totalQuantity}</span>
                     </td>
                     <td>
                       {event.status === 'ON_SALE' && (

--- a/src/pages/seller/SellerDashboard.tsx
+++ b/src/pages/seller/SellerDashboard.tsx
@@ -208,7 +208,7 @@ export default function SellerDashboard() {
                 <th>상태</th>
                 <th>일시</th>
                 <th>가격</th>
-                <th style={{ textAlign: 'right' }}>판매/잔여</th>
+                <th style={{ textAlign: 'right' }}>판매량/총수량</th>
                 <th></th>
               </tr>
             </thead>
@@ -216,9 +216,9 @@ export default function SellerDashboard() {
               {events.map(event => {
                 const status = STATUS_MAP[event.status] ?? { label: event.status, cls: 'badge-gray' }
                 const isForceCancelled = event.status === 'FORCE_CANCELLED'
-                // 강제 취소 건은 결제 완료 구매분 전부 환불되므로 잔여=0/판매=총수량 으로 통일 표시.
-                const sold = isForceCancelled ? event.totalQuantity : event.totalQuantity - event.remainingQuantity
-                const remaining = isForceCancelled ? 0 : event.remainingQuantity
+                // 강제 취소 건은 결제 완료 구매분 전부 환불되므로 판매량=0 / 총수량은 그대로 노출(초기 상태).
+                const sold = isForceCancelled ? 0 : event.totalQuantity - event.remainingQuantity
+                const total = event.totalQuantity
                 return (
                   <tr key={event.eventId}>
                     <td>
@@ -236,7 +236,7 @@ export default function SellerDashboard() {
                     </td>
                     <td style={{ textAlign: 'right' }}>
                       <span style={{ fontWeight: 600 }}>{sold}</span>
-                      <span style={{ color: 'var(--text-3)' }}> / {remaining}</span>
+                      <span style={{ color: 'var(--text-3)' }}> / {total}</span>
                       <div style={{ height: 4, background: 'var(--surface-2)', borderRadius: 99, marginTop: 4, minWidth: 60 }}>
                         <div style={{
                           height: '100%', borderRadius: 99,


### PR DESCRIPTION
## Summary

#172 후속. 강제 취소 이벤트 표기와 셀러/어드민 컬럼명을 한 번에 정리.

### 변경점
- **셀러 대시보드**: 컬럼명 `판매/잔여` → `판매량/총수량` 으로 변경.
- **어드민 이벤트 목록**: 컬럼명 `총/잔여` → `판매량/총수량` 으로 통일 (값 순서도 동일하게 정렬).
- **`FORCE_CANCELLED` 이벤트**: 결제분 전부 환불되므로 셀러/어드민 모두 `판매량 0 / 총수량(원래 재고 그대로)` 으로 표시 — 사실상 초기 상태와 동일.

이전 PR(#172) 의 `잔여=0 / 판매=총수량` 표기가 의미가 거꾸로 읽혀서 정정.

## Test plan
- [ ] 셀러 대시보드: 컬럼 헤더가 `판매량/총수량` 으로 보이는지
- [ ] 셀러 대시보드: 강제 취소 이벤트가 `0 / 총수량` 으로 보이는지
- [ ] 어드민 이벤트 목록: 컬럼 헤더가 `판매량/총수량` 으로 보이는지
- [ ] 어드민 이벤트 목록: 강제 취소 이벤트가 `0 / 총수량` 으로 보이는지
- [ ] 일반 판매중 이벤트는 기존대로 실제 판매량/총수량 그대로 표시되는지

https://claude.ai/code/session_01GtALEpaGoDoX2xXfsUUqhp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtALEpaGoDoX2xXfsUUqhp)_