### PR TITLE
Move design tokens from globals.css to tokens.css

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,66 +1,12 @@
+/* Legacy v1 utility/component styles. Design tokens (:root + dark overrides)
+ * live in tokens.css — do NOT redefine them here, or the [data-theme="dark"]
+ * cascade in tokens.css gets clobbered by source-order (this file is loaded
+ * after styles/index.css from main.tsx). */
+
 *, *::before, *::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
-}
-
-:root {
-  /* brand */
-  --brand: #4F46E5;
-  --brand-hover: #4338CA;
-  --brand-light: #EEF2FF;
-  --brand-muted: #818CF8;
-
-  /* surface */
-  --bg: #F8FAFC;
-  --surface: #FFFFFF;
-  --surface-2: #F1F5F9;
-  --surface-3: #E2E8F0;
-
-  /* text */
-  --text: #0F172A;
-  --text-2: #334155;
-  --text-3: #64748B;
-  --text-4: #94A3B8;
-
-  /* border */
-  --border: #E2E8F0;
-  --border-2: #CBD5E1;
-
-  /* semantic */
-  --success: #10B981;
-  --success-bg: #ECFDF5;
-  --success-text: #065F46;
-  --warning: #F59E0B;
-  --warning-bg: #FFFBEB;
-  --warning-text: #92400E;
-  --danger: #EF4444;
-  --danger-bg: #FEF2F2;
-  --danger-text: #991B1B;
-  --info: #3B82F6;
-  --info-bg: #EFF6FF;
-  --info-text: #1E40AF;
-
-  /* radius */
-  --r-sm: 6px;
-  --r-md: 8px;
-  --r-lg: 12px;
-  --r-xl: 16px;
-  --r-full: 9999px;
-
-  /* shadow */
-  --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.08), 0 1px 2px -1px rgb(0 0 0 / 0.06);
-  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.08), 0 2px 4px -2px rgb(0 0 0 / 0.05);
-  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.05);
-
-  /* type */
-  --font: 'Geist', system-ui, -apple-system, sans-serif;
-  --font-mono: 'Geist Mono', 'Fira Code', monospace;
-
-  /* layout */
-  --nav-h: 60px;
-  --sidebar-w: 240px;
-  --content-max: 1200px;
 }
 
 html { font-size: 16px; }


### PR DESCRIPTION
## Summary
Refactored design token definitions by moving all CSS custom properties (variables) from `globals.css` to a dedicated `tokens.css` file. This change improves stylesheet organization and prevents cascade conflicts with dark mode overrides.

## Key Changes
- Removed all `:root` design token definitions from `globals.css` (brand colors, surface colors, text colors, borders, semantic colors, radius, shadows, typography, and layout variables)
- Added explanatory comment clarifying that design tokens now live in `tokens.css` and should not be redefined in `globals.css` to preserve the dark theme cascade from `tokens.css`
- Retained only the universal box-sizing reset and base HTML/body styles in `globals.css`

## Implementation Details
- The tokens are now centralized in `tokens.css` which is loaded before `globals.css` (via `styles/index.css` from `main.tsx`)
- This load order ensures that dark mode overrides (`[data-theme="dark"]`) in `tokens.css` take precedence over any styles in `globals.css`
- Prevents source-order conflicts that would previously clobber the dark theme cascade

https://claude.ai/code/session_01UfxJWZveC3MjLwpZyhV9pu