### PR TITLE
Fetch event titles for seller settlement items

### DIFF
--- a/src/pages/seller/SellerSettlement.tsx
+++ b/src/pages/seller/SellerSettlement.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useMemo } from 'react'
 import { getSellerSettlementByMonth, getSellerSettlementPreview } from '../../api/seller.api'
+import { getSellerEventDetail } from '../../api/events.api'
 import { extractErrorMessage } from '../../api/client'
 import type { SettlementMonthResponse } from '../../api/types'
 import { useToast } from '../../contexts/ToastContext'
@@ -51,6 +52,9 @@ export default function SellerSettlement() {
   const [selectedIdx, setSelectedIdx] = useState(tabs.length - 1)
   const [data, setData] = useState<SettlementMonthResponse | null>(null)
   const [loading, setLoading] = useState(true)
+  // TODO(BE): /seller/settlements 응답 SettlementEventItem 에 eventTitle 포함 요청.
+  // 현재는 eventId 만 내려오므로 항목별 상세 조회로 보강한다 (N+1).
+  const [eventTitles, setEventTitles] = useState<Record<string, string>>({})
 
   const selected = tabs[selectedIdx]
 
@@ -64,13 +68,28 @@ export default function SellerSettlement() {
   useEffect(() => {
     setLoading(true)
     setData(null)
+    setEventTitles({})
 
     const req = selected.isPreview
       ? getSellerSettlementPreview()
       : getSellerSettlementByMonth(selected.key)
 
     req
-      .then(r => setData(r.data))
+      .then(async r => {
+        setData(r.data)
+        const ids = r.data.settlementItems.map(i => i.eventId)
+        if (ids.length === 0) return
+        const results = await Promise.allSettled(
+          ids.map(id => getSellerEventDetail(id)),
+        )
+        const map: Record<string, string> = {}
+        results.forEach((res, idx) => {
+          if (res.status === 'fulfilled') {
+            map[ids[idx]] = res.value.data.data.title
+          }
+        })
+        setEventTitles(map)
+      })
       .catch((err) =>
         toast(
           extractErrorMessage(err) ?? '정산 데이터를 불러오지 못했습니다',
@@ -233,7 +252,9 @@ export default function SellerSettlement() {
                 <tbody>
                   {data.settlementItems.map(item => (
                     <tr key={item.eventId}>
-                      <td style={{ fontWeight: 500 }}>{item.eventTitle}</td>
+                      <td style={{ fontWeight: 500 }}>
+                        {eventTitles[item.eventId] ?? item.eventTitle ?? item.eventId}
+                      </td>
                       <td style={{ textAlign: 'right' }}>{item.salesAmount.toLocaleString()}원</td>
                       <td style={{ textAlign: 'right', color: 'var(--danger)' }}>
                         {item.refundAmount > 0 ? `−${item.refundAmount.toLocaleString()}원` : '—'}


### PR DESCRIPTION
## Summary
Enhanced the seller settlement page to display event titles by fetching event details from the API, since the settlement response only includes event IDs.

## Key Changes
- Added import for `getSellerEventDetail` from events API
- Introduced `eventTitles` state to cache fetched event titles
- Implemented async data fetching that retrieves event details for all settlement items using `Promise.allSettled()`
- Updated the settlement items table to display fetched event titles with fallback to original `eventTitle` or `eventId`
- Added TODO comment noting the N+1 query issue and requesting backend to include `eventTitle` in the settlement response

## Implementation Details
- Uses `Promise.allSettled()` to handle multiple concurrent API calls gracefully, ensuring one failed request doesn't block others
- Gracefully handles API failures by skipping failed requests and only populating the map with successful responses
- Provides fallback display logic: fetched title → original eventTitle → eventId
- Clears event titles cache when switching between settlement months/preview

https://claude.ai/code/session_01BYAsbT2SHdxtdpkBUQ64bZ