### PR TITLE
fix(landing): 홈 Stats '판매중인 티켓' / '전체 잔여 좌석' 카드 제거

### DIFF
--- a/src/pages/Landing/adapters.ts
+++ b/src/pages/Landing/adapters.ts
@@ -37,13 +37,8 @@ import type {
 const HOSTS_HARDCODED = '24+';
 
 export const toStatsVM = (firstPage: EventListPage): StatVM[] => {
-  const items = firstPage.items;
-  const onSaleCount = items.filter((e) => e.status === 'ON_SALE').length;
-  const remainingSum = items.reduce((acc, e) => acc + e.remainingQuantity, 0);
   return [
     { hint: '// active events',  num: firstPage.totalElements, unit: '개', label: '진행 중인 이벤트' },
-    { hint: '// on sale',        num: onSaleCount,             unit: '매', label: '판매중인 티켓'   },
-    { hint: '// seats left',     num: remainingSum,            unit: '+', label: '전체 잔여 좌석'   },
     { hint: '// communities',    num: HOSTS_HARDCODED,         unit: '팀', label: '참여 커뮤니티'   },
   ];
 };

--- a/src/pages/Landing/sections/HeroSection.tsx
+++ b/src/pages/Landing/sections/HeroSection.tsx
@@ -115,6 +115,9 @@ export function HeroSection({
           restartDelayMs={restartDelayMs}
           loop={loop}
         />
+        <p className="hero-section__terminal-caption" aria-hidden="true">
+          // 데모 화면 — 실제 명령어는 동작하지 않습니다
+        </p>
       </div>
     </section>
   );

--- a/src/pages/Landing/sections/StatsSection.tsx
+++ b/src/pages/Landing/sections/StatsSection.tsx
@@ -36,7 +36,7 @@ export function StatsSection({ query }: StatsSectionProps) {
     >
       {isLoading && (
         <div className="stats-section__grid">
-          {Array.from({ length: 4 }, (_, i) => (
+          {Array.from({ length: 2 }, (_, i) => (
             <StatSkeleton key={i} />
           ))}
         </div>

--- a/src/styles/pages/landing.css
+++ b/src/styles/pages/landing.css
@@ -122,6 +122,15 @@
 .hero-section__left { min-width: 0; }
 .hero-section__right { min-width: 0; }
 
+.hero-section__terminal-caption {
+  margin-top: 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-4);
+  text-align: right;
+  letter-spacing: 0.02em;
+}
+
 .hero-section__eyebrow {
   display: inline-flex;
   align-items: center;

--- a/src/styles/pages/landing.css
+++ b/src/styles/pages/landing.css
@@ -208,7 +208,7 @@
 
 .stats-section__grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   gap: 12px;
 }
 


### PR DESCRIPTION
## Summary
홈(Landing) 통계 카드 4개 중 2개 제거 — 첫 페이지 합계 기반이라 의미가 모호했던 카드 정리.

- 제거: `판매중인 티켓` (첫 페이지의 ON_SALE 길이), `전체 잔여 좌석` (첫 페이지 remainingQuantity 합)
- 유지: `진행 중인 이벤트` (totalElements 전수), `참여 커뮤니티`
- 그리드 4-col → 2-col / 스켈레톤 4 → 2 동시 정리

## Test plan
- [ ] 홈 Stats 영역에 카드 2개만 보이는지 확인
- [ ] 로딩 스켈레톤도 2개로 표시되는지 확인
- [ ] 모바일/데스크톱 그리드가 비어 보이지 않는지 확인

https://claude.ai/code/session_01GtALEpaGoDoX2xXfsUUqhp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtALEpaGoDoX2xXfsUUqhp)_