### PR TITLE
[Front] perf: 판매자 정산 화면의 이벤트명 보강 N+1 호출 제거

### DIFF
--- a/src/pages/seller/SellerSettlement.tsx
+++ b/src/pages/seller/SellerSettlement.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState, useMemo } from 'react'
 import { getSellerSettlementByMonth, getSellerSettlementPreview } from '../../api/seller.api'
-import { getSellerEventDetail } from '../../api/events.api'
 import { extractErrorMessage } from '../../api/client'
 import type { SettlementMonthResponse } from '../../api/types'
 import { useToast } from '../../contexts/ToastContext'
@@ -52,9 +51,6 @@ export default function SellerSettlement() {
   const [selectedIdx, setSelectedIdx] = useState(tabs.length - 1)
   const [data, setData] = useState<SettlementMonthResponse | null>(null)
   const [loading, setLoading] = useState(true)
-  // TODO(BE): /seller/settlements 응답 SettlementEventItem 에 eventTitle 포함 요청.
-  // 현재는 eventId 만 내려오므로 항목별 상세 조회로 보강한다 (N+1).
-  const [eventTitles, setEventTitles] = useState<Record<string, string>>({})
 
   const selected = tabs[selectedIdx]
 
@@ -68,28 +64,13 @@ export default function SellerSettlement() {
   useEffect(() => {
     setLoading(true)
     setData(null)
-    setEventTitles({})
 
     const req = selected.isPreview
       ? getSellerSettlementPreview()
       : getSellerSettlementByMonth(selected.key)
 
     req
-      .then(async r => {
-        setData(r.data)
-        const ids = r.data.settlementItems.map(i => i.eventId)
-        if (ids.length === 0) return
-        const results = await Promise.allSettled(
-          ids.map(id => getSellerEventDetail(id)),
-        )
-        const map: Record<string, string> = {}
-        results.forEach((res, idx) => {
-          if (res.status === 'fulfilled') {
-            map[ids[idx]] = res.value.data.data.title
-          }
-        })
-        setEventTitles(map)
-      })
+      .then(r => setData(r.data))
       .catch((err) =>
         toast(
           extractErrorMessage(err) ?? '정산 데이터를 불러오지 못했습니다',
@@ -253,7 +234,9 @@ export default function SellerSettlement() {
                   {data.settlementItems.map(item => (
                     <tr key={item.eventId}>
                       <td style={{ fontWeight: 500 }}>
-                        {eventTitles[item.eventId] ?? item.eventTitle ?? item.eventId}
+                        {item.eventTitle && item.eventTitle !== 'Unknown'
+                          ? item.eventTitle
+                          : item.eventId}
                       </td>
                       <td style={{ textAlign: 'right' }}>{item.salesAmount.toLocaleString()}원</td>
                       <td style={{ textAlign: 'right', color: 'var(--danger)' }}>


### PR DESCRIPTION
## 배경

판매자 정산 화면(`/seller/settlements`)은 정산 응답에 이벤트 제목이 포함되지 않아 `settlementItems` 의 항목별로 `getSellerEventDetail(eventId)` 를 병렬 호출해 제목을 보강하고 있었습니다. 정확하지만 항목 수만큼 요청이 발생하는 N+1 문제가 있었습니다.

BE 측에서 `/seller/settlements` 응답에 `eventTitle` 을 직접 채워 내려보내도록 수정되어(BE PR: https://github.com/prgrms-be-adv-devcourse/beadv5_1_HeadbuttingDinosaur_BE/pull/702), 프론트에서 추가 호출을 제거합니다.

## 변경 사항

- `SellerSettlement.tsx`
  - `getSellerEventDetail` import 및 `eventTitles` 보조 상태/병렬 호출 제거
  - `item.eventTitle` 을 그대로 사용. 응답이 비어 있거나 `"Unknown"` 인 경우 `eventId` 로 fallback (이전 동작과 동일한 안전장치)

## 영향 범위

- 화면: 판매자 정산 화면 (`/seller/settlements`)
- 네트워크: 정산 항목 조회 시 부가 호출(N) 제거 → 1회 정산 조회만 발생

## 테스트

- [x] `vite build` 성공
- [ ] 정산 내역에 이벤트 제목이 정상 노출되는지 확인 (BE PR #702 머지 후)
- [ ] preview 탭 / 월별 탭 전환 시 정상 동작 확인
- [ ] 정산 항목이 0건일 때 빈 상태가 정상 노출되는지 확인


---
_Generated by [Claude Code](https://claude.ai/code/session_01VDJZDYZP87GspKKnPCF5or)_